### PR TITLE
Add support for time step interpolation

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -23,6 +23,7 @@ interpolation_settings:
   create_txt: True
 search_settings:
   max_splits: 60
+  use_time_step: False # True is faster but may yield different results
 restoration_settings:
   default_frames: 2
   max_frames: 10

--- a/config.yaml
+++ b/config.yaml
@@ -23,7 +23,6 @@ interpolation_settings:
   create_txt: True
 search_settings:
   max_splits: 60
-  use_time_step: False # True is faster but may yield different results
 restoration_settings:
   default_frames: 2
   max_frames: 10

--- a/config.yaml
+++ b/config.yaml
@@ -10,7 +10,7 @@ directories:
   output_upscaling: "output/upscaling"
   output_gif_to_mp4: "output/gif_to_mp4"
 model: "ours" # "_t" auto-appended when using time step
-use_time_step: True
+use_time_step: False
 gpu_ids: "0" # *future use* (cuda device:0 is presumed)
 auto_launch_browser: True
 server_port: 7862

--- a/config.yaml
+++ b/config.yaml
@@ -9,8 +9,8 @@ directories:
   output_fps_change: "output/fps_change"
   output_upscaling: "output/upscaling"
   output_gif_to_mp4: "output/gif_to_mp4"
-model: "ours"
-gpu_ids: "0"
+model: "ours" # "_t" auto-appended when using multi_inference
+gpu_ids: "0" # *future use* (cuda device:0 is presumed)
 auto_launch_browser: True
 server_port: 7862
 server_name: "0.0.0.0"

--- a/config.yaml
+++ b/config.yaml
@@ -9,7 +9,8 @@ directories:
   output_fps_change: "output/fps_change"
   output_upscaling: "output/upscaling"
   output_gif_to_mp4: "output/gif_to_mp4"
-model: "ours" # "_t" auto-appended when using multi_inference
+model: "ours" # "_t" auto-appended when using time step
+use_time_step: True
 gpu_ids: "0" # *future use* (cuda device:0 is presumed)
 auto_launch_browser: True
 server_port: 7862

--- a/deep_interpolate.py
+++ b/deep_interpolate.py
@@ -76,6 +76,7 @@ class DeepInterpolate():
                                                     output_filepath_prefix, num_steps)
             for path in self.interpolater.output_paths:
                 self.register_frame(path)
+            self.interpolater.output_paths = []
         else:
             self._set_up_outer_frames(before_filepath, after_filepath, output_filepath_prefix)
             self._recursive_split_frames(0.0, 1.0, output_filepath_prefix)

--- a/interpolate.py
+++ b/interpolate.py
@@ -119,18 +119,12 @@ class Interpolate:
         preds = model.multi_inference(I0_, I2_, TTA=TTA, time_list=[(i+1)*(1./set_count) for i in range(set_count - 1)], fast_TTA=TTA)
         for pred in preds:
             images.append((padder.unpad(pred).detach().cpu().numpy().transpose(1, 2, 0) * 255.0).astype(np.uint8)[:, :, ::-1])
-            print("@@@@@@@@")
         images.append(I2[:, :, ::-1])
-
-        print("*" * 50)
-        print(len(images))
 
         pbar_desc = "Writing frames"
         for index, image in enumerate(tqdm(images, desc=pbar_desc)):
             if 0 < index < len(images) - 1:
                 time = sortable_float_index(index / set_count)
-                print("$")
-                print(time)
                 output_filepath = os.path.join(output_path, f"{filename}@{time}.png")
                 imsave(output_filepath, image)
                 self.output_paths.append(output_filepath)

--- a/interpolate.py
+++ b/interpolate.py
@@ -110,8 +110,8 @@ class Interpolate:
         set_count = 2 if frame_count < 1 else frame_count + 1
 
         output_path, filename, extension = split_filepath(middle_filepath)
-        images = [I0[:, :, ::-1]]
         output_filepath = os.path.join(output_path, f"{filename}@0.0.png")
+        images = [I0[:, :, ::-1]]
         imsave(output_filepath, images[0])
         self.output_paths.append(output_filepath)
         self.log("create_between_frames() saved " + output_filepath)

--- a/interpolate.py
+++ b/interpolate.py
@@ -1,13 +1,17 @@
 """Core Code for all frame interpolations"""
+import os
 import cv2
 import sys
 import torch
 import numpy as np
 import argparse
+from tqdm import tqdm
 from imageio import imsave
 import argparse
 from typing import Callable
 from webui_utils.simple_log import SimpleLog
