### PR TITLE
Merge script to go along with split script

### DIFF
--- a/create_ui.py
+++ b/create_ui.py
@@ -29,6 +29,8 @@ from tabs.dedupe_report_ui import DuplicateFramesReport
 from tabs.dedupe_autofill_ui import AutofillFrames
 from tabs.dedupe_tuning_ui import DuplicateTuning
 from tabs.video_details_ui import VideoDetails
+from tabs.split_frames_ui import SplitFrames
+from tabs.merge_frames_ui import MergeFrames
 
 def create_ui(config : SimpleConfig,
               engine : InterpolateEngine,
@@ -69,6 +71,12 @@ def create_ui(config : SimpleConfig,
                 SimplifyPngFiles(config, engine, log.log).render_tab()
                 ResizeFrames(config, engine, log.log).render_tab()
             ResequenceFiles(config, engine, log.log).render_tab()
+            with gr.Tab("Split & Merge Frames"):
+                gr.HTML(SimpleIcons.HAMMER_WRENCH +
+                    "Split & Merge large PNG framesets and process in groups",
+                    elem_id="tabheading")
+                SplitFrames(config, engine, log.log).render_tab()
+                MergeFrames(config, engine, log.log).render_tab()
             ChangeFPS(config, engine, log.log).render_tab()
             UpscaleFrames(config, engine, log.log).render_tab()
             VideoDetails(config, engine, log.log).render_tab()

--- a/merge_frames.py
+++ b/merge_frames.py
@@ -97,7 +97,6 @@ class MergeFrames:
         else:
             self.merge_precise(num_width, group_names)
 
-
     def merge_precise(self, num_width, group_names):
         with Mtqdm().open_bar(total=len(group_names), desc="Groups") as group_bar:
             for group_name in group_names:
@@ -133,7 +132,6 @@ class MergeFrames:
                         self.log(f"deleting group {group_path}")
                         shutil.rmtree(group_path)
                     Mtqdm().update_bar(bar)
-
 
     def merge_resynthesis(self, first_index, last_index, num_width, group_names):
         group_size = last_index - first_index
@@ -290,56 +288,86 @@ class MergeFrames:
                 Mtqdm().update_bar(group_bar)
 
 
-
-            # EXPECTED FILES = GROUP SIZE - 1
-
-        # go through each group, renumbering files
-        # FILE COUNT = count of files in group
-
-        # - for each group, the count of files must match EXPECTED FILES
-        #   - except the first group, where the count of files should be EXPECTED FILES - 1
-
-            #   - except the last group, where the count of files should match THAT group size - 1
-                # same group size and expected files calculation just on last group
-
-        # - the renumbering START INDEX is FIRST INDEX + 1
-        # - renumber the files starting START INDEX using NUM WIDTH padding
-
-            # - copy all group files to the output directory
-
-        # - each file should not already exist at destination
-        pass
-
-
     def merge_inflation(self, first_index, last_index, num_width, group_names):
+        group_size = last_index - first_index
         if self.action == "combine":
-            self.merge_inflation_combine(first_index, last_index, num_width)
+            self.merge_inflation_combine(first_index, last_index, num_width, group_size, group_names)
         else:
-            self.merge_inflation_revert(first_index, last_index, num_width)
+            self.merge_inflation_revert(first_index, last_index, num_width, group_size, group_names)
 
-    def merge_inflation_revert(self, first_index, last_index, num_width, group_names):
-            # GROUP SIZE = LAST INDEX - FIRST INDEX
+    def merge_inflation_revert(self, first_index, last_index, num_width, group_size, group_names):
+        expected_files = group_size + 1 # extra file is unneeded ending outer anchor
 
-        # FILE COUNT = count of files in group
+        with Mtqdm().open_bar(total=len(group_names), desc="Groups") as group_bar:
+            for group_index, group_name in enumerate(group_names):
+                group_expected_files = expected_files
 
-        # EXPECTED FILES = GROUP SIZE + 1
-        # - extra file is ending outer anchor frame and won't be copied
-        # go through each group, renumbering files
-        # FILE COUNT = count of files in group
-        # - for each group, the count of files must match EXPECTED FILES
-        #   - except the last group, where the count of files should match THAT group size + 1
-        #   - (GROUP SIZE * (LAST INDEX - FIRST INDEX)) + 1
-              # same group size and expected files calculation just on last group
+                first_index, last_index, _ = self.details_from_group_name(group_name)
 
-            # - the renumbering START INDEX is FIRST INDEX
+                if group_index == len(group_names)-1:
+                    # last group's expected files based on its own name
+                    group_expected_files = last_index - first_index + 1
 
-        # - renumber the files starting START INDEX using NUM WIDTH padding
-        # - copy all group files to the output directory EXCEPT THE LAST FILE
-        #   - except the last group - COPY ALL FILES
-        # - each file should not already exist at destination
-        pass
+                group_files = self.group_files(group_name)
+                if len(group_files) != group_expected_files:
+                    raise RuntimeError(
+                        f"expected {expected_files} files in {group_name} but found {len(group_files)}")
 
-    def merge_inflation_combine(self, first_index, last_index, num_width, group_names):
+                # renumber all present files according to the first, last indexes
+                # including files that will not be ulitmately copied back
+                group_path = self.group_path(group_name)
+                first_index, last_index, _ = self.details_from_group_name(group_name)
+                if self.dry_run:
+                    print(f"[Dry Run] Resequencing files in {group_path}")
+                else:
+                    self.log(f"Resequencing files in {group_path}")
+                    base_filename = "reverted-resynthesis-split"
+
+                    ResequenceFiles(group_path,
+                                    self.file_ext,
+                                    base_filename,
+                                    first_index, 1, 1, 0, num_width,
+                                    True,
+                                    self.log).resequence()
+
+                renamed_group_files = self.group_files(group_name)
+                with Mtqdm().open_bar(total=len(renamed_group_files), desc="Copying") as file_bar:
+                    for file_index, file in enumerate(renamed_group_files):
+                        if group_index < len(group_names)-1:
+                            # for all groups except last, copy all but the last file
+                            # it's anchor frame duplicated during splitting
+                            if file_index == len(renamed_group_files)-1:
+                                Mtqdm().update_bar(file_bar)
+                                continue
+
+                        _, filename, ext = split_filepath(file)
+                        to_filepath = os.path.join(self.output_path, filename + ext)
+                        if os.path.exists(to_filepath):
+                            raise RuntimeError(
+                                f"file {to_filepath} already exists in the output path")
+                        if self.dry_run:
+                            print(f"[Dry Run] copying {file} to {to_filepath}")
+                        else:
+                            self.log(f"copying {file} to {to_filepath}")
+                            shutil.copy(file, to_filepath)
+                        Mtqdm().update_bar(file_bar)
+
+                # restore the original filenames
+                self.log(f"Restoring original filenames in {group_path}")
+                with Mtqdm().open_bar(total=len(renamed_group_files),
+                                        desc="Copying") as bar:
+                    for index, file in enumerate(renamed_group_files):
+                        original_filename = group_files[index]
+                        if self.dry_run:
+                            print(
+                            f"[Dry Run] Restoring file '{file}' to '{original_filename}'")
+                        else:
+                            self.log(f"Restoring file '{file}' to '{original_filename}'")
+                            os.replace(file, original_filename)
+                        Mtqdm().update_bar(bar)
+                Mtqdm().update_bar(group_bar)
+
+    def merge_inflation_combine(self, first_index, last_index, num_width, group_size, group_names):
             # ORIG GROUP SIZE = LAST INDEX - FIRST INDEX
 
         # FILE COUNT = count of files in group

--- a/merge_frames.py
+++ b/merge_frames.py
@@ -1,0 +1,317 @@
+"""Merge Frames Feature Core Code"""
+import os
+import shutil
+import glob
+import argparse
+from typing import Callable
+from webui_utils.simple_log import SimpleLog
+from webui_utils.file_utils import create_directory, is_safe_path, split_filepath, get_directories
+from webui_utils.mtqdm import Mtqdm
+from resequence_files import ResequenceFiles
+
+def main():
+    """Use the Merge Frames feature from the command line"""
+    parser = argparse.ArgumentParser(description='Split a directory of PNG frame files')
+    parser.add_argument("--input_path", default=None, type=str,
+        help="Base path with frame group directories")
+    parser.add_argument("--output_path", default=None, type=str,
+        help="Output path for recombined files")
+    parser.add_argument("--file_ext", default="png", type=str,
+                        help="File extension, default: 'png'; any extension or '*'")
+    parser.add_argument("--type", default="precise", type=str,
+        help="Merge type 'precise' (default), 'resynthesis', 'inflation'")
+    parser.add_argument("--num_groups", default=-1, type=int,
+                        help="Number of file groups, -1 for auto-detect (default)")
+    parser.add_argument("--action", default="combine", type=str,
+        help="Files action 'combine' (default), 'revert'")
+    parser.add_argument("--dry_run", dest="dry_run", default=False, action="store_true",
+                        help="Show changes that will be made")
+    parser.add_argument("--verbose", dest="verbose", default=False, action="store_true",
+        help="Show extra details")
+    args = parser.parse_args()
+
+    log = SimpleLog(args.verbose)
+    MergeFrames(args.input_path,
+                args.output_path,
+                args.file_ext,
+                args.type,
+                args.num_groups,
+                args.action,
+                args.dry_run,
+                log.log).merge()
+
+class MergeFrames:
+    """Encapsulate logic for Merge Frames feature"""
+    def __init__(self,
+                input_path : str,
+                output_path : str,
+                file_ext : str,
+                type : str,
+                num_groups : int,
+                action : str,
+                dry_run : bool,
+                log_fn : Callable | None):
+        self.input_path = input_path
+        self.output_path = output_path
+        self.file_ext = file_ext
+        self.type = type
+        self.num_groups = num_groups
+        self.action = action
+        self.dry_run = dry_run
+        self.log_fn = log_fn
+        valid_types = ["precise", "resynthesis", "inflation"]
+        valid_actions = ["revert", "combine"]
+
+        if not is_safe_path(input_path):
+            raise ValueError("'input_path' must be a legal path")
+        if not is_safe_path(output_path):
+            raise ValueError("'output_path' must be a legal path")
+        if num_groups < -1 or num_groups == 0:
+            raise ValueError("'num_groups' must be > 0 or -1")
+        if not type in valid_types:
+            raise ValueError(f"'type' must be one of {', '.join([t for t in valid_types])}")
+        if not action in valid_actions:
+            raise ValueError(f"'action' must be one of {', '.join([t for t in valid_actions])}")
+
+    def merge(self) -> None:
+        """Invoke the Merge Frames feature"""
+        group_names = self.validate_input_path()
+        self.validate_group_names(group_names)
+
+        if self.dry_run:
+            print(f"[Dry Run] Creating output path {self.output_path}")
+        else:
+            self.log(f"Creating output path {self.output_path}")
+            create_directory(self.output_path)
+
+        first_group_name = group_names[0]
+        first_index, last_index, num_width = self.details_from_group_name(first_group_name)
+
+        if type == "resynthesis":
+            self.merge_resynthesis(first_index, last_index, num_width, group_names)
+        elif type == "inflation":
+            self.merge_inflation(first_index, last_index, num_width, group_names)
+        else:
+            self.merge_precise(num_width, group_names)
+
+    def group_path(self, group_name):
+        return os.path.join(self.input_path, group_name)
+
+    def group_files(self, group_name):
+        group_path = self.group_path(group_name)
+        return sorted(glob.glob(os.path.join(group_path, f"*.{self.file_ext}")))
+
+
+    def merge_precise(self, num_width, group_names):
+        with Mtqdm().open_bar(total=len(group_names), desc="Groups") as group_bar:
+            for group_name in group_names:
+                first_index, last_index, _ = self.details_from_group_name(group_name)
+                group_size = last_index - first_index + 1
+                expected_files = group_size
+                group_files = self.group_files(group_name)
+                if len(group_files) != expected_files:
+                    raise RuntimeError(
+                        f"expected {expected_files} files in {group_name} but found {len(group_files)}")
+
+                with Mtqdm().open_bar(total=len(group_files), desc="Copying") as file_bar:
+                    for file in group_files:
+                        _, filename, ext = split_filepath(file)
+                        to_filepath = os.path.join(self.output_path, filename + ext)
+                        if os.path.exists(to_filepath):
+                            raise RuntimeError(f"file {to_filepath} already exists in the output path")
+                        if self.dry_run:
+                            print(f"[Dry Run] copying {file} to {to_filepath}")
+                        else:
+                            self.log(f"copying {file} to {to_filepath}")
+                            shutil.copy(file, to_filepath)
+                        Mtqdm().update_bar(file_bar)
+                Mtqdm().update_bar(group_bar)
+
+        if self.action == "move":
+            with Mtqdm().open_bar(total=len(group_names), desc="Deleting Groups") as bar:
+                for group_name in group_names:
+                    group_path = self.group_path(group_name)
+                    if self.dry_run:
+                        print(f"[Dry Run] deleting group {group_path}")
+                    else:
+                        self.log(f"deleting group {group_path}")
+                        shutil.rmtree(group_path)
+                    Mtqdm().update_bar(bar)
+
+    def merge_precise_combine(self, num_width, group_names):
+        # go through each group, renumbering files
+
+        # FILE COUNT = count of files in group
+
+        # - for each group, the count of files must match EXPECTED FILES
+        # - the renumbering START INDEX is FIRST INDEX
+        # - renumber the files starting START INDEX using NUM WIDTH padding
+        # - copy all group files to the output directory
+        # - each file should not already exist at destination
+        pass
+
+
+                    # if self.dry_run:
+                    #     print(f"[Dry Run] Resequencing files in {group_path}")
+                    # else:
+                    #     self.log(f"Resequencing files in {group_path}")
+                    #     base_filename = f"{group_name}-{self.type}-split-frame"
+                    #     ResequenceFiles(group_path,
+                    #                     self.file_ext,
+                    #                     base_filename,
+                    #                     0, 1, 1, 0, num_width,
+                    #                     True,
+                    #                     self.log).resequence()
+
+    def merge_resynthesis(self, first_index, last_index, num_width, group_names):
+        group_size = last_index - first_index
+        if self.action == "combine":
+            self.merge_resynthesis_combine(first_index, last_index, num_width, group_size)
+        else:
+            self.merge_resynthesis_revert(first_index, last_index, num_width, group_size)
+
+    def merge_resynthesis_revert(self, first_index, last_index, num_width, group_size, group_names):
+            # EXPECTED FILES = GROUP SIZE + 2
+
+        # go through each group, renumbering files
+        # FILE COUNT = count of files in group
+
+        # - for each group, the count of files must match EXPECTED FILES
+        #   - except the first group, where the count of files should be EXPECTED FILES - 1
+        #   - except the last group, where the count of files should be EXPECTED FILES - 1
+
+        # - the renumbering START INDEX is FIRST INDEX + 1
+        # - renumber the files starting START INDEX using NUM WIDTH padding
+
+            # - copy all EXCEPT first and last group files to the output directory
+            #   - except first group, copy all but last file
+            #   - except last group, copy all but first file
+
+        # - each file should not already exist at destination
+        pass
+
+    def merge_resynthesis_combine(self, first_index, last_index, num_width, group_size, group_names):
+            # EXPECTED FILES = GROUP SIZE - 1
+
+        # go through each group, renumbering files
+        # FILE COUNT = count of files in group
+
+        # - for each group, the count of files must match EXPECTED FILES
+        #   - except the first group, where the count of files should be EXPECTED FILES - 1
+
+            #   - except the last group, where the count of files should match THAT group size - 1
+                # same group size and expected files calculation just on last group
+
+        # - the renumbering START INDEX is FIRST INDEX + 1
+        # - renumber the files starting START INDEX using NUM WIDTH padding
+
+            # - copy all group files to the output directory
+
+        # - each file should not already exist at destination
+        pass
+
+
+    def merge_inflation(self, first_index, last_index, num_width, group_names):
+        if self.action == "combine":
+            self.merge_inflation_combine(first_index, last_index, num_width)
+        else:
+            self.merge_inflation_revert(first_index, last_index, num_width)
+
+    def merge_inflation_revert(self, first_index, last_index, num_width, group_names):
+            # GROUP SIZE = LAST INDEX - FIRST INDEX
+
+        # FILE COUNT = count of files in group
+
+        # EXPECTED FILES = GROUP SIZE + 1
+        # - extra file is ending outer anchor frame and won't be copied
+        # go through each group, renumbering files
+        # FILE COUNT = count of files in group
+        # - for each group, the count of files must match EXPECTED FILES
+        #   - except the last group, where the count of files should match THAT group size + 1
+        #   - (GROUP SIZE * (LAST INDEX - FIRST INDEX)) + 1
+              # same group size and expected files calculation just on last group
+
+            # - the renumbering START INDEX is FIRST INDEX
+
+        # - renumber the files starting START INDEX using NUM WIDTH padding
+        # - copy all group files to the output directory EXCEPT THE LAST FILE
+        #   - except the last group - COPY ALL FILES
+        # - each file should not already exist at destination
+        pass
+
+    def merge_inflation_combine(self, first_index, last_index, num_width, group_names):
+            # ORIG GROUP SIZE = LAST INDEX - FIRST INDEX
+
+        # FILE COUNT = count of files in group
+
+            # DETECTED INFLATION = FILE COUNT / ORIG GROUP SIZE
+            # DETECTED INFLATION must be an integer
+            # GROUP SIZE = DETECTED INFLATION * ORIG GROUP SIZE
+
+        # EXPECTED FILES = GROUP SIZE + 1
+        # - extra file is ending outer anchor frame and won't be copied
+        # go through each group, renumbering files
+        # FILE COUNT = count of files in group
+        # - for each group, the count of files must match EXPECTED FILES
+        #   - except the last group, where the count of files should match THAT group size + 1
+        #   - (GROUP SIZE * (LAST INDEX - FIRST INDEX)) + 1
+              # same group size and expected files calculation just on last group
+
+            # - the renumbering START INDEX is FIRST INDEX * DETECTED INFLATION
+
+        # - renumber the files starting START INDEX using NUM WIDTH padding
+        # - copy all group files to the output directory EXCEPT THE LAST FILE
+        #   - except the last group - COPY ALL FILES
+        # - each file should not already exist at destination
+        pass
+
+
+
+
+
+
+
+
+
+    def validate_input_path(self):
+        """returns the list of group names"""
+        if not os.path.exists(self.input_path):
+            raise ValueError("'input_path' must be the path of an existing directory")
+
+        group_names = get_directories(self.input_path)
+        if len(group_names) < 1:
+            raise ValueError(f"no folders founder in directory {self.input_path}")
+
+        if self.num_groups == -1:
+            self.num_groups = len(group_names)
+        else:
+            if len(group_names) != self.num_groups:
+                raise ValueError(
+                    f"'num_groups' should match count of directories found at {self.input_path}")
+        return group_names
+
+    def validate_group_names(self, group_names):
+            try:
+                for name in group_names:
+                    _, _, _ = self.details_from_group_name(name)
+            except RuntimeError as error:
+                raise RuntimeError(f"one or more group directory namaes is not valid: {error}")
+
+    def details_from_group_name(self, group_name : str):
+        indexes = group_name.split("-")
+        if len(indexes) != 2:
+            raise RuntimeError(f"group name '{group_name}' cannot be parsed into indexes")
+        first_index = int(indexes[0])
+        last_index = int(indexes[1])
+        num_width = len(str(first_index))
+        if num_width < 1:
+            raise RuntimeError(f"group name '{group_name}' cannot be parsed into index fill width")
+        return first_index, last_index, num_width
+
+    def log(self, message : str) -> None:
+        """Logging"""
+        if self.log_fn:
+            self.log_fn(message)
+
+if __name__ == '__main__':
+    main()

--- a/merge_frames.py
+++ b/merge_frames.py
@@ -153,7 +153,7 @@ class MergeFrames:
                 group_files = self.group_files(group_name)
                 if len(group_files) != group_expected_files:
                     raise RuntimeError(
-                        f"expected {expected_files} files in {group_name} but found {len(group_files)}")
+                        f"expected {group_expected_files} files in {group_name} but found {len(group_files)}")
 
                 # renumber all present files according to the first, last indexes
                 # including files that will not be ulitmately copied back
@@ -235,7 +235,7 @@ class MergeFrames:
                 group_files = self.group_files(group_name)
                 if len(group_files) != group_expected_files:
                     raise RuntimeError(
-                        f"expected {expected_files} files in {group_name} but found {len(group_files)}")
+                        f"expected {group_expected_files} files in {group_name} but found {len(group_files)}")
 
                 # renumber all present files according to the first, last indexes
                 # including files that will not be ulitmately copied back
