### PR TITLE
Fix resources page links

### DIFF
--- a/resources.csv
+++ b/resources.csv
@@ -1,7 +1,7 @@
 icon,title,link_description,url
 "globe","FFmpeg (Free Download)","Download FFmpeg","https://ffmpeg.org/download.html"
 "globe","Real-ESRGAN Image/Video Restoration (Github)","Practical Algorithms for General Image/Video Restoration","https://github.com/xinntao/Real-ESRGAN"
-"globe","Adobe AI-Based Speech Enhancement (Free)","Adobe Podcast (Beta) Enhance Speech", "https://podcast.adobe.com/enhance"
-"globe","Coqui TTS (Python)","Advanced Text-to-Speech generation", "https://pypi.org/project/TTS/"
-"globe","Motion Array (Royalty-Free Content)","The All-in-One Video &amp; Filmmakers Platform", "https://motionarray.com/"
+"globe","Adobe AI-Based Speech Enhancement (Free)","Adobe Podcast (Beta) Enhance Speech","https://podcast.adobe.com/enhance"
+"globe","Coqui TTS (Python)","Advanced Text-to-Speech generation","https://pypi.org/project/TTS/"
+"globe","Motion Array (Royalty-Free Content)","The All-in-One Video &amp; Filmmakers Platform","https://motionarray.com/"
 "baby","My YouTube Channel","youtube.com/@jerryhogsett","https://www.youtube.com/@jerryhogsett"


### PR DESCRIPTION
There were spaces after some commas, causing the csv engine to skip remaining line data