### PR TITLE
Deduplication - add threshold tuning feature

### DIFF
--- a/deduplicate_frames.py
+++ b/deduplicate_frames.py
@@ -136,7 +136,7 @@ class DeduplicateFrames:
                                                                                 self.threshold,
                                                                                 self.max_dupes)
             self.log("mpdecimate data received from 'get_duplicate_frames:")
-            self.log(mpdecimate_log)
+            self.log("/r/n".join(mpdecimate_log))
             self.log(f"beginning processing of {len(dupe_groups)} duplicate groups for deletion")
 
             # remove duplicates from full list of frame files

--- a/guide/deduplicate_frames.md
+++ b/guide/deduplicate_frames.md
@@ -19,8 +19,8 @@
 1. The _Details_ box shows the result of the operation, or any errors encountered
 
 ## Important
+- **Note!** If the frames in the output path are to be fed to FFmpeg or video editing software, use _Resequence Files_ to remove gaps in the numbering sequence
 - `ffmpeg.exe` must be available on the system path
-- _Resequence Files_ can be used to renumber a PNG sequence
 - The _Video Preview_ tab on the _Video Blender_ page can be used to watch a preview video of a set of PNG files
 - The values for the _Threshold_ slider can be changed in the `config.yaml` file section `deduplicate_settings`
 


### PR DESCRIPTION
#### Added a new feature _Tuning_ to the  `deduplicate_frames.py`  command-line script 
- Runs a duplicate check repeatedly, with ever-increasing threshold values, keeping stats on the found duplicates
- Can be used to find the best threshold value for detecting _all_ duplicate frames, and _only_ duplicate frames
- Outputs to the console or to a CSV file
- Data is usable in spreadsheet programs for visualizing results

### Usage

#### Basic
```
> python deduplicate_frames.py --input_path "your-input-path" --disposition tuning
```

#### Options

* `--outout_path` .csv file path (optional, default: displays to console)
* `--tune_min` minimum threshold for tuning (default 0)
* `--tune_max` maximum threshold for tuning (default 25000)
* `--tune_step` threshold step for tuning (default 100)
* `--max_dupes` maximum allowed consecutive duplicate frames (default 0 - no limit)

### Example
- Video has some duplicates, but wasn't seen to have move than two duplicate frames in a row, so `2` seems like a good max dupes per group value for deduplication
- Max dupes per group jumps to `3` past about `1400` so < `1400` seems a good threshold value for deduplication

![Screenshot 2023-06-18 125642](https://github.com/jhogsett/EMA-VFI-WebUI/assets/825994/06b7af77-195b-4c6a-bd20-1642976c0203)