@@ -287,7 +287,6 @@ class MergeFrames:
                         Mtqdm().update_bar(bar)
                 Mtqdm().update_bar(group_bar)
 
-
     def merge_inflation(self, first_index, last_index, num_width, group_names):
         group_size = last_index - first_index
         if self.action == "combine":
@@ -311,7 +310,7 @@ class MergeFrames:
                 group_files = self.group_files(group_name)
                 if len(group_files) != group_expected_files:
                     raise RuntimeError(
-                        f"expected {expected_files} files in {group_name} but found {len(group_files)}")
+                        f"expected {group_expected_files} files in {group_name} but found {len(group_files)}")
 
                 # renumber all present files according to the first, last indexes
                 # including files that will not be ulitmately copied back
@@ -368,35 +367,92 @@ class MergeFrames:
                 Mtqdm().update_bar(group_bar)
 
     def merge_inflation_combine(self, first_index, last_index, num_width, group_size, group_names):
-            # ORIG GROUP SIZE = LAST INDEX - FIRST INDEX
+        first_group_files = self.group_files(group_names[0])
+        file_count = len(first_group_files)
 
-        # FILE COUNT = count of files in group
+        # after inflation there will be more files than accounted for in group name
+        # there's a final keyframe that should not be accounted for in the detection
+        detection_file_count = file_count - 1
+        detected_inflation = detection_file_count / group_size
+        # the detected inflation must be an even multiple of the computed group size
+        if detection_file_count % group_size:
+            raise RuntimeError(f"inflated file count {detection_file_count} must be" +\
+                                f" a multiple of group size {group_size}")
+        inflated_group_size = int(group_size * detected_inflation)
+        expected_files = inflated_group_size + 1 # extra file is uneeded keyframe copied during inflation
 