+from webui_utils.simple_utils import sortable_float_index
+from webui_utils.file_utils import split_filepath
 from interpolate_engine import InterpolateEngine
 
 '''==========import from our code=========='''
@@ -21,23 +25,31 @@ def main():
         default='ours', type=str)
     parser.add_argument('--gpu_ids', type=str, default='0',
         help='gpu ids: e.g. 0  0,1,2, 0,2. use -1 for CPU (FUTURE USE)')
-    parser.add_argument('--img_before', default="./images/image0.png", type=str,
+    parser.add_argument('--img_before', default="images/image0.png", type=str,
         help="Path to before frame image")
-    parser.add_argument('--img_after', default="./images/image2.png", type=str,
+    parser.add_argument('--img_after', default="images/image2.png", type=str,
         help="Path to after frame image")
-    parser.add_argument('--img_new', default="./images/image1.png", type=str,
+    parser.add_argument('--img_new', default="images/image1.png", type=str,
         help="Path to new middle frame image")
     parser.add_argument("--time_step", dest="time_step", default=Interpolate.STD_MIDFRAME,
-        type=float, help="Middle frame time step (Default: 0.5)")
+        type=float, help="Middle frame time step if one frame (Default: 0.5)")
+    parser.add_argument("--multiple", dest="multiple", default=1,
+        type=int, help="Create multiple evenly-spaced frames if > 1 (Default: 1)")
     parser.add_argument("--verbose", dest="verbose", default=False, action="store_true",
         help="Show extra details")
     args = parser.parse_args()
 
     log = SimpleLog(args.verbose)
-    use_time_step = args.time_step != Interpolate.STD_MIDFRAME
+    use_time_step = args.multiple > 1 or args.time_step != Interpolate.STD_MIDFRAME
     engine = InterpolateEngine(args.model, args.gpu_ids, use_time_step)
     interpolater = Interpolate(engine.model, log.log)
-    interpolater.create_between_frame(args.img_before, args.img_after, args.img_new, args.time_step)
+
+    if args.multiple > 1:
+        interpolater.create_between_frames(args.img_before, args.img_after, args.img_new,
+                                           args.multiple)
+    else:
+        interpolater.create_between_frame(args.img_before, args.img_after, args.img_new,
+                                          args.time_step)
 
 class Interpolate:
     """Encapsulate logic for the Frame Interpolation feature"""
@@ -71,7 +83,52 @@ class Interpolate:
         mid = (padder.unpad(model.inference(I0_, I2_, TTA=TTA, fast_TTA=TTA, timestep = time_step))[0].detach().cpu().numpy().transpose(1, 2, 0) * 255.0).astype(np.uint8)
         images = [I0[:, :, ::-1], mid[:, :, ::-1], I2[:, :, ::-1]]
         imsave(middle_filepath, images[1])
-        self.log("create_mid_frame() saved " + middle_filepath)
+        self.log("create_between_frame() saved " + middle_filepath)
+
+    def create_between_frames(self,
+                            before_filepath : str,
+                            after_filepath : str,
+                            middle_filepath : str,
+                            frame_count : int):
+        """Invoke the Frame Interpolation feature for multiple between frames
+           frame_count is the number of new frames, ex: 8X interpolation, 7 new frames are needed
+        """
+        # code borrowed from EMA-VFI/demo_2x.py
+        I0 = cv2.imread(before_filepath)
+        I2 = cv2.imread(after_filepath)
+
+        I0_ = (torch.tensor(I0.transpose(2, 0, 1)).cuda() / 255.).unsqueeze(0)
+        I2_ = (torch.tensor(I2.transpose(2, 0, 1)).cuda() / 255.).unsqueeze(0)
+
+        padder = InputPadder(I0_.shape, divisor=32)
+        I0_, I2_ = padder.pad(I0_, I2_)
+
+        model = self.model["model"]
+        TTA = self.model["TTA"]
+        set_count = 2 if frame_count < 1 else frame_count + 1
+
+        output_path, filename, extension = split_filepath(middle_filepath)
+        images = [I0[:, :, ::-1]]
+        output_filepath = os.path.join(output_path, f"{filename}@0.0.png")
+        imsave(output_filepath, images[0])
+        self.log("create_between_frames() saved " + output_filepath)
+
+        preds = model.multi_inference(I0_, I2_, TTA=TTA, time_list=[(i+1)*(1./set_count) for i in range(set_count - 1)], fast_TTA=TTA)
+        for pred in preds:
+            images.append((padder.unpad(pred).detach().cpu().numpy().transpose(1, 2, 0) * 255.0).astype(np.uint8)[:, :, ::-1])
+        images.append(I2[:, :, ::-1])
+
+        pbar_desc = "Writing frames"
+        for index, image in enumerate(tqdm(images[1:-1], desc=pbar_desc)):
+            if index > 0:
+                time = sortable_float_index(index / set_count)
+                output_filepath = os.path.join(output_path, f"{filename}@{time}.png")
+                imsave(output_filepath, image)
+                self.log("create_between_frames() saved " + output_filepath)
+
+        output_filepath = os.path.join(output_path, f"{filename}@1.0.png")
+        imsave(output_filepath, images[-1])
+        self.log("create_between_frames() saved " + output_filepath)
 
     def log(self, message):
         """Logging"""

--- a/interpolate_engine.py
+++ b/interpolate_engine.py
@@ -5,25 +5,25 @@ import sys
 sys.path.append('.')
 import config as cfg # pylint: disable=import-error
 from Trainer import Model # pylint: disable=import-error
-from webui_utils.simple_utils import FauxArgs
 
 class InterpolateEngine:
     """Singleton class encapsulating the EMA-VFI engine and related logic"""
     # model should be "ours" or "ours_small", or your own trained model
     # gpu_ids is for *future use*
-    def __new__(cls, model : str, gpu_ids : str):
+    # if use_time_step is True "_t" is appended to the model name
+    def __new__(cls, model : str, gpu_ids : str, use_time_step : bool=False):
         if not hasattr(cls, 'instance'):
             cls.instance = super(InterpolateEngine, cls).__new__(cls)
-            cls.instance.init(model, gpu_ids)
+            cls.instance.init(model, gpu_ids, use_time_step)
         return cls.instance
 
-    def init(self, model : str, gpu_ids: str):
+    def init(self, model : str, gpu_ids: str, use_time_step):
         """Iniitalize the class by calling into EMA-VFI code"""
         gpu_id_array = self.init_device(gpu_ids)
-        self.model = self.init_model(model, gpu_id_array)
+        self.model = self.init_model(model, gpu_id_array, use_time_step)
 
     def init_device(self, gpu_ids : str):
-        """EMA-VFI code from demo_2x.py"""
+        """for *future use*"""
         str_ids = gpu_ids.split(',')
         gpu_ids = []
         for str_id in str_ids:
@@ -36,7 +36,7 @@ class InterpolateEngine:
         # cudnn.benchmark = True
         return gpu_ids
 
-    def init_model(self, model, gpu_id_array):
+    def init_model(self, model, gpu_id_array, use_time_step):
         """EMA-VFI code from demo_2x.py"""
         # for *future use*
         # device = torch.device('cuda' if len(gpu_id_array) != 0 else 'cpu')
@@ -44,13 +44,13 @@ class InterpolateEngine:
         TTA = True
         if model == 'ours_small':
             TTA = False
-            cfg.MODEL_CONFIG['LOGNAME'] = 'ours_small'
+            cfg.MODEL_CONFIG['LOGNAME'] = 'ours_small' + ("_t" if use_time_step else "")
             cfg.MODEL_CONFIG['MODEL_ARCH'] = cfg.init_model_config(
                 F = 16,
                 depth = [2, 2, 2, 2, 2]
             )
         else:
-            cfg.MODEL_CONFIG['LOGNAME'] = 'ours'
+            cfg.MODEL_CONFIG['LOGNAME'] = 'ours' + ("_t" if use_time_step else "")
             cfg.MODEL_CONFIG['MODEL_ARCH'] = cfg.init_model_config(
                 F = 32,
                 depth = [2, 2, 2, 4, 4]

--- a/interpolate_engine.py
+++ b/interpolate_engine.py
@@ -15,11 +15,16 @@ class InterpolateEngine:
         if not hasattr(cls, 'instance'):
             cls.instance = super(InterpolateEngine, cls).__new__(cls)
             cls.instance.init(model, gpu_ids, use_time_step)
+        elif cls.instance.model_name != model or cls.instance.use_time_step != use_time_step:
+            cls.instance = super(InterpolateEngine, cls).__new__(cls)
+            cls.instance.init(model, gpu_ids, use_time_step)
         return cls.instance
 
     def init(self, model : str, gpu_ids: str, use_time_step):
         """Iniitalize the class by calling into EMA-VFI code"""
         gpu_id_array = self.init_device(gpu_ids)
+        self.model_name = model
+        self.use_time_step = use_time_step
         self.model = self.init_model(model, gpu_id_array, use_time_step)
 
     def init_device(self, gpu_ids : str):

--- a/interpolate_series.py
+++ b/interpolate_series.py
@@ -15,25 +15,27 @@ def main():
         default="ours", type=str)
     parser.add_argument("--gpu_ids", type=str, default="0",
         help="gpu ids: e.g. 0  0,1,2, 0,2. use -1 for CPU")
-    parser.add_argument("--input_path", default="./images", type=str,
+    parser.add_argument("--input_path", default="images", type=str,
         help="Input path for PNGs to interpolate")
     parser.add_argument("--depth", default=2, type=int,
         help="How many doublings of the frames")
     parser.add_argument("--offset", default=1, type=int,
         help="Frame series offset, 1 for slow motion, 2+ for frame resynthesis")
-    parser.add_argument("--output_path", default="./output", type=str,
+    parser.add_argument("--output_path", default="images", type=str,
         help="Output path for interpolated PNGs")
     parser.add_argument("--base_filename", default="interpolated_frames", type=str,
         help="Base filename for interpolated PNGs")
+    parser.add_argument("--time_step", dest="time_step", default=False, action="store_true",
+        help="Use Time Step instead of Binary Search interpolation (Default: False)")
     parser.add_argument("--verbose", dest="verbose", default=False, action="store_true",
         help="Show extra details")
     args = parser.parse_args()
 
     log = SimpleLog(args.verbose)
     create_directory(args.output_path)
-    engine = InterpolateEngine(args.model, args.gpu_ids)
+    engine = InterpolateEngine(args.model, args.gpu_ids, use_time_step=args.time_step)
     interpolater = Interpolate(engine.model, log.log)
-    deep_interpolater = DeepInterpolate(interpolater, log.log)
+    deep_interpolater = DeepInterpolate(interpolater, args.time_step, log.log)
     series_interpolater = InterpolateSeries(deep_interpolater, log.log)
 
     file_list = get_files(args.input_path, extension="png")

--- a/interpolation_target.py
+++ b/interpolation_target.py
@@ -18,10 +18,10 @@ def main():
     parser.add_argument("--model",
         default="ours", type=str)
     parser.add_argument("--gpu_ids", type=str, default="0",
-        help="gpu ids: e.g. 0  0,1,2, 0,2. use -1 for CPU")
-    parser.add_argument("--img_before", default="./images/image0.png", type=str,
+        help="gpu ids: e.g. 0  0,1,2, 0,2. use -1 for CPU (FUTURE USE)")
+    parser.add_argument("--img_before", default="images/image0.png", type=str,
         help="Path to before frame image")
-    parser.add_argument("--img_after", default="./images/image2.png", type=str,
+    parser.add_argument("--img_after", default="images/image2.png", type=str,
         help="Path to after frame image")
     parser.add_argument("--depth", default=10, type=int,
         help="How deep the frame splits go to reach the target")
@@ -29,23 +29,36 @@ def main():
         help="Lower bound of target time")
     parser.add_argument("--max_target", default=0.334, type=float,
         help="Upper bound of target time")
-    parser.add_argument("--output_path", default="./output", type=str,
+    parser.add_argument("--output_path", default="images", type=str,
         help="Output path for interpolated PNGs")
     parser.add_argument("--base_filename", default="interpolated_frame", type=str,
         help="Base filename for interpolated PNGs")
     parser.add_argument("--keep_samples", dest="keep_samples", default=False, action="store_true",
-        help="True to keep the interative sample PNGs")
+        help="Keep the interative sample PNGs (Default: False)")
+    parser.add_argument("--time_step", dest="time_step", default=False, action="store_true",
+        help="Use Time Step instead of Binary Search interpolation (Default: False)")
     parser.add_argument("--verbose", dest="verbose", default=False, action="store_true",
-        help="Show extra details")
+        help="Show extra details (Default: False)")
     args = parser.parse_args()
 
     log = SimpleLog(args.verbose)
     create_directory(args.output_path)
-    engine = InterpolateEngine(args.model, args.gpu_ids)
-    interpolater = Interpolate(engine.model, log.log)
-    target_interpolater = TargetInterpolate(interpolater, log.log)
-    target_interpolater.split_frames(args.img_before, args.img_after, args.depth, args.min_target,
-        args.max_target, args.output_path, args.base_filename, args.keep_samples)
+
+    if args.time_step:
+        # use the time step feature of the model to reach the midpoint of the target range
+        engine = InterpolateEngine(args.model, args.gpu_ids, use_time_step=True)
+        interpolater = Interpolate(engine.model, log.log)
+        midpoint = args.min_target + (args.max_target - args.min_target) / 2.0
+        img_new = os.path.join(args.output_path, f"{args.base_filename}@{midpoint}.png")
+        interpolater.create_between_frame(args.img_before, args.img_after, img_new, midpoint)
+    else:
+        # use binary search interpolation to reach the target range
+        engine = InterpolateEngine(args.model, args.gpu_ids, use_time_step=False)
+        interpolater = Interpolate(engine.model, log.log)
+        target_interpolater = TargetInterpolate(interpolater, log.log)
+        target_interpolater.split_frames(args.img_before, args.img_after, args.depth,
+                                         args.min_target, args.max_target, args.output_path,
+                                         args.base_filename, args.keep_samples)
 
 class TargetInterpolate():
     """Enscapsulate logic for the Frame Search feature"""

--- a/interpolation_target.py
+++ b/interpolation_target.py
@@ -221,7 +221,6 @@ class TargetInterpolate():
             self.progress = None
         else:
             self.progress = tqdm(range(_max), desc=description)
-        # self.progress = tqdm(range(_max), desc=description)
 
     def step_progress(self):
         """Advance the progress bar"""

--- a/resample_series.py
+++ b/resample_series.py
@@ -109,6 +109,7 @@ class ResampleSeries():
                 output_filepath = os.path.join(output_path, filename)
                 self.log(f"copying keyframe {before_file} to {output_filepath}")
                 shutil.copy(before_file, output_filepath)
+                self.output_paths.append(output_filepath)
             else:
                 if self.time_step:
                     filename = f"{base_filename}[{frame_number}]"
@@ -128,8 +129,12 @@ class ResampleSeries():
                                                             output_path=output_path,
                                                             base_filename=filename,
                                                             progress_label="Search")
-        self.output_paths.extend(self.target_interpolater.output_paths)
-        self.target_interpolater.output_paths = []
+        if self.time_step:
+            self.output_paths.extend(self.interpolater.output_paths)
+            self.interpolater.output_paths = []
+        else:
+            self.output_paths.extend(self.target_interpolater.output_paths)
+            self.target_interpolater.output_paths = []
 
     def log(self, message):
         """Logging"""

--- a/restore_frames.py
+++ b/restore_frames.py
@@ -1,4 +1,5 @@
 """Restore Frames Feature Core Code"""
+import os
 import sys
 import argparse
 from typing import Callable
@@ -16,29 +17,31 @@ def main():
     parser.add_argument("--model",
         default="ours", type=str)
     parser.add_argument("--gpu_ids", type=str, default="0",
-        help="gpu ids: e.g. 0  0,1,2, 0,2. use -1 for CPU")
-    parser.add_argument("--img_before", default="./images/image0.png", type=str,
+        help="gpu ids: e.g. 0  0,1,2, 0,2. use -1 for CPU (FUTURE USE)")
+    parser.add_argument("--img_before", default="images/image0.png", type=str,
         help="Path to image file before the damaged frames")
-    parser.add_argument("--img_after", default="./images/image2.png", type=str,
+    parser.add_argument("--img_after", default="images/image2.png", type=str,
         help="Path to image file after the damaged frames")
     parser.add_argument("--num_frames", default=2, type=int,
         help="Number of frames to restore")
     parser.add_argument("--depth", default=10, type=int,
         help="How deep the frame splits go to reach the target")
-    parser.add_argument("--output_path", default="./output", type=str,
+    parser.add_argument("--output_path", default="images", type=str,
         help="Output path for interpolated PNGs")
     parser.add_argument("--base_filename", default="restored_frame", type=str,
         help="Base filename for interpolated PNGs")
+    parser.add_argument("--time_step", dest="time_step", default=False, action="store_true",
+        help="Use Time Step instead of Binary Search interpolation (Default: False)")
     parser.add_argument("--verbose", dest="verbose", default=False, action="store_true",
         help="Show extra details")
     args = parser.parse_args()
 
     log = SimpleLog(args.verbose)
     create_directory(args.output_path)
-    engine = InterpolateEngine(args.model, args.gpu_ids)
+    engine = InterpolateEngine(args.model, args.gpu_ids, use_time_step=args.time_step)
     interpolater = Interpolate(engine.model, log.log)
     target_interpolater = TargetInterpolate(interpolater, log.log)
-    frame_restorer = RestoreFrames(target_interpolater, log.log)
+    frame_restorer = RestoreFrames(interpolater, target_interpolater, args.time_step, log.log)
 
     frame_restorer.restore_frames(args.img_before, args.img_after, args.num_frames,
         args.depth, args.output_path, args.base_filename)
@@ -46,9 +49,13 @@ def main():
 class RestoreFrames():
     """Encapsulate logic for the Frame Restoration feature"""
     def __init__(self,
+                interpolater : Interpolate,
                 target_interpolater : TargetInterpolate,
+                time_step : bool,
                 log_fn : Callable | None):
+        self.interpolater = interpolater
         self.target_interpolater = target_interpolater
+        self.time_step = time_step
         self.log_fn = log_fn
         self.output_paths = []
 
@@ -62,13 +69,27 @@ class RestoreFrames():
                     progress_label="Frames"):
         """Invoke the Frame Restoration feature"""
         searches = restored_frame_searches(num_frames)
-        for search in tqdm(searches, desc=progress_label):
-            self.log(f"searching for frame {search}")
-            self.target_interpolater.split_frames(img_before, img_after, depth, min_target=search,
-                max_target=search + sys.float_info.epsilon, output_path=output_path,
-                base_filename=base_filename, progress_label="Search")
-        self.output_paths.extend(self.target_interpolater.output_paths)
-        self.target_interpolater.output_paths = []
+        if self.time_step:
+            output_filepath = os.path.join(output_path, base_filename)
+            self.interpolater.create_between_frames(img_before, img_after, output_filepath,
+                                                    num_frames)
+            self.output_paths.extend(self.interpolater.output_paths)
+            self.interpolater.output_paths = []
+            print(self.output_paths)
+        else:
+            for search in tqdm(searches, desc=progress_label):
+                self.log(f"searching for frame {search}")
+                self.target_interpolater.split_frames(img_before,
+                                                    img_after,
+                                                    depth,
+                                                    min_target=search,
+                                                    max_target=search + sys.float_info.epsilon,
+                                                    output_path=output_path,
+                                                    base_filename=base_filename,
+                                                    progress_label="Search")
+            self.output_paths.extend(self.target_interpolater.output_paths)
+            self.target_interpolater.output_paths = []
+            print(self.output_paths)
 
     def log(self, message):
         """Logging"""

--- a/restore_frames.py
+++ b/restore_frames.py
@@ -88,7 +88,6 @@ class RestoreFrames():
                                                     progress_label="Search")
             self.output_paths.extend(self.target_interpolater.output_paths)
             self.target_interpolater.output_paths = []
-            print(self.output_paths)
 
     def log(self, message):
         """Logging"""

--- a/restore_frames.py
+++ b/restore_frames.py
@@ -75,7 +75,6 @@ class RestoreFrames():
                                                     num_frames)
             self.output_paths.extend(self.interpolater.output_paths)
             self.interpolater.output_paths = []
-            print(self.output_paths)
         else:
             for search in tqdm(searches, desc=progress_label):
                 self.log(f"searching for frame {search}")

--- a/tabs/change_fps_ui.py
+++ b/tabs/change_fps_ui.py
@@ -89,7 +89,9 @@ class ChangeFPS(TabBase):
         if input_path:
             interpolater = Interpolate(self.engine.model, self.log)
             target_interpolater = TargetInterpolate(interpolater, self.log)
-            series_resampler = ResampleSeries(target_interpolater, self.log)
+            use_time_step = self.config.use_time_step
+            series_resampler = ResampleSeries(interpolater, target_interpolater, use_time_step,
+                                              self.log)
             if output_path:
                 base_output_path = output_path
                 create_directory(base_output_path)

--- a/tabs/frame_interpolation_ui.py
+++ b/tabs/frame_interpolation_ui.py
@@ -56,7 +56,8 @@ class FrameInterpolation(TabBase):
         """Interpolate button handler"""
         if img_before_file and img_after_file:
             interpolater = Interpolate(self.engine.model, self.log_fn)
-            deep_interpolater = DeepInterpolate(interpolater, self.log_fn)
+            use_time_step = self.config.use_time_step
+            deep_interpolater = DeepInterpolate(interpolater, use_time_step, self.log_fn)
             base_output_path = self.config.directories["output_interpolation"]
             output_path, run_index = AutoIncrementDirectory(base_output_path).next_directory("run")
             output_basename = "interpolated_frames"

--- a/tabs/frame_restoration_ui.py
+++ b/tabs/frame_restoration_ui.py
@@ -82,7 +82,9 @@ class FrameRestoration(TabBase):
         if img_before_file and img_after_file:
             interpolater = Interpolate(self.engine.model, self.log)
             target_interpolater = TargetInterpolate(interpolater, self.log)
-            frame_restorer = RestoreFrames(target_interpolater, self.log)
+            use_time_step = self.config.use_time_step
+            frame_restorer = RestoreFrames(interpolater, target_interpolater, use_time_step,
+                                           self.log)
             base_output_path = self.config.directories["output_restoration"]
             create_directory(base_output_path)
             output_path, run_index = AutoIncrementDirectory(base_output_path).next_directory("run")

--- a/tabs/frame_restoration_ui.py
+++ b/tabs/frame_restoration_ui.py
@@ -99,8 +99,9 @@ class FrameRestoration(TabBase):
                 preview_gif = os.path.join(output_path, output_basename + str(run_index) + ".gif")
                 self.log(f"creating preview file {preview_gif}")
                 duration = self.config.restoration_settings["gif_duration"] / len(output_paths)
-                gif_paths = [img_before_file, *output_paths, img_after_file]
-                create_gif(gif_paths, preview_gif, duration=duration)
+                # gif_paths = [img_before_file, *output_paths, img_after_file]
+                # create_gif(gif_paths, preview_gif, duration=duration)
+                create_gif(output_paths, preview_gif, duration=duration)
                 downloads.append(preview_gif)
 
             if self.config.restoration_settings["create_zip"]:

--- a/tabs/frame_search_ui.py
+++ b/tabs/frame_search_ui.py
@@ -1,4 +1,5 @@
 """Frame Search feature UI and event handlers"""
+import os
 from typing import Callable
 import gradio as gr
 from webui_utils.simple_config import SimpleConfig
@@ -58,16 +59,27 @@ class FrameSearch(TabBase):
                     max_target : float):
         """Search button handler"""
         if img_before_file and img_after_file and min_target and max_target:
-            interpolater = Interpolate(self.engine.model, self.log)
-            target_interpolater = TargetInterpolate(interpolater, self.log)
             base_output_path = self.config.directories["output_search"]
             create_directory(base_output_path)
             output_path, _ = AutoIncrementDirectory(base_output_path).next_directory("run")
             output_basename = "frame"
 
-            self.log(f"beginning targeted interpolations at {output_path}")
-            target_interpolater.split_frames(img_before_file, img_after_file, num_splits,
-                float(min_target), float(max_target), output_path, output_basename)
-            output_paths = target_interpolater.output_paths
+            if self.config.search_settings["use_time_step"]:
+                # use the time step feature of the model to reach the midpoint of the target range
+                interpolater = Interpolate(self.engine.model, self.log)
+                midpoint = float(min_target) + (float(max_target) - float(min_target)) / 2.0
+                img_new = os.path.join(output_path, f"{output_basename}@{midpoint}.png")
+                interpolater.create_between_frame(img_before_file, img_after_file, img_new,
+                                                  midpoint)
+                output_paths = interpolater.output_paths
+            else:
+                # use binary search interpolation to reach the target range
+                interpolater = Interpolate(self.engine.model, self.log)
+                target_interpolater = TargetInterpolate(interpolater, self.log)
+
+                self.log(f"beginning targeted interpolations at {output_path}")
+                target_interpolater.split_frames(img_before_file, img_after_file, num_splits,
+                    float(min_target), float(max_target), output_path, output_basename)
+                output_paths = target_interpolater.output_paths
             return gr.Image.update(value=output_paths[0]), gr.File.update(value=output_paths,
                 visible=True)

