### PR TITLE
clarify

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -7,7 +7,7 @@ blender_settings:
   frame_fixer_depth: 10
   frame_rate: 30
   gif_duration: 1000
-  max_frame_rate: 240
+  max_frame_rate: 1000
   projects_file: "video_blender_projects.csv"
   skip_frames: 100
 directories:
@@ -63,7 +63,7 @@ gif_to_mp4_settings:
   - "webm"
   - "wmv"
   maximum_crf: 28
-  max_frame_rate: 240
+  max_frame_rate: 1000
   minimum_crf: 17
   resampling_precision: 10
   use_tiling: False
@@ -77,7 +77,7 @@ logviewer_settings:
   max_lines: 25
 mp4_to_png_settings:
   frame_rate: 30
-  max_frame_rate: 240
+  max_frame_rate: 1000
 restoration_settings:
   create_gif: True
   create_zip: True
@@ -89,11 +89,11 @@ restoration_settings:
   max_precision: 60
 png_to_gif_settings:
   frame_rate: 30
-  max_frame_rate: 240
+  max_frame_rate: 1000
 png_to_mp4_settings:
   default_crf: 23
   frame_rate: 30
-  max_frame_rate: 240
+  max_frame_rate: 1000
   maximum_crf: 28
   minimum_crf: 17
 search_settings:

--- a/tabs/resize_frames_ui.py
+++ b/tabs/resize_frames_ui.py
@@ -48,7 +48,7 @@ class ResizeFrames(TabBase):
                         crop_type = gr.Radio(value="none",
                             choices=["crop", "none"],
                             label="Cropping Type",
-                            info = "Choose 'crop' to crop the resized image, 'none' for no cropping")
+            info = "If cropping, Scale Width and Scale Height must be set to the pre-cropped size")
                     with gr.Column():
                         with gr.Row():
                             crop_width = gr.Number(value=-1, label="Crop Width",

--- a/tabs/video_details_ui.py
+++ b/tabs/video_details_ui.py
@@ -33,7 +33,7 @@ class VideoDetails(TabBase):
                 duration = gr.Text(max_lines=1, label="Duration")
                 frame_count = gr.Text(max_lines=1, label="Frame Count")
                 file_size = gr.Text(max_lines=1, label="File Size")
-            count_frames = gr.Checkbox(value=True, label="Count Frames (Slower)",
+            count_frames = gr.Checkbox(value=False, label="Count Frames (Slower)",
                 info="Scans file counting frames; required for media without frame count metadata")
             report_button = gr.Button("Get Details", variant="primary")
             output_text = gr.Textbox(label="Details", interactive=False)


### PR DESCRIPTION
- Bump up default max FPS for sliders from 240 to 1000 on `config.yaml`
- _Count Frames_ should be unchecked by default (has to read the entire file)
- Cropping requires that `split_width` and `split_height` be set, even if not resizing (add a message to clarify)