-            # DETECTED INFLATION = FILE COUNT / ORIG GROUP SIZE
-            # DETECTED INFLATION must be an integer
-            # GROUP SIZE = DETECTED INFLATION * ORIG GROUP SIZE
+        with Mtqdm().open_bar(total=len(group_names), desc="Groups") as group_bar:
+            for group_index, group_name in enumerate(group_names):
+                group_expected_files = expected_files
 
-        # EXPECTED FILES = GROUP SIZE + 1
-        # - extra file is ending outer anchor frame and won't be copied
-        # go through each group, renumbering files
-        # FILE COUNT = count of files in group
-        # - for each group, the count of files must match EXPECTED FILES
-        #   - except the last group, where the count of files should match THAT group size + 1
-        #   - (GROUP SIZE * (LAST INDEX - FIRST INDEX)) + 1
-              # same group size and expected files calculation just on last group
+                first_index, last_index, _ = self.details_from_group_name(group_name)
 
-            # - the renumbering START INDEX is FIRST INDEX * DETECTED INFLATION
+                if group_index == len(group_names)-1:
+                    # last group's expected files based on its own name
+                    group_expected_files = (last_index - first_index) * detected_inflation + 1
 
-        # - renumber the files starting START INDEX using NUM WIDTH padding
-        # - copy all group files to the output directory EXCEPT THE LAST FILE
-        #   - except the last group - COPY ALL FILES
-        # - each file should not already exist at destination
-        pass
+                group_files = self.group_files(group_name)
+                if len(group_files) != group_expected_files:
+                    raise RuntimeError(
+            f"expected {group_expected_files} files in {group_name} but found {len(group_files)}")
 
