### PR TITLE
Add stride and offset options to resequencing feature

### DIFF
--- a/guide/resequence_files.md
+++ b/guide/resequence_files.md
@@ -11,16 +11,27 @@
     - A wildcard such as `*` will not work here
 1. Set _Base Filename_ or accept the default
     - This is used ahead of the frame index number for new filenames
-1. Set _Starting Sequence Number_ or accept the default of 0
+    - **⚠️ Important: use a name other than the current name of the files**
+1. Set _Starting Frame Number_ or accept the default of `0`
     - A different value might be useful if inserting a PNG sequence into another
-1. Set _Integer Step_ or accept the default the default of 1
+1. Set _Frame Number Step_ or accept the default the default of `1`
     - This sets the increment between the added frame index numbers
-1. Set _Number Padding_ or accept the default of -1
+1. Set _Frame Number Padding_ or accept the default of `-1`
     - This set the width of the added frame index numbers
-    - If set to -1, the width is determined based on the number of files
+    - If set to `-1`, the width is determined based on the number of files
+1. Leave _Samping Stride_ set to `1` and _Sampling Offset_ set to `0`
+    - These are used for special purposes, for example:
+        - To select only _even_ frames:
+            - set _Sampling Stride_ to `2`
+        - To select only _odd_ frames:
+            - set _Sampling Stride_ to `2`
+            - set _Sampling Offset_ to `1`
+        - _Tip: selecting_ even _or_ odd _frames can be useful if using de-interlaced content_
 1. Leave _Rename instead of duplicate files_ unchecked to keep a copy of the original files
     - The original files can be handy for tracking down a source frame
 1. Click _Resequence Files_
 
-## Important
+## ⚠️ Important
+1.  **Make a backup copy of the original files before using _Rename instead of duplicate files_ due to the danger of losing the original content**
+1. Ensure _Base Filename_ is set to a different name than the source files
 1. Ensure the only files present in the input path are the ones to be resequenced

--- a/tabs/change_fps_ui.py
+++ b/tabs/change_fps_ui.py
@@ -113,5 +113,5 @@ class ChangeFPS(TabBase):
                 ending_fps, precision, f"resampled@{starting_fps}")
 
             self.log(f"auto-resequencing sampled frames at {output_path}")
-            _ResequenceFiles(base_output_path, "png", f"resampled@{ending_fps}fps", 0, 1, 0, 1, -1,
+            _ResequenceFiles(base_output_path, "png", f"resampled@{ending_fps}fps", 0, 1, 1, 0, -1,
                              True, self.log).resequence()

--- a/tabs/change_fps_ui.py
+++ b/tabs/change_fps_ui.py
@@ -113,5 +113,5 @@ class ChangeFPS(TabBase):
                 ending_fps, precision, f"resampled@{starting_fps}")
 
             self.log(f"auto-resequencing sampled frames at {output_path}")
-            _ResequenceFiles(base_output_path, "png", f"resampled@{ending_fps}fps", 0, 1, -1, True,
-                 self.log).resequence()
+            _ResequenceFiles(base_output_path, "png", f"resampled@{ending_fps}fps", 0, 1, 0, 1, -1,
+                             True, self.log).resequence()

--- a/tabs/gif_to_mp4_ui.py
+++ b/tabs/gif_to_mp4_ui.py
@@ -229,7 +229,7 @@ class GIFtoMP4(TabBase):
             self.inflate_using_resampling(input_path, output_path, inflate_factor, precision)
 
         self.log(f"auto-resequencing sampled frames at {output_path}")
