### PR TITLE
Fix Guide Icon

### DIFF
--- a/webui_utils/simple_icons.py
+++ b/webui_utils/simple_icons.py
@@ -90,7 +90,7 @@ class SimpleIcons:
     TWO_HEARTS = "💕"
 
     # shared symbol definitions
-    TIPS_SYMBOL = INFO
+    TIPS_SYMBOL = QUESTION
     SLOW_SYMBOL = WATCH
     PROP_SYMBOL = PROPERTIES
     CONV_SYMBOL = STILL


### PR DESCRIPTION
The white-on-blue Guide icon changed to a tiny letter 'i' after the Gradio update. Switch to a red question mark instead. (Tested in Chrome)