+                # renumber all present files according to the first, last indexes
+                # including files that will not be ulitmately copied back
+                group_path = self.group_path(group_name)
+                first_index, last_index, _ = self.details_from_group_name(group_name)
 
+                # take inflated frame counts into consideration in index used for renumbering
+                first_index = int(first_index * detected_inflation)
 
+                if self.dry_run:
+                    print(f"[Dry Run] Resequencing files in {group_path}")
+                else:
+                    self.log(f"Resequencing files in {group_path}")
+                    base_filename = "reverted-resynthesis-split"
 
+                    ResequenceFiles(group_path,
+                                    self.file_ext,
+                                    base_filename,
+                                    first_index, 1, 1, 0, num_width,
+                                    True,
+                                    self.log).resequence()
 
+                renamed_group_files = self.group_files(group_name)
+                with Mtqdm().open_bar(total=len(renamed_group_files), desc="Copying") as file_bar:
+                    for file_index, file in enumerate(renamed_group_files):
+                        if group_index < len(group_names)-1:
+                            # for all groups except last, copy all but the last file
+                            # it's anchor frame duplicated during splitting
+                            if file_index == len(renamed_group_files)-1:
+                                Mtqdm().update_bar(file_bar)
+                                continue
+
+                        _, filename, ext = split_filepath(file)
+                        to_filepath = os.path.join(self.output_path, filename + ext)
+                        if os.path.exists(to_filepath):
+                            raise RuntimeError(
+                                f"file {to_filepath} already exists in the output path")
+                        if self.dry_run:
+                            print(f"[Dry Run] copying {file} to {to_filepath}")
+                        else:
+                            self.log(f"copying {file} to {to_filepath}")
+                            shutil.copy(file, to_filepath)
+                        Mtqdm().update_bar(file_bar)
+
+                # restore the original filenames
+                self.log(f"Restoring original filenames in {group_path}")
+                with Mtqdm().open_bar(total=len(renamed_group_files),
+                                        desc="Copying") as bar:
+                    for index, file in enumerate(renamed_group_files):
+                        original_filename = group_files[index]
+                        if self.dry_run:
+                            print(
+                            f"[Dry Run] Restoring file '{file}' to '{original_filename}'")
+                        else:
+                            self.log(f"Restoring file '{file}' to '{original_filename}'")
+                            os.replace(file, original_filename)
+                        Mtqdm().update_bar(bar)
+                Mtqdm().update_bar(group_bar)
 
 
 

