### PR TITLE
Fix frame fixer

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -35,7 +35,7 @@ restoration_settings:
 blender_settings:
   projects_file: "video_blender_projects.csv"
   skip_frames: 100
-  frame_fixer_depth: 31
+  frame_fixer_depth: 10
   gif_duration: 1000
 mp4_to_png_settings:
   frame_rate: 30

--- a/tabs/video_blender_ui.py
+++ b/tabs/video_blender_ui.py
@@ -374,8 +374,6 @@ class VideoBlender(TabBase):
             preview_gif = os.path.join(output_path, output_basename + str(run_index) + ".gif")
             self.log(f"creating preview file {preview_gif}")
             duration = self.config.blender_settings["gif_duration"] / len(output_paths)
-            # gif_paths = [before_file, *output_paths, after_file]
-            # create_gif(gif_paths, preview_gif, duration=duration)
             create_gif(output_paths, preview_gif, duration=duration)
 
             return gr.Image.update(value=preview_gif), gr.Text.update(value=output_path,
@@ -388,9 +386,7 @@ class VideoBlender(TabBase):
         """Apply Fixed Frames button handler"""
         fixed_frames = sorted(get_files(fixed_frames_path, "png"))
         frame = before_frame + 1
-        # for file in fixed_frames:
-        # the outer frames are the orginal before/after frames
-        for file in fixed_frames[1:-1]:
+        for file in fixed_frames:
             project_file = locate_frame_file(project_path, frame)
             self.log(f"copying {file} to {project_file}")
             shutil.copy(file, project_file)

--- a/tabs/video_blender_ui.py
+++ b/tabs/video_blender_ui.py
@@ -237,13 +237,13 @@ class VideoBlender(TabBase):
         fix_frames_button_vb.click(self.video_blender_fix_frames,
             inputs=[input_project_path_vb, fix_frames_last_before, fix_frames_first_after],
             outputs=[tabs_video_blender, project_path_ff, input_clean_before_ff,
-                input_clean_after_ff])
+                input_clean_after_ff, fixed_path_ff])
         preview_button_ff.click(self.video_blender_preview_fixed,
             inputs=[project_path_ff, input_clean_before_ff, input_clean_after_ff],
             outputs=[preview_image_ff, fixed_path_ff])
         use_fixed_button_ff.click(self.video_blender_used_fixed,
             inputs=[project_path_ff, fixed_path_ff, input_clean_before_ff],
-            outputs=tabs_video_blender)
+            outputs=[tabs_video_blender, fixed_path_ff])
         render_video_vb.click(self.video_blender_render_preview,
             inputs=[preview_path_vb, input_frame_rate_vb], outputs=[video_preview_vb])
 
@@ -343,7 +343,7 @@ class VideoBlender(TabBase):
     def video_blender_fix_frames(self, project_path : str, last_frame_before : float,
                                  first_frame_after : float):
         """Fix Frames button handler"""
-        return gr.update(selected=2), project_path, last_frame_before, first_frame_after
+        return gr.update(selected=2), project_path, last_frame_before, first_frame_after, None
 
     def video_blender_preview_fixed(self,
                                     project_path : str,
@@ -384,14 +384,16 @@ class VideoBlender(TabBase):
                                 fixed_frames_path : str,
                                 before_frame : int):
         """Apply Fixed Frames button handler"""
-        fixed_frames = sorted(get_files(fixed_frames_path, "png"))
-        frame = before_frame + 1
-        for file in fixed_frames:
-            project_file = locate_frame_file(project_path, frame)
-            self.log(f"copying {file} to {project_file}")
-            shutil.copy(file, project_file)
-            frame += 1
-        return gr.update(selected=1)
+        if fixed_frames_path:
+            fixed_frames = sorted(get_files(fixed_frames_path, "png"))
+            frame = before_frame + 1
+            for file in fixed_frames:
+                project_file = locate_frame_file(project_path, frame)
+                self.log(f"copying {file} to {project_file}")
+                shutil.copy(file, project_file)
+                frame += 1
+            return gr.update(selected=1), None
+        return gr.update(selected=2), None
 
     def video_blender_preview_video(self, input_path : str):
         """Preview Video button handler"""


### PR DESCRIPTION
- a regression was causing part of the fixed frames to be applied not all - fixed
- forgetting to click "preview" before applying fixed frames led to the wrong frames being overwritten - fixed
- a search depth of 31 is too high for the general case of synthesizing good replacement frames - changed to 10