### PR TITLE
Add auto use of tiling to upscale images that exceed VRAM

### DIFF
--- a/guide/upscale_frames.md
+++ b/guide/upscale_frames.md
@@ -24,8 +24,12 @@ Real-ESRGAN must be installed locally to use
     - Real-ESRGAN will perform upscaling when _factor_ is > 1.0
         - _Tip: It will remove dirt and noise even when not upscaling_
 1. Choose whether or not to use _Tiling_
+    - select _Auto_ to ensure all files are processed
+        - Files will be processed first for the best possible quality
+        - Files that fail to process will be redone using _tiling_ (see _Yes_ option below)
     - Select _No_ for the best quality.
         - Entire images will be upscaled at once
+        - Files that cannot be processed due to VRAM limitations will be skipped
     - Select _Yes_ if upscaling large images, or running into low VRAM conditions
         - Images will be upscaled in blocks then stiched together
         - Tiling _Size_ and _Padding_ (in pixels) are set using the config settings:


### PR DESCRIPTION
When upscaling a folder of images, some can fail due to VRAM limitations, making it necessary to determine which ones failed and rerun them. This adds a new "Auto" option to the _Upscale Frames_ tab (chosen by default). Files are first upscaled without tiling. Files that failed are rerun again using tiling.