--- a/split_frames.py
+++ b/split_frames.py
@@ -146,7 +146,7 @@ class SplitFrames:
                     self.log("Adding after anchor frame")
                     file_groups[group] = file_groups[group] + [next_start_file]
 
-        with Mtqdm().open_bar(total=self.num_groups, desc="Group") as group_bar:
+        with Mtqdm().open_bar(total=self.num_groups, desc="Groups") as group_bar:
             for group in range(self.num_groups):
                 group_files = file_groups[group]
                 num_group_files = len(group_files)

--- a/split_frames.py
+++ b/split_frames.py
@@ -8,6 +8,7 @@ from typing import Callable
 from webui_utils.simple_log import SimpleLog
 from webui_utils.file_utils import create_directory, is_safe_path, split_filepath
 from webui_utils.mtqdm import Mtqdm
+from resequence_files import ResequenceFiles
 
 def main():
     """Use the Split Frames feature from the command line"""
@@ -17,12 +18,14 @@ def main():
     parser.add_argument("--output_path", default=None, type=str,
         help="Base path for frame group directories")
     parser.add_argument("--file_ext", default="png", type=str,
-                        help="File extension, default: 'png'; others such as 'gif' or '*' work")
+                        help="File extension, default: 'png'; any extensiion or or '*'")
     parser.add_argument("--type", default="precise", type=str,
-        help="Split type 'precise' (default) or 'interpolation'")
+        help="Split type 'precise' (default), 'resynthesis', 'inflation'")
     parser.add_argument("--num_groups", default=10, type=int, help="Number of new file groups")