-        _ResequenceFiles(output_path, "png", f"resampledX{inflate_factor}", 0, 1, -1, True,
+        _ResequenceFiles(output_path, "png", f"resampledX{inflate_factor}", 0, 1, 0, 1, -1, True,
                 self.log).resequence()
 
     def convert_png_frames_to_mp4(self, input_path, output_filepath, frame_rate, quality):

--- a/tabs/gif_to_mp4_ui.py
+++ b/tabs/gif_to_mp4_ui.py
@@ -229,7 +229,7 @@ class GIFtoMP4(TabBase):
             self.inflate_using_resampling(input_path, output_path, inflate_factor, precision)
 
         self.log(f"auto-resequencing sampled frames at {output_path}")
-        _ResequenceFiles(output_path, "png", f"resampledX{inflate_factor}", 0, 1, 0, 1, -1, True,
+        _ResequenceFiles(output_path, "png", f"resampledX{inflate_factor}", 0, 1, 1, 0, -1, True,
                 self.log).resequence()
 
     def convert_png_frames_to_mp4(self, input_path, output_filepath, frame_rate, quality):

--- a/tabs/resequence_files_ui.py
+++ b/tabs/resequence_files_ui.py
@@ -65,4 +65,4 @@ class ResequenceFiles(TabBase):
         if input_path and input_filetype and input_newname and input_start and input_step \
                 and input_zerofill:
             _ResequenceFiles(input_path, input_filetype, input_newname, int(input_start),
-                int(input_step), int(input_zerofill), input_rename_check, self.log).resequence()
+                int(input_step), 0, 1, int(input_zerofill), input_rename_check, self.log).resequence()

--- a/tabs/resequence_files_ui.py
+++ b/tabs/resequence_files_ui.py
@@ -34,14 +34,16 @@ class ResequenceFiles(TabBase):
                             label="Base Filename")
                     with gr.Row():
                         input_start_text = gr.Text(value="0", max_lines=1,
-                            placeholder="Starting integer for the sequence",
-                            label="Starting Sequence Number")
+                            label="Starting Frame Number (usually 0)")
                         input_step_text = gr.Text(value="1", max_lines=1,
-                            placeholder="Integer step for the sequentially numbered files",
-                            label="Integer Step")
+                            label="Frame Number Step (usually 1)")
                         input_zerofill_text = gr.Text(value="-1", max_lines=1,
-                            placeholder="Padding with for sequential numbers, -1=auto",
-                            label="Number Padding")
+                            label="Frame Number Padding (-1 for auto detect)")
+                    with gr.Row():
+                        input_stride = gr.Text(value="1", max_lines=1,
+                            label="Sampling Stride (usually 1)")
+                        input_offset = gr.Text(value="0", max_lines=1,
+                            label="Sampling Offset (usually 0)")
                     with gr.Row():
                         input_rename_check = gr.Checkbox(value=False,
                             label="Rename instead of duplicate files")
@@ -50,7 +52,7 @@ class ResequenceFiles(TabBase):
                 WebuiTips.resequence_files.render()
         resequence_button.click(self.resequence_files,
             inputs=[input_path_text2, input_filetype_text, input_newname_text,
-                input_start_text, input_step_text, input_zerofill_text,
+                input_start_text, input_step_text, input_stride, input_offset, input_zerofill_text,
                 input_rename_check])
 
     def resequence_files(self,
@@ -59,10 +61,13 @@ class ResequenceFiles(TabBase):
                         input_newname : str,
                         input_start : str,
                         input_step : str,
+                        input_stride : str,
+                        input_offset : str,
                         input_zerofill : str,
                         input_rename_check : bool):
         """Resequence Button handler"""
         if input_path and input_filetype and input_newname and input_start and input_step \
                 and input_zerofill:
             _ResequenceFiles(input_path, input_filetype, input_newname, int(input_start),
-                int(input_step), 1, 0, int(input_zerofill), input_rename_check, self.log).resequence()
+                int(input_step), int(input_stride), int(input_offset), int(input_zerofill),
+                input_rename_check, self.log).resequence()

--- a/tabs/resequence_files_ui.py
+++ b/tabs/resequence_files_ui.py
@@ -65,4 +65,4 @@ class ResequenceFiles(TabBase):
         if input_path and input_filetype and input_newname and input_start and input_step \
                 and input_zerofill:
             _ResequenceFiles(input_path, input_filetype, input_newname, int(input_start),
-                int(input_step), 0, 1, int(input_zerofill), input_rename_check, self.log).resequence()
+                int(input_step), 1, 0, int(input_zerofill), input_rename_check, self.log).resequence()