--- a/tabs/frame_search_ui.py
+++ b/tabs/frame_search_ui.py
@@ -64,7 +64,7 @@ class FrameSearch(TabBase):
             output_path, _ = AutoIncrementDirectory(base_output_path).next_directory("run")
             output_basename = "frame"
 
-            if self.config.search_settings["use_time_step"]:
+            if self.config.use_time_step:
                 # use the time step feature of the model to reach the midpoint of the target range
                 interpolater = Interpolate(self.engine.model, self.log)
                 midpoint = float(min_target) + (float(max_target) - float(min_target)) / 2.0

--- a/tabs/gif_to_mp4_ui.py
+++ b/tabs/gif_to_mp4_ui.py
@@ -189,7 +189,9 @@ class GIFtoMP4(TabBase):
                                 precision : int):
         interpolater = Interpolate(self.engine.model, self.log)
         target_interpolater = TargetInterpolate(interpolater, self.log)
-        series_resampler = ResampleSeries(target_interpolater, self.log)
+        use_time_step = self.config.use_time_step
+        series_resampler = ResampleSeries(interpolater, target_interpolater, use_time_step,
+                                          self.log)
         series_resampler.resample_series(input_path, output_path, 1, inflate_factor, precision,
             f"resampledX{inflate_factor}")
 