-    parser.add_argument("--action", default="dryrun", type=str,
-        help="Files action 'copy' (default), 'move', 'dryrun'")
+    parser.add_argument("--action", default="copy", type=str,
+        help="Files action 'copy' (default), 'move'")
+    parser.add_argument("--dry_run", dest="dry_run", default=False, action="store_true",
+                        help="Show changes that will be made")
     parser.add_argument("--verbose", dest="verbose", default=False, action="store_true",
         help="Show extra details")
     args = parser.parse_args()
@@ -34,6 +37,7 @@ def main():
                 args.type,
                 args.num_groups,
                 args.action,
+                args.dry_run,
                 log.log).split()
 
 class SplitFrames:
@@ -45,6 +49,7 @@ class SplitFrames:
                 type : str,
                 num_groups : int,
                 action : str,
+                dry_run : bool,
                 log_fn : Callable | None):
         self.input_path = input_path
         self.output_path = output_path
@@ -52,9 +57,10 @@ class SplitFrames:
         self.type = type
         self.num_groups = num_groups
         self.action = action
+        self.dry_run = dry_run
         self.log_fn = log_fn
-        valid_types = ["precise", "interpolation"]
-        valid_actions = ["copy", "move", "dryrun"]
+        valid_types = ["precise", "resynthesis", "inflation"]
+        valid_actions = ["copy", "move"]
 
         if not is_safe_path(input_path):
             raise ValueError("'input_path' must be a legal path")
@@ -74,13 +80,13 @@ class SplitFrames:
         if self.num_groups > num_files:
             raise ValueError(f"'num_groups' must be <= source file count {num_files}")
         num_width = len(str(num_files))
-        add_interpolation_frames = self.type == "interpolation"
-        dry_run = self.action == "dryrun"
+        add_resynthesis_frames = self.type == "resynthesis"
+        add_inflation_frame = self.type == "inflation"
 
         files_per_group = int(math.ceil(num_files / self.num_groups))
         self.log(f"Splitting files to {self.num_groups} groups of {files_per_group} files")
 
-        if dry_run:
+        if self.dry_run:
             print(f"[Dry Run] Creating base output path {self.output_path}")
         else:
             self.log(f"Creating base output path {self.output_path}")
@@ -95,8 +101,8 @@ class SplitFrames:
                 if file_index < num_files:
                     file_groups[group].append(files[file_index])
 
-            if add_interpolation_frames:
-                self.log("Adding surrounding frames for interpolation")
+            if add_resynthesis_frames:
+                self.log("Adding surrounding anchor frames for resynthesis")
                 prev_group = group - 1
                 _prev_start_index = prev_group * files_per_group
                 prev_last_index = _prev_start_index + files_per_group-1
@@ -112,17 +118,33 @@ class SplitFrames:
                 else:
                     next_start_file = None
                 self.log(
-                f"Files for interpolation frames: prev '{prev_last_file}' next '{next_start_file}'")
+        f"Anchor files for resynthesis frames: prev '{prev_last_file}' next '{next_start_file}'")
 
                 if group == 0:
