### PR TITLE
Move resources page links from hard code to resources.csv

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -84,3 +84,4 @@ user_interface:
   css_file: "webui.css"
   log_file: None
   show_header: True
+  resources_path: "resources.csv"

--- a/resources.csv
+++ b/resources.csv
@@ -1,0 +1,7 @@
+icon,title,link_description,url
+"globe","FFmpeg (Free Download)","Download FFmpeg","https://ffmpeg.org/download.html"
+"globe","Real-ESRGAN Image/Video Restoration (Github)","Practical Algorithms for General Image/Video Restoration","https://github.com/xinntao/Real-ESRGAN"
+"globe","Adobe AI-Based Speech Enhancement (Free)","Adobe Podcast (Beta) Enhance Speech", "https://podcast.adobe.com/enhance"
+"globe","Coqui TTS (Python)","Advanced Text-to-Speech generation", "https://pypi.org/project/TTS/"
+"globe","Motion Array (Royalty-Free Content)","The All-in-One Video &amp; Filmmakers Platform", "https://motionarray.com/"
+"baby","My YouTube Channel","youtube.com/@jerryhogsett","https://www.youtube.com/@jerryhogsett"

--- a/webui_utils/simple_icons.py
+++ b/webui_utils/simple_icons.py
@@ -63,6 +63,7 @@ class SimpleIcons:
     WARNING = "⚠️"
 
     BALLOON = "🎈"
+    BABY = "👶"
     BOMB = "💣"
     CHERRY_BLOSSOM = "🌸"
     COOL = "🆒"


### PR DESCRIPTION
The list of online resources is now kept in local file `resouces.csv`. 

A custom `.csv` can be used instead by modifying the `config.yaml` value `user_interface.resources_path`.