@@ -198,7 +200,8 @@ class GIFtoMP4(TabBase):
                                 output_path : str,
                                 inflate_factor: int):
         interpolater = Interpolate(self.engine.model, self.log)
-        deep_interpolater = DeepInterpolate(interpolater, self.log)
+        use_time_step = self.config.use_time_step
+        deep_interpolater = DeepInterpolate(interpolater, use_time_step, self.log)
         series_interpolater = InterpolateSeries(deep_interpolater, self.log)
 
         file_list = get_files(input_path)

--- a/tabs/resynthesize_video_ui.py
+++ b/tabs/resynthesize_video_ui.py
@@ -47,7 +47,8 @@ class ResynthesizeVideo(TabBase):
         """Resynthesize Video button handler"""
         if input_path:
             interpolater = Interpolate(self.engine.model, self.log)
-            deep_interpolater = DeepInterpolate(interpolater, self.log)
+            use_time_step = self.config.use_time_step
+            deep_interpolater = DeepInterpolate(interpolater, use_time_step, self.log)
             series_interpolater = InterpolateSeries(deep_interpolater, self.log)
 
             if output_path:

--- a/tabs/video_blender_ui.py
+++ b/tabs/video_blender_ui.py
@@ -372,8 +372,9 @@ class VideoBlender(TabBase):
             preview_gif = os.path.join(output_path, output_basename + str(run_index) + ".gif")
             self.log(f"creating preview file {preview_gif}")
             duration = self.config.blender_settings["gif_duration"] / len(output_paths)
