### PR TITLE
Fix display of PNG frames with ancillary chunks

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -37,6 +37,7 @@ blender_settings:
   skip_frames: 100
   frame_fixer_depth: 10
   gif_duration: 1000
+  clean_frames: True
 mp4_to_png_settings:
   frame_rate: 30
 png_to_mp4_settings:

--- a/create_ui.py
+++ b/create_ui.py
@@ -22,6 +22,7 @@ from tabs.resources_ui import Resources
 from tabs.upscale_frames_ui import UpscaleFrames
 from tabs.gif_to_mp4_ui import GIFtoMP4
 from tabs.log_viewer import LogViewer
+from tabs.simplify_png_files_ui import SimplifyPngFiles
 
 def create_ui(config : SimpleConfig,
               engine : InterpolateEngine,
@@ -51,6 +52,7 @@ def create_ui(config : SimpleConfig,
                 GIFtoPNG(config, engine, log.log).render_tab()
                 PNGtoGIF(config, engine, log.log).render_tab()
             ResequenceFiles(config, engine, log.log).render_tab()
+            SimplifyPngFiles(config, engine, log.log).render_tab()
             ChangeFPS(config, engine, log.log).render_tab()
             UpscaleFrames(config, engine, log.log).render_tab()
             Resources(config, engine, log.log).render_tab()

--- a/resequence_files.py
+++ b/resequence_files.py
@@ -1,4 +1,4 @@
-"""Resequence Files Featuer Core Code"""
+"""Resequence Files Feature Core Code"""
 import os
 import shutil
 import glob

--- a/simplify_png_files.py
+++ b/simplify_png_files.py
@@ -1,0 +1,50 @@
+"""Simplify PNG Files Feature Core Code"""
+import os
+import glob
+import argparse
+from typing import Callable
+from tqdm import tqdm
+from webui_utils.simple_log import SimpleLog
+from PIL import Image
+
+def main():
+    """Use the Simplify PNG Files feature from the command line"""
+    parser = argparse.ArgumentParser(description='Simplify video frame PNG files')
+    parser.add_argument("--path", default="./images", type=str,
+        help="Path to PNG files to simplify")
+    parser.add_argument("--verbose", dest="verbose", default=False, action="store_true",
+        help="Show extra details")
+    args = parser.parse_args()
+
+    log = SimpleLog(args.verbose)
+    SimplifyPngFiles(args.path, log.log).simplify()
+
+class SimplifyPngFiles:
+    """Encapsulate logic for Resequence Files feature"""
+    def __init__(self,
+                path : str,
+                log_fn : Callable | None):
+        self.path = path
+        self.log_fn = log_fn
+
+    def simplify(self) -> None:
+        """Invoke the Simplify PNG Files feature"""
+        files = sorted(glob.glob(os.path.join(self.path, "*.png")))
+        num_files = len(files)
+        self.log(f"Found {num_files} files")
+
+        pbar_title = "Simplifying"
+        for file in tqdm(files, desc=pbar_title):
+            self.log(f"removing image info from {file}")
+            img = Image.open(file)
+            if img.info:
+                self.log(f"removing: {img.info}")
+            img.save(file)
+
+    def log(self, message : str) -> None:
+        """Logging"""
+        if self.log_fn:
+            self.log_fn(message)
+
+if __name__ == '__main__':
+    main()

--- a/tabs/simplify_png_files_ui.py
+++ b/tabs/simplify_png_files_ui.py
@@ -3,8 +3,6 @@ from typing import Callable
 import gradio as gr
 from webui_utils.simple_config import SimpleConfig
 from webui_utils.simple_icons import SimpleIcons
-from webui_utils.file_utils import create_directory
-from webui_utils.video_utils import GIFtoPNG as _GIFtoPNG
 # from webui_tips import WebuiTips
 from interpolate_engine import InterpolateEngine
 from tabs.tab_base import TabBase
@@ -21,7 +19,8 @@ class SimplifyPngFiles(TabBase):
     def render_tab(self):
         """Render tab into UI"""
         with gr.Tab("Clean PNG Files"):
-            gr.Markdown(SimpleIcons.SPONGE + "Clean _Ancillary Chunks_ from PNG files")
+            gr.HTML(SimpleIcons.SPONGE + "Remove non-essential PNG chunks for proper display",
+                elem_id="tabheading")
             input_path_text = gr.Text(max_lines=1, label="PNG files path",
                 placeholder="Path on this server to the PNG files to be cleaned")
             with gr.Row():
@@ -29,6 +28,7 @@ class SimplifyPngFiles(TabBase):
                 # output_info_text_gp = gr.Textbox(label="Details", interactive=False)
             # with gr.Accordion(SimpleIcons.TIPS_SYMBOL + " Guide", open=False):
             #     WebuiTips.gif_to_png.render()
+        # gr.Markdown("*Progress can be tracked in the console*")
         clean_button.click(self.clean_png_files, inputs=input_path_text, show_progress=False)
 
     def clean_png_files(self, input_path : str):

--- a/tabs/simplify_png_files_ui.py
+++ b/tabs/simplify_png_files_ui.py
@@ -1,0 +1,37 @@
+"""Simplify PNG files feature UI and event handlers"""
+from typing import Callable
+import gradio as gr
+from webui_utils.simple_config import SimpleConfig
+from webui_utils.simple_icons import SimpleIcons
+from webui_utils.file_utils import create_directory
+from webui_utils.video_utils import GIFtoPNG as _GIFtoPNG
+# from webui_tips import WebuiTips
+from interpolate_engine import InterpolateEngine
+from tabs.tab_base import TabBase
+from simplify_png_files import SimplifyPngFiles as _SimplifyPngFiles
+
+class SimplifyPngFiles(TabBase):
+    """Encapsulates UI elements and events for the Simplify PNG files feature"""
+    def __init__(self,
+                    config : SimpleConfig,
+                    engine : InterpolateEngine,
+                    log_fn : Callable):
+        TabBase.__init__(self, config, engine, log_fn)
+
+    def render_tab(self):
+        """Render tab into UI"""
+        with gr.Tab("Clean PNG Files"):
+            gr.Markdown(SimpleIcons.SPONGE + "Clean _Ancillary Chunks_ from PNG files")
+            input_path_text = gr.Text(max_lines=1, label="PNG files path",
+                placeholder="Path on this server to the PNG files to be cleaned")
+            with gr.Row():
+                clean_button = gr.Button("Clean", variant="primary")
+                # output_info_text_gp = gr.Textbox(label="Details", interactive=False)
+            # with gr.Accordion(SimpleIcons.TIPS_SYMBOL + " Guide", open=False):
+            #     WebuiTips.gif_to_png.render()
+        clean_button.click(self.clean_png_files, inputs=input_path_text, show_progress=False)
+
+    def clean_png_files(self, input_path : str):
+        """Clean button handler"""
+        if input_path:
+            _SimplifyPngFiles(input_path, self.log_fn).simplify()

--- a/tabs/video_blender_ui.py
+++ b/tabs/video_blender_ui.py
@@ -19,6 +19,7 @@ from resequence_files import ResequenceFiles
 from restore_frames import RestoreFrames
 from video_blender import VideoBlenderState, VideoBlenderProjects
 from tabs.tab_base import TabBase
+from simplify_png_files import SimplifyPngFiles
 
 class VideoBlender(TabBase):
     """Encapsulates UI elements and events for the Video Blender eature"""
@@ -670,6 +671,16 @@ class VideoBlender(TabBase):
                     self.log).resequence()
             else:
                 self.log("skipping synchronization of frame sets")
+
+            if self.config.blender_settings["clean_frames"]:
+                self.log(f"cleaning source files in {source_frames_path}")
+                SimplifyPngFiles(source_frames_path, self.log).simplify()
+
+                self.log(f"cleaning restored files in {restored_frames_path}")
+                SimplifyPngFiles(restored_frames_path, self.log).simplify()
+
+                self.log(f"cleaning resynthesized files in {resynth_frames_path}")
+                SimplifyPngFiles(resynth_frames_path, self.log).simplify()
 
             self.log(f"saving new project {new_project_name}")
             self.video_blender_projects.save_project(new_project_name, restored_frames_path,

--- a/tabs/video_blender_ui.py
+++ b/tabs/video_blender_ui.py
@@ -249,7 +249,7 @@ class VideoBlender(TabBase):
         save_project_button_vb.click(self.video_blender_save_project,
             inputs=[input_project_name_vb, input_project_path_vb, input_path1_vb, input_path2_vb,
                     input_main_path, input_project_frame_rate],
-            outputs=[projects_dropdown_vb],
+            outputs=[projects_dropdown_vb, reset_project_dropdown],
             show_progress=False)
         load_button_vb.click(self.video_blender_load,
             inputs=[input_project_path_vb, input_path1_vb, input_path2_vb, input_main_path,
@@ -329,7 +329,7 @@ class VideoBlender(TabBase):
         new_project_button.click(self.video_blender_new_project,
             inputs=[new_project_name, new_project_path, step1_enabled, step2_enabled, step3_enabled,
                 step4_enabled, step1_input, step2_input, step3_input, new_project_frame_rate],
-            outputs=projects_dropdown_vb, show_progress=False)
+            outputs=[projects_dropdown_vb, reset_project_dropdown], show_progress=False)
         reset_project_button.click(self.video_blender_reset_project,
             inputs=reset_project_dropdown,
             outputs=[tabs_video_blender, new_project_name, new_project_path, step1_enabled,
@@ -354,7 +354,8 @@ class VideoBlender(TabBase):
         self.video_blender_projects.save_project(project_name, project_path, frames1_path,
             frames2_path, main_path, fps)
         return gr.update(choices=self.video_blender_projects.get_project_names(),
-                         value=project_name)
+                         value=project_name), \
+                gr.update(choices=self.video_blender_projects.get_project_names())
 
     def video_blender_choose_project(self, project_name):
         """Load Project button handler"""
@@ -687,7 +688,8 @@ class VideoBlender(TabBase):
                                                      source_frames_path, resynth_frames_path,
                                                      new_project_path, step1_frame_rate)
 
-            return gr.update(choices=self.video_blender_projects.get_project_names())
+            return gr.update(choices=self.video_blender_projects.get_project_names()), \
+                gr.update(choices=self.video_blender_projects.get_project_names())
 
     def video_blender_reset_project(self, project_name : str):
         if project_name:

--- a/webui_utils/simple_icons.py
+++ b/webui_utils/simple_icons.py
@@ -83,6 +83,7 @@ class SimpleIcons:
     SCROLL = "📜"
     SEEDLING = "🌱"
     SOAP = "🧼"
+    SPONGE = "🧽"
     STILL = "⚗️"
     SWEAT = "💦"
     TWO_HEARTS = "💕"
@@ -127,6 +128,7 @@ class SimpleIcons:
         ROCKET,
         SCROLL,
         SEEDLING,
+        SPONGE,
         STILL,
         TELEVISION,
         THREE,

--- a/webui_utils/test_simple_icons.py
+++ b/webui_utils/test_simple_icons.py
@@ -5,7 +5,7 @@ from .simple_icons import *
 
 GOOD_EXAMPLES = [
     (SimpleIcons.SYMBOLS, 4, 6),
-    (SimpleIcons.APP_ICONS, 34, 50)]
+    (SimpleIcons.APP_ICONS, 35, 51)]
 
 def test_SimpleIcons():
     for example, expected_items, expected_len in GOOD_EXAMPLES:


### PR DESCRIPTION
PNG frames created by the MP4toPNG feature (and other tools like Adobe Media Encoder and FFmpeg) contain non-essential "ancillary chunks" that specify device-related color information. This info is not ignored by some browsers, for example Chrome, causing a very noticeable difference in the display of frame images while using the video blender frame chooser tool. 

This is a browser display issue only and doesn't seem to affect the output of MP4 files created from the PNG frames with the tool. The "gamma" and "chromaticity" data seems to be the cause. There's more on it here:

https://stackoverflow.com/questions/8206438/why-does-this-png-file-look-different-depending-on-the-browser

and I discovered a simple fix here:

https://stackoverflow.com/questions/62378674/pillow-does-not-preseve-png-info-like-gamma

- Created new `simplify_png_files.py` script to open and resave PNG files in a path, striping the non-essential ancillary chunks
- Added a new _Clean PNG Files_ tab to use the script via the Web UI
- Added an automatic cleaning of PNG files in the Video Blender _New Project_ operation
    - can be disabled with the `blender_settings:clean_frames` setting 