-                    self.log("Adding after frame")
+                    self.log("Adding after anchor frame")
                     file_groups[group] = file_groups[group] + [next_start_file]
                 elif group == self.num_groups-1:
-                    self.log("Adding before frame")
+                    self.log("Adding before anchor frame")
                     file_groups[group] = [prev_last_file] + file_groups[group]
                 else:
-                    self.log("Adding before and after frames")
+                    self.log("Adding before and after anchor frames")
                     file_groups[group] = [prev_last_file] + file_groups[group] + [next_start_file]
+
+            elif add_inflation_frame:
+                self.log("Adding ending anchor frame for inflation")
+                next_group = group + 1
+                next_start_index = next_group * files_per_group
+
+                if next_start_index < num_files:
+                    next_start_file = files[next_start_index]
+                else:
+                    next_start_file = None
+                self.log(
+                f"Anchor File for inflation frames: next '{next_start_file}'")
+
+                if group < self.num_groups-1:
+                    self.log("Adding after anchor frame")
+                    file_groups[group] = file_groups[group] + [next_start_file]
 
         with Mtqdm().open_bar(total=self.num_groups, desc="Group") as group_bar:
             for group in range(self.num_groups):
@@ -135,7 +157,8 @@ class SplitFrames:
 
                 group_name_first_index = first_index
                 group_name_last_index = last_index
-                if add_interpolation_frames:
+
+                if add_resynthesis_frames:
                     if group == 0:
                         group_name_last_index += 1
                     elif group == self.num_groups-1:
@@ -143,11 +166,15 @@ class SplitFrames:
                     else:
                         group_name_first_index -= 1
                         group_name_last_index += 1
+                elif add_inflation_frame:
+                    if group < self.num_groups-1:
+                        group_name_last_index += 1
+
                 group_name = f"{str(group_name_first_index).zfill(num_width)}" +\
                     f"-{str(group_name_last_index).zfill(num_width)}"
                 group_path = os.path.join(self.output_path, group_name)
 
-                if dry_run:
+                if self.dry_run:
                     self.log(f"[Dry Run] Creating directory {group_path}")
                 else:
                     self.log(f"Creating directory {group_path}")
@@ -159,7 +186,7 @@ class SplitFrames:
                         from_filepath = file
                         _, filename, ext = split_filepath(file)
                         to_filepath = os.path.join(group_path, filename + ext)
-                        if dry_run:
+                        if self.dry_run:
                             print(f"[Dry Run] Copying {from_filepath} to {to_filepath}")
                         else:
                             self.log(f"Copying {from_filepath} to {to_filepath}")
@@ -167,11 +194,24 @@ class SplitFrames:
                         Mtqdm().update_bar(file_bar)
                 Mtqdm().update_bar(group_bar)
 
+                if add_resynthesis_frames or add_inflation_frame:
+                    if self.dry_run:
+                        print(f"[Dry Run] Resequencing files in {group_path}")
+                    else:
+                        self.log(f"Resequencing files in {group_path}")
+                        base_filename = f"{group_name}-{self.type}-split-frame"
+                        ResequenceFiles(group_path,
+                                        self.file_ext,
+                                        base_filename,
+                                        0, 1, 1, 0, num_width,
+                                        True,
+                                        self.log).resequence()
+
         if self.action != "copy":
             with Mtqdm().open_bar(total=num_files, desc="Deleting") as bar:
                 for file in files:
                     if os.path.exists(file):
-                        if dry_run:
+                        if self.dry_run:
                             print(f"[Dry Run] Deleting {file}")
                         else:
                             self.log(f"Deleting {file}")

--- a/tabs/merge_frames_ui.py
+++ b/tabs/merge_frames_ui.py
@@ -1,0 +1,62 @@
+"""Merge Frames feature UI and event handlers"""
+from typing import Callable
+import gradio as gr
+from webui_utils.simple_config import SimpleConfig
+from webui_utils.simple_icons import SimpleIcons
+from webui_tips import WebuiTips
+from interpolate_engine import InterpolateEngine
+from tabs.tab_base import TabBase
+from merge_frames import MergeFrames as _MergeFrames
+
+class MergeFrames(TabBase):
+    """Encapsulates UI elements and events for the Split Frames feature"""
+    def __init__(self,
+                    config : SimpleConfig,
+                    engine : InterpolateEngine,
+                    log_fn : Callable):
+        TabBase.__init__(self, config, engine, log_fn)
+
+    def render_tab(self):
+        """Render tab into UI"""
+        with gr.Tab("Merge Frames"):
+            gr.Markdown(
+                SimpleIcons.CONV_SYMBOL + "Recombine previously split PNG sequences")
+            input_path = gr.Text(max_lines=1, label="Split Groups Base Path",
+                placeholder="Path on this server to the split file group directories")
+            output_path = gr.Text(max_lines=1, label="PNG Files Path",
+                placeholder="Path on this server to store the recombined PNG files")
+            with gr.Row():
+                num_groups = gr.Number(value=-1,
+                                       label="Number of Split Groups (-1 for auto-detect)")
+                split_type = gr.Radio(value="precise", label="Split Type",
+                                      choices=["precise", "resynthesis", "inflation"],
+                        info="Choose 'precise' unless the group files will be further processed")
+                action_type = gr.Radio(value="combine", label="Disposition",
+                                       choices=["combine", "revert"],
+            info="Choose 'combine' to merge processed frames, 'revert' to undo a previous split")
+                delete = gr.Checkbox(value=False, label="Delete groups after successful merge")
+            with gr.Row():
+                merge_button = gr.Button("Merge Frames", variant="primary")
+            # with gr.Accordion(SimpleIcons.TIPS_SYMBOL + " Guide", open=False):
+            #     WebuiTips.mp4_to_png.render()
+        merge_button.click(self.merge_frames,
+            inputs=[input_path, output_path, num_groups, split_type, action_type, delete])
+
+    def merge_frames(self,
+                        input_path : str,
+                        output_path : str,
+                        num_groups : int,
+                        split_type : str,
+                        action_type : str,
+                        delete : bool):
+        """Split button handler"""
+        if input_path and output_path:
+            _MergeFrames(
+                input_path,
+                output_path,
+                "png",
+                split_type,
+                num_groups,
+                action_type,
+                delete,
+                False, self.log).merge()