-            gif_paths = [before_file, *output_paths, after_file]
-            create_gif(gif_paths, preview_gif, duration=duration)
+            # gif_paths = [before_file, *output_paths, after_file]
+            # create_gif(gif_paths, preview_gif, duration=duration)
+            create_gif(output_paths, preview_gif, duration=duration)
 
             return gr.Image.update(value=preview_gif), gr.Text.update(value=output_path,
                 visible=True)
@@ -385,7 +386,9 @@ class VideoBlender(TabBase):
         """Apply Fixed Frames button handler"""
         fixed_frames = sorted(get_files(fixed_frames_path, "png"))
         frame = before_frame + 1
-        for file in fixed_frames:
+        # for file in fixed_frames:
+        # the outer frames are the orginal before/after frames
+        for file in fixed_frames[1:-1]:
             project_file = locate_frame_file(project_path, frame)
             self.log(f"copying {file} to {project_file}")
             shutil.copy(file, project_file)

--- a/tabs/video_blender_ui.py
+++ b/tabs/video_blender_ui.py
@@ -353,7 +353,9 @@ class VideoBlender(TabBase):
         if project_path and after_frame > before_frame:
             interpolater = Interpolate(self.engine.model, self.log)
             target_interpolater = TargetInterpolate(interpolater, self.log)
