### PR TITLE
New Feature: Resize Frames

### DIFF
--- a/create_ui.py
+++ b/create_ui.py
@@ -24,6 +24,7 @@ from tabs.gif_to_mp4_ui import GIFtoMP4
 from tabs.log_viewer import LogViewer
 from tabs.simplify_png_files_ui import SimplifyPngFiles
 from tabs.dedupe_frames_ui import DedupeFrames
+from tabs.resize_frames_ui import ResizeFrames
 
 def create_ui(config : SimpleConfig,
               engine : InterpolateEngine,
@@ -63,6 +64,7 @@ def create_ui(config : SimpleConfig,
                 PNGtoGIF(config, engine, log.log).render_tab()
                 SimplifyPngFiles(config, engine, log.log).render_tab()
                 DedupeFrames(config, engine, log.log).render_tab()
+                ResizeFrames(config, engine, log.log).render_tab()
             ResequenceFiles(config, engine, log.log).render_tab()
             ChangeFPS(config, engine, log.log).render_tab()
             UpscaleFrames(config, engine, log.log).render_tab()

--- a/guide/resize_frames.md
+++ b/guide/resize_frames.md
@@ -1,0 +1,19 @@
+**Resize Frames** - Use `OpenCV Resize` to Enlarge or Reduce Frames
+
+## Uses
+- Increase or decrease the size of video frames
+- Modify Aspect Ratio
+- Reduce image blur prior to using _Upscale Frames_ to enlarge using _Real-ESRGAN_
+
+## How It Works
+1. Set _Input Path_ to a directory on this server to the PNG files to be resized
+1. Set _Output Path_ to a directory on this server for the resized PNG files
+1. Set _New Width_ and _New Height_ to the dimensions for the new PNG frames
+1. Set _Scaling Type_ to one of the available types:
+    - **area** `cv2.INTER_AREA` (best quality reducing)
+    - **cubic** `cv2.INTER_CUBIC` (better quality than linear)
+    - **lanczos** `cv2.INTER_LANCZOS4` (best quality enlarging)
+    - **linear** `cv2.INTER_LINEAR` (fast, good at enlarging)
+    - **nearest** `cv2.INTER_NEAREST` (fastest, lower quality)
+1. Click _Resize Frames_
+1. When complete, the output path will contain a new set of frames

--- a/resize_frames.py
+++ b/resize_frames.py
@@ -1,0 +1,89 @@
+"""Resize Frames Feature Core Code"""
+import os
+import glob
+import argparse
+import cv2
+from typing import Callable
+from tqdm import tqdm
+from webui_utils.simple_log import SimpleLog
+from webui_utils.file_utils import split_filepath, create_directory
+
+def main():
+    """Use the Resize Frames feature from the command line"""
+    parser = argparse.ArgumentParser(description='Resize PNG files')
+    parser.add_argument("--input_path", default="images", type=str,
+        help="Input path to PNG files to resize")
+    parser.add_argument("--output_path", default="images/resized", type=str,
+        help="Output path for resized PNG files")
+    parser.add_argument("--new_width", default=None, type=int,
+        help="Resized image width (default=None)")
+    parser.add_argument("--new_height", default=None, type=int,
+        help="Resized image height (default=None)")
+    parser.add_argument("--scale_type", default="lanczos", type=str,
+        help="Scaling type 'lanczos' (default), 'nearest', 'linear', 'cubic', 'area'")
+    parser.add_argument("--verbose", dest="verbose", default=False, action="store_true",
+        help="Show extra details")
+    args = parser.parse_args()
+
+    log = SimpleLog(args.verbose)
+    ResizeFrames(args.input_path,
+                 args.output_path,
+                 args.new_width,
+                 args.new_height,
+                 args.scale_type,
+                 log.log).resize()
+
+class ResizeFrames:
+    """Encapsulate logic for Resize Frames feature"""
+    def __init__(self,
+                input_path : str,
+                output_path : str,
+                new_width : int,
+                new_height : int,
+                scale_type : str,
+                log_fn : Callable | None):
+        self.input_path = input_path
+        self.output_path = output_path
+        self.new_width = new_width
+        self.new_height = new_height
+        self.scale_type = scale_type
+        self.log_fn = log_fn
+
+    def get_scale_type(self, scale_type : str) -> int:
+        try:
+            return {
+                "lanczos" : cv2.INTER_LANCZOS4,
+                "nearest" : cv2.INTER_NEAREST,
+                "linear" : cv2.INTER_LINEAR,
+                "cubic" : cv2.INTER_CUBIC,
+                "area" : cv2.INTER_AREA
+            }[scale_type]
+        except KeyError:
+            raise ValueError(f"The type {scale_type} is unknown")
+
+    def resize(self) -> None:
+        """Invoke the Resize Frames feature"""
+        files = sorted(glob.glob(os.path.join(self.input_path, "*.png")))
+        num_files = len(files)
+        self.log(f"Found {num_files} files")
+        create_directory(self.output_path)
+        scale_type = self.get_scale_type(self.scale_type)
+
+        pbar_title = "Resizing"
+        for file in tqdm(files, desc=pbar_title):
+            self.log(f"resizing {file}")
+            image = cv2.imread(file)
+            size = (self.new_width, self.new_height)
+            resized_image = cv2.resize(image, size, interpolation = scale_type)
+            _, filename, ext = split_filepath(file)
+            output_filepath = os.path.join(self.output_path, f"{filename}.{ext}")
+            self.log(f"saving resized file {output_filepath}")
+            cv2.imwrite(output_filepath, resized_image)
+
+    def log(self, message : str) -> None:
+        """Logging"""
+        if self.log_fn:
+            self.log_fn(message)
+
+if __name__ == '__main__':
+    main()

--- a/split_channels.py
+++ b/split_channels.py
@@ -25,7 +25,7 @@ def main():
     SplitChannels(args.input_path, args.output_path, args.type, log.log).split()
 
 class SplitChannels:
-    """Encapsulate logic for Resequence Files feature"""
+    """Encapsulate logic for Split Channels feature"""
     def __init__(self,
                 input_path : str,
                 output_path : str,

--- a/tabs/resize_frames_ui.py
+++ b/tabs/resize_frames_ui.py
@@ -6,7 +6,7 @@ from webui_utils.simple_icons import SimpleIcons
 from webui_utils.file_utils import create_directory, get_files
 from webui_utils.auto_increment import AutoIncrementDirectory
 from webui_utils.ui_utils import update_splits_info
-# from webui_tips import WebuiTips
+from webui_tips import WebuiTips
 from resize_frames import ResizeFrames as _ResizeFrames
 from tabs.tab_base import TabBase
 
@@ -43,8 +43,8 @@ class ResizeFrames(TabBase):
             gr.Markdown("*Progress can be tracked in the console*")
             resize_button = gr.Button("Resize Frames " + SimpleIcons.SLOW_SYMBOL,
                                        variant="primary")
-            # with gr.Accordion(SimpleIcons.TIPS_SYMBOL + " Guide", open=False):
-            #     WebuiTips.upscale_frames.render()
+            with gr.Accordion(SimpleIcons.TIPS_SYMBOL + " Guide", open=False):
+                WebuiTips.resize_frames.render()
         resize_button.click(self.resize_frames,
             inputs=[input_path_text, output_path_text, new_width, new_height, scale_type])
 

--- a/tabs/resize_frames_ui.py
+++ b/tabs/resize_frames_ui.py
@@ -1,0 +1,65 @@
+"""Resize Frames feature UI and event handlers"""
+from typing import Callable
+import gradio as gr
+from webui_utils.simple_config import SimpleConfig
+from webui_utils.simple_icons import SimpleIcons
+from webui_utils.file_utils import create_directory, get_files
+from webui_utils.auto_increment import AutoIncrementDirectory
+from webui_utils.ui_utils import update_splits_info
+# from webui_tips import WebuiTips
+from resize_frames import ResizeFrames as _ResizeFrames
+from tabs.tab_base import TabBase
+
+class ResizeFrames(TabBase):
+    """Encapsulates UI elements and events for the Resize Frames feature"""
+    def __init__(self,
+                    config : SimpleConfig,
+                    engine : any,
+                    log_fn : Callable):
+        TabBase.__init__(self, config, engine, log_fn)
+
+    def render_tab(self):
+        """Render tab into UI"""
+        with gr.Tab("Resize Frames"):
+            gr.HTML(SimpleIcons.PINCHING_HAND + " Use OpenCV 'Resize' to Enlarge or Reduce Frames",
+                elem_id="tabheading")
+            with gr.Row():
+                with gr.Column():
+                    input_path_text = gr.Text(max_lines=1,
+                        placeholder="Path on this server to the frame PNG files",
+                        label="Input Path")
+                    output_path_text = gr.Text(max_lines=1,
+                        placeholder="Where to place the resized frames",
+                        label="Output Path")
+                    with gr.Row():
+                        new_width = gr.Number(value=None,
+                        label="New Width")
+                        new_height = gr.Number(value=None,
+                        label="New Height")
+                    with gr.Row():
+                        scale_type = gr.Radio(value="lanczos",
+                            choices=["area", "cubic", "lanczos", "linear", "nearest"],
+                            label="Scaling Type")
+            gr.Markdown("*Progress can be tracked in the console*")
+            resize_button = gr.Button("Resize Frames " + SimpleIcons.SLOW_SYMBOL,
+                                       variant="primary")
+            # with gr.Accordion(SimpleIcons.TIPS_SYMBOL + " Guide", open=False):
+            #     WebuiTips.upscale_frames.render()
+        resize_button.click(self.resize_frames,
+            inputs=[input_path_text, output_path_text, new_width, new_height, scale_type])
+
+    def resize_frames(self,
+                       input_path : str,
+                       output_path : str,
+                       new_width : int,
+                       new_height : int,
+                       scale_type : str):
+        """Resize Frames button handler"""
+        if input_path and output_path:
+            self.log(f"initializing ResizeFrames with input_path={input_path} output_path={output_path} new_width={new_width} new_height={new_height} scaling_type={scale_type}")
+            _ResizeFrames(input_path,
+                         output_path,
+                         int(new_width),
+                         int(new_height),
+                         scale_type,
+                         self.log).resize()

--- a/webui_tips.py
+++ b/webui_tips.py
@@ -53,3 +53,4 @@ class WebuiTips:
     upscale_frames = gr.Markdown(load_markdown(tips_path, "upscale_frames"))
     simplify_png_files = gr.Markdown(load_markdown(tips_path, "simplify_png_files"))
     deduplicate_frames = gr.Markdown(load_markdown(tips_path, "deduplicate_frames"))
+    resize_frames = gr.Markdown(load_markdown(tips_path, "resize_frames"))

--- a/webui_utils/simple_icons.py
+++ b/webui_utils/simple_icons.py
@@ -24,6 +24,7 @@ class SimpleIcons:
     THREE = "3️⃣"
     TOOLBOX = "🧰"
     TWO = "2️⃣"
+    UP_DOWN_ARROW = "↕️"
     WRENCH = "🔧"
 
     BELL = "🔔"
@@ -54,6 +55,7 @@ class SimpleIcons:
     OK_HAND = "👌"
     FINGERS_CROSSED = "🤞"
     FIST = "🤜"
+    PINCHING_HAND = "🤏"
     THUMBS_DOWN = "👎"
     THUMBS_UP = "👍"
 
@@ -137,6 +139,7 @@ class SimpleIcons:
         THREE,
         TWO,
         TWO_HEARTS,
+        PINCHING_HAND,
         WARNING,
         WATCH,
         WRENCH,

--- a/webui_utils/test_simple_icons.py
+++ b/webui_utils/test_simple_icons.py
@@ -5,7 +5,7 @@ from .simple_icons import *
 
 GOOD_EXAMPLES = [
     (SimpleIcons.SYMBOLS, 5, 6),
-    (SimpleIcons.APP_ICONS, 35, 51)]
+    (SimpleIcons.APP_ICONS, 36, 52)]
 
 def test_SimpleIcons():
     for example, expected_items, expected_len in GOOD_EXAMPLES:


### PR DESCRIPTION
New _Resize Frames_ tab under the _Tools, File Conversion_ tab 

![Screenshot 2023-06-15 205706](https://github.com/jhogsett/EMA-VFI-WebUI/assets/825994/da9d938d-2f85-4e42-a766-0c16c67b8adc)


- Accepts inputs
    - input path - a directory with a set of PNG frame files to be resized
    - output path - a directory to place the resizes frames
    - new width and height - dimensions for the new frames
    - scaling types - `OpenCV Resize` interpolation types _(area, cubic, linear, lanczos, nearest)_

- Useful for
    - Fast pre-AI-quality frame resizing
    - Fixing/changing aspect ratio
    - Reducing blur ahead of using AI frame upscaling
 
- Note
    - Has an accompanying command-line script `resize_frames.py`