### PR TITLE
fix issues with frame number matching UI

### DIFF
--- a/video_blender.py
+++ b/video_blender.py
@@ -38,6 +38,11 @@ class VideoBlenderProjects:
             entries = list(reader)
             for entry in entries:
                 project_name = entry["project_name"]
+                # new fields added after first version:
+                if "main_path" not in entry or not entry["main_path"]:
+                    entry["main_path"], _ = os.path.split(entry["project_path"])
+                if "fps" not in entry or not entry["fps"]:
+                    entry["fps"] = "30"
                 self.projects[project_name] = entry
 
     def write_projects(self):

--- a/video_blender_projects.csv
+++ b/video_blender_projects.csv
@@ -1,2 +1,2 @@
 project_name,project_path,frames1_path,frames2_path,main_path,fps
-Untitled,,,,,
+Untitled,,,,,30

--- a/webui_utils/simple_icons.py
+++ b/webui_utils/simple_icons.py
@@ -18,6 +18,7 @@ class SimpleIcons:
     NUMBERS = "🔢"
     ONE = "1️⃣"
     QUESTION = "❓"
+    RECYCLE = "♻️"
     RIGHT_ARROW = "➡️"
     SCISSORS = "✂️"
     THREE = "3️⃣"
@@ -122,6 +123,7 @@ class SimpleIcons:
         NUMBERS,
         ONE,
         PROPERTIES,
+        RECYCLE,
         ROCKET,
         SCROLL,
         SEEDLING,

--- a/webui_utils/test_simple_icons.py
+++ b/webui_utils/test_simple_icons.py
@@ -5,7 +5,7 @@ from .simple_icons import *
 
 GOOD_EXAMPLES = [
     (SimpleIcons.SYMBOLS, 4, 6),
-    (SimpleIcons.APP_ICONS, 33, 48)]
+    (SimpleIcons.APP_ICONS, 34, 50)]
 
 def test_SimpleIcons():
     for example, expected_items, expected_len in GOOD_EXAMPLES:


### PR DESCRIPTION
- the video blender new project functionality works to reset a project
- add a new "reset project" tab to pre-fill the new project fields for easy use
- make a couple tweaks to the new project process
  - only delete the original frame #0 when 1) a video was extracted to PNG frames, 2) the PNG frames were resynthesized to repair frames (the two operations together create a mismatch in frame sets, since the resynthesized frames cannot include the outermost original frames)
  - resequence all frame sets to being at frame #0 to match the UI (this ensures the frame index in the PNG file matches the ones shown in the UI and recorded into the edits.csv, avoiding off-by-one confusion)
  - without this change, resetting a project is not idempotent