-            frame_restorer = RestoreFrames(target_interpolater, self.log)
+            use_time_step = self.config.use_time_step
+            frame_restorer = RestoreFrames(interpolater, target_interpolater, use_time_step,
+                                           self.log)
             base_output_path = self.config.directories["output_blender"]
             create_directory(base_output_path)
             output_path, run_index = AutoIncrementDirectory(base_output_path).next_directory("run")

--- a/tabs/video_inflation_ui.py
+++ b/tabs/video_inflation_ui.py
@@ -54,7 +54,8 @@ class VideoInflation(TabBase):
         """Inflate Video button handler"""
         if input_path:
             interpolater = Interpolate(self.engine.model, self.log)
-            deep_interpolater = DeepInterpolate(interpolater, self.log)
+            use_time_step = self.config.use_time_step
+            deep_interpolater = DeepInterpolate(interpolater, use_time_step, self.log)
             series_interpolater = InterpolateSeries(deep_interpolater, self.log)
 
             if output_path:

--- a/webui.py
+++ b/webui.py
@@ -37,7 +37,8 @@ class WebUI:
     def start(self):
         """Create the UI and start the event loop"""
         WebuiTips.set_tips_path(self.config.user_interface["tips_path"])
-        engine = InterpolateEngine(self.config.model, self.config.gpu_ids)
+        use_time_step = self.config.use_time_step
+        engine = InterpolateEngine(self.config.model, self.config.gpu_ids, use_time_step=use_time_step)
         while True:
             print("\nStarting EMA-VFI-WebUI")
             print("Models are loaded on the first interpolation")


### PR DESCRIPTION
Support the time step versions of the models (with "_t")
- adds global config to enable/disable:  `use_time_step` (default false)
- adds `--time_step` switch and support to low-level scripts that use the interpolation model
- updated UI code to pass the time step enablement to low-level scripts

# Important
- I've not had good success so far with the time step version of the model
- It is disabled by default. To enable, set `use_time_step` to `True` in `config.yaml` and restart the application