--- a/tabs/resynthesize_video_ui.py
+++ b/tabs/resynthesize_video_ui.py
@@ -63,5 +63,5 @@ class ResynthesizeVideo(TabBase):
             series_interpolater.interpolate_series(file_list, output_path, 1, output_basename,
                 offset=2)
             self.log(f"auto-resequencing recreated frames at {output_path}")
-            ResequenceFiles(output_path, "png", "resynthesized_frame", 1, 1, 0, 1, -1, True,
+            ResequenceFiles(output_path, "png", "resynthesized_frame", 1, 1, 1, 0, -1, True,
                 self.log).resequence()

--- a/tabs/resynthesize_video_ui.py
+++ b/tabs/resynthesize_video_ui.py
@@ -63,5 +63,5 @@ class ResynthesizeVideo(TabBase):
             series_interpolater.interpolate_series(file_list, output_path, 1, output_basename,
                 offset=2)
             self.log(f"auto-resequencing recreated frames at {output_path}")
-            ResequenceFiles(output_path, "png", "resynthesized_frame", 1, 1, -1, True,
+            ResequenceFiles(output_path, "png", "resynthesized_frame", 1, 1, 0, 1, -1, True,
                 self.log).resequence()

--- a/tabs/video_blender_ui.py
+++ b/tabs/video_blender_ui.py
@@ -637,7 +637,7 @@ class VideoBlender(TabBase):
                 series_interpolater.interpolate_series(file_list, resynth_frames_path, 1,
                                                        output_basename, offset=2)
                 self.log(f"auto-resequencing recreated frames at {resynth_frames_path}")
-                ResequenceFiles(resynth_frames_path, "png", "repair_frame", 1, 1, 0, 1, -1, True,
+                ResequenceFiles(resynth_frames_path, "png", "repair_frame", 1, 1, 1, 0, -1, True,
                     self.log).resequence()
             else:
                 self.log(
@@ -666,15 +666,15 @@ class VideoBlender(TabBase):
                 self.log("synchronizing frame sets")
 
                 self.log(f"resequencing source files in {source_frames_path}")
-                ResequenceFiles(source_frames_path, "png", "source_frame", 0, 1, 0, 1, -1, True,
+                ResequenceFiles(source_frames_path, "png", "source_frame", 0, 1, 1, 0, -1, True,
                     self.log).resequence()
 
                 self.log(f"resequencing restored files in {restored_frames_path}")
-                ResequenceFiles(restored_frames_path, "png", "source_frame", 0, 1, 0, 1, -1, True,
+                ResequenceFiles(restored_frames_path, "png", "source_frame", 0, 1, 1, 0, -1, True,
                     self.log).resequence()
 
                 self.log(f"resequencing resynthesized files in {resynth_frames_path}")
-                ResequenceFiles(resynth_frames_path, "png", "repair_frame", 0, 1, 0, 1, -1, True,
+                ResequenceFiles(resynth_frames_path, "png", "repair_frame", 0, 1, 1, 0, -1, True,
                     self.log).resequence()
             else:
                 self.log("skipping synchronization of frame sets")

--- a/tabs/video_blender_ui.py
+++ b/tabs/video_blender_ui.py
@@ -637,7 +637,7 @@ class VideoBlender(TabBase):
                 series_interpolater.interpolate_series(file_list, resynth_frames_path, 1,
                                                        output_basename, offset=2)
                 self.log(f"auto-resequencing recreated frames at {resynth_frames_path}")
-                ResequenceFiles(resynth_frames_path, "png", "repair_frame", 1, 1, -1, True,
+                ResequenceFiles(resynth_frames_path, "png", "repair_frame", 1, 1, 0, 1, -1, True,
                     self.log).resequence()
             else:
                 self.log(
@@ -666,15 +666,15 @@ class VideoBlender(TabBase):
                 self.log("synchronizing frame sets")
 
                 self.log(f"resequencing source files in {source_frames_path}")
-                ResequenceFiles(source_frames_path, "png", "source_frame", 0, 1, -1, True,
+                ResequenceFiles(source_frames_path, "png", "source_frame", 0, 1, 0, 1, -1, True,
                     self.log).resequence()
 
                 self.log(f"resequencing restored files in {restored_frames_path}")
-                ResequenceFiles(restored_frames_path, "png", "source_frame", 0, 1, -1, True,
+                ResequenceFiles(restored_frames_path, "png", "source_frame", 0, 1, 0, 1, -1, True,
                     self.log).resequence()
 
                 self.log(f"resequencing resynthesized files in {resynth_frames_path}")
-                ResequenceFiles(resynth_frames_path, "png", "repair_frame", 0, 1, -1, True,
+                ResequenceFiles(resynth_frames_path, "png", "repair_frame", 0, 1, 0, 1, -1, True,
                     self.log).resequence()
             else:
                 self.log("skipping synchronization of frame sets")

--- a/webui_utils/simple_utils.py
+++ b/webui_utils/simple_utils.py
@@ -111,3 +111,27 @@ def power_of_two_precision(var):
         return int(math.log2(var))
     else:
         raise ValueError(f"{var} is not a power of 2")
+
+def _should_sample(index : int, offset : int, stride : int):
+    if index < offset:
+        return False
+    return (index - offset) % stride == 0
+
+def create_sample_indices(set_size : int, offset : int, stride : int):
+    if set_size < 0:
+        raise ValueError("'set_size' must be zero or positive")
+    if offset < 0:
+        raise ValueError("'offset' must be zero or positive")
+    if stride < 1:
+        raise ValueError("'stride' must be >= 1")
+    sample_indices = []
+    for index in range(set_size):
+        if _should_sample(index, offset, stride):
+            sample_indices.append(index)
+    return sample_indices
+
+def create_sample_set(samples : list, offset : int, stride : int):
+    if not isinstance(samples, list):
+        raise ValueError("'samples' must be a list")
+    sample_set = create_sample_indices(len(samples), offset, stride)
+    return [samples[index] for index in sample_set]

--- a/webui_utils/simple_utils.py
+++ b/webui_utils/simple_utils.py
@@ -115,6 +115,8 @@ def power_of_two_precision(var):
 def _should_sample(index : int, offset : int, stride : int):
     if index < offset:
         return False
+    # (index - offset) ensures 1: first sample gets taken,
+    # 2: sampling is synchronized to frame #0 regardless of offset
     return (index - offset) % stride == 0
 
 def create_sample_indices(set_size : int, offset : int, stride : int):

--- a/webui_utils/test_simple_utils.py
+++ b/webui_utils/test_simple_utils.py
@@ -1,0 +1,102 @@
+import pytest # pylint: disable=import-error
+from .simple_utils import *
+
+GOOD_CREATE_SAMPLE_INDICES_ARGS = [
+    ((10, 0, 1), [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]),
+    ((10, 1, 1), [1, 2, 3, 4, 5, 6, 7, 8, 9]),
+    ((10, 2, 1), [2, 3, 4, 5, 6, 7, 8, 9]),
+    ((10, 3, 1), [3, 4, 5, 6, 7, 8, 9]),
+    ((10, 4, 1), [4, 5, 6, 7, 8, 9]),
+    ((10, 5, 1), [5, 6, 7, 8, 9]),
+    ((10, 6, 1), [6, 7, 8, 9]),
+    ((10, 7, 1), [7, 8, 9]),
+    ((10, 8, 1), [8, 9]),
+    ((10, 9, 1), [9]),
+    ((10, 10, 1), []),
+    ((10, 11, 1), []),
+
+    ((10, 0, 2), [0, 2, 4, 6, 8]),
+    ((10, 1, 2), [1, 3, 5, 7, 9]),
+    ((10, 2, 2), [2, 4, 6, 8]),
+    ((10, 3, 2), [3, 5, 7, 9]),
+    ((10, 4, 2), [4, 6, 8]),
+    ((10, 5, 2), [5, 7, 9]),
+    ((10, 6, 2), [6, 8]),
+    ((10, 7, 2), [7, 9]),
+    ((10, 8, 2), [8]),
+    ((10, 9, 2), [9]),
+    ((10, 10, 2), []),
+    ((10, 11, 2), []),
+
+    ((10, 0, 3), [0, 3, 6, 9]),
+    ((10, 1, 3), [1, 4, 7]),
+    ((10, 2, 3), [2, 5, 8]),
+    ((10, 3, 3), [3, 6, 9]),
+    ((10, 4, 3), [4, 7]),
+    ((10, 5, 3), [5, 8]),
+    ((10, 6, 3), [6, 9]),
+    ((10, 7, 3), [7]),
+    ((10, 8, 3), [8]),
+    ((10, 9, 3), [9]),
+    ((10, 10, 3), []),
+    ((10, 11, 3), []),
+
+    ((0, 0, 1), []),
+    ((0, 1, 1), []),
+    ((0, 2, 1), []),
+    ((0, 0, 2), []),
+    ((0, 1, 2), []),
+    ((0, 2, 2), []),
+    ((1, 0, 1), [0]),
+    ((1, 1, 1), []),
+    ((1, 2, 2), []),
+    ((1, 0, 2), [0]),
+    ((1, 1, 2), []),
+    ((1, 2, 2), []),
+    ((5, 2, 3), [2]),
+]
+
+BAD_CREATE_SAMPLE_INDICES_ARGS = [
+    ((-1, 0, 1), "'set_size' must be zero or positive"),
+    ((10, -1, 1), "'offset' must be zero or positive"),
+    ((10, 0, 0), "'stride' must be >= 1"),
+    ((10, 0, -1), "'stride' must be >= 1")]
+
+def test_create_sample_indices():
+    for args, expected in GOOD_CREATE_SAMPLE_INDICES_ARGS:
+        result = create_sample_indices(*args)
+        assert result == expected
+
+    for bad_args, match_text in BAD_CREATE_SAMPLE_INDICES_ARGS:
+        with pytest.raises(ValueError, match=match_text):
+            create_sample_indices(*bad_args)
+
+GOOD_CREATE_SAMPLE_SET_ARGS = [
+    (([1, 2, 3, 4, 5], 0, 1), [1, 2, 3, 4, 5]),
+    (([1, 2, 3, 4, 5], 1, 1), [2, 3, 4, 5]),
+    (([1, 2, 3, 4, 5], 0, 2), [1, 3, 5]),
+    (([1, 2, 3, 4, 5], 1, 2), [2, 4]),
+    (([1, 2, 3, 4, 5], 0, 3), [1, 4]),
+    (([1, 2, 3, 4, 5], 1, 3), [2, 5]),
+    (([1, 2, 3, 4, 5], 0, 4), [1, 5]),
+    (([1, 2, 3, 4, 5], 1, 4), [2]),
+    (([1, 2, 3, 4, 5], 0, 5), [1]),
+    (([1, 2, 3, 4, 5], 1, 5), [2]),
+    ((["1", "2", "3", "4", "5"], 0, 1), ["1", "2", "3", "4", "5"]),
+    (([1, 2.0, {3:3}, "four", {5}], 1, 1), [2.0, {3:3}, "four", {5}])]
+
+BAD_CREATE_SAMPLE_SET_ARGS = [
+    ((1, 0, 0), "'samples' must be a list"),
+    ((2.0, 0, 0), "'samples' must be a list"),
+    (({3:3}, 0, 0), "'samples' must be a list"),
+    (("four", 0, 0), "'samples' must be a list"),
+    (({5, 5}, 0, 0), "'samples' must be a list")]
+
+def test_create_sample_set():
+    for args, expected in GOOD_CREATE_SAMPLE_SET_ARGS:
+        result = create_sample_set(*args)
+        assert result == expected
+
+    for bad_args, match_text in BAD_CREATE_SAMPLE_SET_ARGS:
+        with pytest.raises(ValueError, match=match_text):
+            create_sample_set(*bad_args)


### PR DESCRIPTION
Adds the ability to specify a _sampling stride_ and _sampling offset_ used when reading from a set of PNG frames to rename them for resequencing.
- A typical use for this is to separate a set of frames into _even_ and _odd_ sets (useful for some de-interlaced content)
- For example, to select all odd frames, _stride_ is set to `2` and _offset_ is set to `0`
- Stride and offset should be set to `1` and `0` respectively (the defaults) when sampling all frames