### PR TITLE
New command line script: split directory of files

### DIFF
--- a/split_frames.py
+++ b/split_frames.py
@@ -1,0 +1,187 @@
+"""Split Frames Feature Core Code"""
+import os
+import glob
+import argparse
+import math
+import shutil
+from typing import Callable
+from webui_utils.simple_log import SimpleLog
+from webui_utils.file_utils import create_directory, is_safe_path, split_filepath
+from webui_utils.mtqdm import Mtqdm
+
+def main():
+    """Use the Split Frames feature from the command line"""
+    parser = argparse.ArgumentParser(description='Split a directory of PNG frame files')
+    parser.add_argument("--input_path", default=None, type=str,
+        help="Input path to PNG frame files to split")
+    parser.add_argument("--output_path", default=None, type=str,
+        help="Base path for frame group directories")
+    parser.add_argument("--file_ext", default="png", type=str,
+                        help="File extension, default: 'png'; others such as 'gif' or '*' work")
+    parser.add_argument("--type", default="precise", type=str,
+        help="Split type 'precise' (default) or 'interpolation'")
+    parser.add_argument("--num_groups", default=10, type=int, help="Number of new file groups")
+    parser.add_argument("--action", default="copy", type=str,
+        help="Files action 'copy' (default), 'move', 'dryrun'")
+    parser.add_argument("--verbose", dest="verbose", default=False, action="store_true",
+        help="Show extra details")
+    args = parser.parse_args()
+
+    log = SimpleLog(args.verbose)
+    SplitFrames(args.input_path,
+                args.output_path,
+                args.file_ext,
+                args.type,
+                args.num_groups,
+                args.action,
+                log.log).split()
+
+class SplitFrames:
+    """Encapsulate logic for Split Frames feature"""
+    def __init__(self,
+                input_path : str,
+                output_path : str,
+                file_ext : str,
+                type : str,
+                num_groups : int,
+                action : str,
+                log_fn : Callable | None):
+        self.input_path = input_path
+        self.output_path = output_path
+        self.file_ext = file_ext
+        self.type = type
+        self.num_groups = num_groups
+        self.action = action
+        self.log_fn = log_fn
+        valid_types = ["precise", "interpolation"]
+        valid_actions = ["copy", "move", "dryrun"]
+
+        if not is_safe_path(input_path):
+            raise ValueError("'input_path' must be a legal path")
+        if not is_safe_path(output_path):
+            raise ValueError("'output_path' must be a legal path")
+        if num_groups < 1:
+            raise ValueError("'num_groups' must be >= 1")
+        if not type in valid_types:
+            raise ValueError(f"'type' must be one of {', '.join([t for t in valid_types])}")
+        if not action in valid_actions:
+            raise ValueError(f"'action' must be one of {', '.join([t for t in valid_actions])}")
+
+    def split(self) -> None:
+        """Invoke the Split Frames feature"""
+        files = sorted(glob.glob(os.path.join(self.input_path, f"*.{self.file_ext}")))
+        num_files = len(files)
+        if self.num_groups > num_files:
+            raise ValueError(f"'num_groups' must be <= source file count {num_files}")
+        num_width = len(str(num_files))
+        add_interpolation_frames = self.type == "interpolation"
+        dry_run = self.action == "dryrun"
+
+        files_per_group = int(math.ceil(num_files / self.num_groups))
+        self.log(f"Splitting files to {self.num_groups} groups of {files_per_group} files")
+
+        if dry_run:
+            print(f"[Dry Run] Creating base output path {self.output_path}")
+        else:
+            self.log(f"Creating base output path {self.output_path}")
+            create_directory(self.output_path)
+
+        file_groups = [[] for n in range(self.num_groups)]
+        for group in range(self.num_groups):
+            self.log(f"Collecting filenames for group {group}")
+            start_index = group * files_per_group
+            for index in range(files_per_group):
+                file_index = start_index + index
+                if file_index < num_files:
+                    file_groups[group].append(files[file_index])
+
+            if add_interpolation_frames:
+                self.log("Adding surrounding frames for interpolation")
+                prev_group = group - 1
+                _prev_start_index = prev_group * files_per_group
+                prev_last_index = _prev_start_index + files_per_group-1
+                next_group = group + 1
+                next_start_index = next_group * files_per_group
+
+                if _prev_start_index >= 0:
+                    prev_last_file = files[prev_last_index]
+                else:
+                    prev_last_file = None
+                if next_start_index < num_files:
+                    next_start_file = files[next_start_index]
+                else:
+                    next_start_file = None
+                self.log(
+                f"Files for interpolation frames: prev '{prev_last_file}' next '{next_start_file}'")
+
+                if group == 0:
+                    self.log("Adding after frame")
+                    file_groups[group] = file_groups[group] + [next_start_file]
+                elif group == self.num_groups-1:
+                    self.log("Adding before frame")
+                    file_groups[group] = [prev_last_file] + file_groups[group]
+                else:
+                    self.log("Adding before and after frames")
+                    file_groups[group] = [prev_last_file] + file_groups[group] + [next_start_file]
+
+        with Mtqdm().open_bar(total=self.num_groups, desc="Group") as group_bar:
+            for group in range(self.num_groups):
+                group_files = file_groups[group]
+                num_group_files = len(group_files)
+                first_index = group * files_per_group
+                last_index = ((group+1) * files_per_group) - 1
+                if last_index > num_files:
+                    last_index = num_files-1
+
+                group_name_first_index = first_index
+                group_name_last_index = last_index
+                if add_interpolation_frames:
+                    if group == 0:
+                        group_name_last_index += 1
+                    elif group == self.num_groups-1:
+                        group_name_first_index -= 1
+                    else:
+                        group_name_first_index -= 1
+                        group_name_last_index += 1
+                group_name = f"{str(group_name_first_index).zfill(num_width)}" +\
+                    f"-{str(group_name_last_index).zfill(num_width)}"
+                group_path = os.path.join(self.output_path, group_name)
+
+                if dry_run:
+                    self.log(f"[Dry Run] Creating directory {group_path}")
+                else:
+                    self.log(f"Creating directory {group_path}")
+                    create_directory(group_path)
+
+                desc = "Copying" if self.action == "copy" else "Moving"
+                with Mtqdm().open_bar(total=num_group_files, desc=desc) as file_bar:
+                    for file in group_files:
+                        from_filepath = file
+                        _, filename, ext = split_filepath(file)
+                        to_filepath = os.path.join(group_path, filename + ext)
+                        if dry_run:
+                            print(f"[Dry Run] Copying {from_filepath} to {to_filepath}")
+                        else:
+                            self.log(f"Copying {from_filepath} to {to_filepath}")
+                            shutil.copy(from_filepath, to_filepath)
+                        Mtqdm().update_bar(file_bar)
+                Mtqdm().update_bar(group_bar)
+
+        if self.action != "copy":
+            with Mtqdm().open_bar(total=num_files, desc="Deleting") as bar:
+                for file in files:
+                    if os.path.exists(file):
+                        if dry_run:
+                            print(f"[Dry Run] Deleting {file}")
+                        else:
+                            self.log(f"Deleting {file}")
+                            os.remove(file)
+                    Mtqdm().update_bar(bar)
+
+    def log(self, message : str) -> None:
+        """Logging"""
+        if self.log_fn:
+            self.log_fn(message)
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
New command line script `split_frames.py` for splitting large groups of files into smaller directory groups
- Helpful for processing a large video in smaller chunks
- Helpful for transporting a large set of files (reduced file system overhead)

Usage
```
> python split_frames.py --input_path "my path" --output_path "my path/grouped" 
```

| Command-Line Options| &nbsp;  | Default |
| :- | :- | :- |
| `input_path` path | path to directory of files to split | |
| `output_path` path | path to base directory new split directories | |
| `file_ext` ext | type of files to move (any extension or `*`) | `png` |
| `type` type | type of split ('precise', 'interpolation`) | `precise` |
| `num_groups` num | number of new split directories | `10` |
| `action` action | action to take ('copy', 'move', 'dryrun') | `dryrun` |
| `verbose` | enable display of internal details | not enbled |

| Split Types | &nbsp; |
| :- | :- |
| `precise` | copy only the number of files necessary to split |
| `interpolation` | include outer frames from neighboring groups for seamless interpolation across groups |

| Action Types | &nbsp; |
| :- | :- |
| `move` | delete the original files after successfully copying all files |
| `dryrun` | make no changes; print the actions that would be taken for a `move` action |