--- a/tabs/split_frames_ui.py
+++ b/tabs/split_frames_ui.py
@@ -1,0 +1,58 @@
+"""Split Frames feature UI and event handlers"""
+from typing import Callable
+import gradio as gr
+from webui_utils.simple_config import SimpleConfig
+from webui_utils.simple_icons import SimpleIcons
+from webui_tips import WebuiTips
+from interpolate_engine import InterpolateEngine
+from tabs.tab_base import TabBase
+from split_frames import SplitFrames as _SplitFrames
+
+class SplitFrames(TabBase):
+    """Encapsulates UI elements and events for the Split Frames feature"""
+    def __init__(self,
+                    config : SimpleConfig,
+                    engine : InterpolateEngine,
+                    log_fn : Callable):
+        TabBase.__init__(self, config, engine, log_fn)
+
+    def render_tab(self):
+        """Render tab into UI"""
+        with gr.Tab("Split Frames"):
+            gr.Markdown(
+                SimpleIcons.CONV_SYMBOL + "Split large PNG sequences into processible chunks")
+            input_path = gr.Text(max_lines=1, label="PNG Files Path",
+                placeholder="Path on this server to the PNG files to be split")
+            output_path = gr.Text(max_lines=1, label="Split Groups Base Path",
+                placeholder="Path on this server to store the split file group directories")
+            with gr.Row():
+                num_groups = gr.Slider(value=10, minimum=1, maximum=1000,
+                                       label="Number of Split Groups")
+                split_type = gr.Radio(value="precise", label="Split Type",
+                                      choices=["precise", "resynthesis", "inflation"],
+                        info="Choose 'precise' unless the group files will be further processed")
+                action_type = gr.Radio(value="copy", label="Disposition", choices=["copy", "move"],
+                        info="Choose 'move' to delete the source files after splitting")
+            with gr.Row():
+                split_button = gr.Button("Split Frames", variant="primary")
+            # with gr.Accordion(SimpleIcons.TIPS_SYMBOL + " Guide", open=False):
+            #     WebuiTips.mp4_to_png.render()
+        split_button.click(self.split_frames,
+            inputs=[input_path, output_path, num_groups, split_type, action_type])
+
+    def split_frames(self,
+                        input_path : str,
+                        output_path : str,
+                        num_groups : int,
+                        split_type : str,
+                        action_type : str):
+        """Split button handler"""
+        if input_path and output_path:
+            _SplitFrames(
+                input_path,
+                output_path,
+                "png",
+                split_type,
+                num_groups,
+                action_type,
+                False, self.log).split()


### PR DESCRIPTION
New command line script `merge_frames.py` to merge groups of files previously split with `split_frames.py`
- Combine several runs of a split process
- Pull together files that were split up for transport
- Undo a previous split

Usage
```
> python merge_frames.py --input_path "my path/grouped" --output_path "my path/merged" 
```

| Command-Line Options| &nbsp;  | Default |
| :- | :- | :- |
| `--input_path` path | path to base directory of existing split directories | |
| `--output_path` path | path to store the merged files | |
| `--file_ext` ext | type of files to move (any extension or `*`) | `png` |
| `--type` type | type of split ('precise', 'resynthesis`, `inflation`) | `precise` |
| `--num_groups` num | number of new split directories (-1 for auto-detect) | `-1` |
| `--action` action | action to take ('revert', 'combine) | `copy` |
| `--delete` delete | delete groups after merge | False |
| `--dry_run` | show what changes would be made | not enabled |
| `--verbose` | enable display of internal details | not enabled |

| Split Types | &nbsp; |
| :- | :- |
| `precise` | recombine files split for transport or non-interpolation related processing |
| `resynthesis` | recombine files that were previously split for resynthesis |
| `inflation` | recombine files that were previously split for inflation |

| Action Types | &nbsp; |
| :- | :- |
| `revert` | Undo a previous split; recombine original unprocessed files |
| `combine` | Recombine files after interpolation or other processing |

## Important
For merging to be successful:
- The merge type must match the original split type (as information about how to recombine the files is encoded in the group names)
- The number and names of groups must not be changed
- The number of files within the groups must not be changed, with the exception of using _inflation_
