### PR TITLE
Add ability to hide some UI elements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -149,3 +149,6 @@ temp/
 notes.txt
 test_assets/
 models!/
+ui.bat
+config-local.yaml
+my_video_blender_projects.csv

--- a/config.yaml
+++ b/config.yaml
@@ -83,3 +83,4 @@ user_interface:
   theme: "default"
   css_file: "webui.css"
   log_file: None
+  show_header: True

--- a/create_ui.py
+++ b/create_ui.py
@@ -30,11 +30,25 @@ def create_ui(config : SimpleConfig,
               restart_fn : Callable):
     """Construct the Gradio Blocks UI"""
 
+    app_header = gr.HTML(SimpleIcons.CLAPPER + "EMA-VFI Web UI", elem_id="appheading")
+    sep = '  •  '
+    _js = ('<a href="/" ' +
+        'onclick="javascript:gradioApp()' +
+        '.getElementById(\'settings_restart_gradio\').click();' +
+        'return false">Reload UI</a>')
+    footer = (SimpleIcons.COPYRIGHT + ' 2023 J. Hogsett' +
+        sep + '<a href="https://github.com/jhogsett/EMA-VFI-WebUI">Github</a>' +
+        sep + '<a href="https://github.com/MCG-NJU/EMA-VFI">EMA-VFI</a>' +
+        sep + '<a href="https://gradio.app">Gradio</a>' +
+        sep + _js)
+    app_footer = gr.HTML(footer, elem_id="footer")
+
     with gr.Blocks(analytics_enabled=False,
                     title="EMA-VFI Web UI",
                     theme=config.user_interface["theme"],
                     css=config.user_interface["css_file"]) as app:
-        gr.HTML(SimpleIcons.CLAPPER + "EMA-VFI Web UI", elem_id="appheading")
+        if config.user_interface["show_header"]:
+            app_header.render()
         FrameInterpolation(config, engine, log.log).render_tab()
         FrameSearch(config, engine, log.log).render_tab()
         VideoInflation(config, engine, log.log).render_tab()
@@ -58,15 +72,6 @@ def create_ui(config : SimpleConfig,
             Resources(config, engine, log.log).render_tab()
             Options(config, engine, log.log, restart_fn).render_tab()
             LogViewer(config, engine, log.log, log).render_tab()
-        sep = '  •  '
-        _js = ('<a href="/" ' +
-            'onclick="javascript:gradioApp()' +
-            '.getElementById(\'settings_restart_gradio\').click();' +
-            'return false">Reload UI</a>')
-        footer = (SimpleIcons.COPYRIGHT + ' 2023 J. Hogsett' +
-            sep + '<a href="https://github.com/jhogsett/EMA-VFI-WebUI">Github</a>' +
-            sep + '<a href="https://github.com/MCG-NJU/EMA-VFI">EMA-VFI</a>' +
-            sep + '<a href="https://gradio.app">Gradio</a>' +
-            sep + _js)
-        gr.HTML(footer, elem_id="footer")
+        if config.user_interface["show_header"]:
+            app_footer.render()
     return app

--- a/tabs/video_blender_ui.py
+++ b/tabs/video_blender_ui.py
@@ -129,8 +129,9 @@ class VideoBlender(TabBase):
                             input_text_frame_vb = gr.Number(value=0, precision=0,
                                 label="Frame Number")
 
-                    with gr.Accordion(SimpleIcons.TIPS_SYMBOL + " Guide", open=False):
-                        WebuiTips.video_blender_frame_chooser.render()
+                    if self.config.user_interface["show_header"]:
+                        with gr.Accordion(SimpleIcons.TIPS_SYMBOL + " Guide", open=False):
+                            WebuiTips.video_blender_frame_chooser.render()
 
                 ### FRAME FIXER
                 with gr.Tab(SimpleIcons.HAMMER + "Frame Fixer", id=2):


### PR DESCRIPTION
Adds a config `user_interface:show_header` (default True) that when set False hides the Header, Footer and Guide (Frame Chooser tab only) to allow using the Frame Chooser tool with less chance of the screen scrolling when the mouse wheel is used for scrubbing.*

*These can also help to reduce screen scrolling
- set browser to full screen
- set Windows task bar to auto-hide
- set browser zoom to < 100%

![Screenshot 2023-04-04 220015](https://user-images.githubusercontent.com/825994/229985584-2bdfe0cb-4291-43db-8c8a-ea86b8a97572.png)


Future plans: use Javascript to lock the screen from scrolling while the Frame Chooser tab is displayed (I could use help with this)