### PR TITLE
Misc clean up items

### DIFF
--- a/deduplicate_frames.py
+++ b/deduplicate_frames.py
@@ -271,8 +271,7 @@ class DeduplicateFrames:
     def invoke_autofill(self, suppress_output=False):
         self.log("invoke_autofill() using invoke_delete() to copy non-duplicate frames")
 
-        # repurpose max_dupes for auto-fill to mean:
-        # skip auto-fill on groups larger than this size
+        # repurpose max_dupes for auto-fill to mean: skip auto-fill on groups larger than this size
         ignore_over_size = self.max_dupes
         self.max_dupes = 0
         _, dupe_groups, frame_filenames = self.invoke_delete(True,
@@ -281,6 +280,7 @@ class DeduplicateFrames:
         self.log(f"beginning processing of {len(dupe_groups)} duplicate frame groups")
         restored_total = 0
         with Mtqdm().open_bar(total=len(dupe_groups), desc="Auto-Filling") as bar:
+            auto_filled_files = []
             for index, group in enumerate(dupe_groups):
                 self.log(f"processing group #{index+1}")
                 group_indexes = list(group.keys())
@@ -337,14 +337,16 @@ class DeduplicateFrames:
                             new_filename = os.path.join(self.output_path, filename + ext)
                             self.log(f"renaming {restored_file} to {new_filename}")
                             os.replace(restored_file, new_filename)
+                            auto_filled_files.append(new_filename)
                 Mtqdm().update_bar(bar)
 
+        self.log(f"auto-filled files: {','.join(auto_filled_files)}")
         message = f"{restored_total} duplicate frames filled with interpolated replacements at" +\
                   f" {self.output_path}"
         self.log(message)
         if not suppress_output:
             print(message)
-        return message, dupe_groups, frame_filenames
+        return message, auto_filled_files
 
     def log(self, message : str) -> None:
         """Logging"""

--- a/tabs/dedupe_autofill_ui.py
+++ b/tabs/dedupe_autofill_ui.py
@@ -111,7 +111,7 @@ f"""Error deduplicating frames:
     def create_autofill_report(self, input_path : str, output_path : str, threshold : int,
                     max_dupes : int, depth : int, message : str, auto_filled_files : list) -> str:
         report = []
-        report.append("[Autofill Frames Report]")
+        report.append("[Auto-filled Frames Report]")
         report.append(f"input path: {input_path}")
         report.append(f"output path: {output_path}")
         report.append(f"threshold: {threshold}")

--- a/tabs/mp4_to_png_ui.py
+++ b/tabs/mp4_to_png_ui.py
@@ -54,6 +54,7 @@ class MP4toPNG(TabBase):
         """Convert button handler"""
         if input_filepath and output_path:
             create_directory(output_path)
+            self.log("using MP4toPNG (may cause long delay while counting frames)")
             ffmpeg_cmd = _MP4toPNG(input_filepath,
                                    output_pattern,
                                    int(frame_rate),

--- a/tabs/video_details_ui.py
+++ b/tabs/video_details_ui.py
@@ -121,6 +121,8 @@ class VideoDetails(TabBase):
                     stream["sample_rate"] = stream_data.get("sample_rate")
                     stream["channels"] = stream_data.get("channels")
                     stream["channel_layout"] = stream_data.get("channel_layout")
+                    stream["sample_aspect_ratio"] = stream_data.get("sample_aspect_ratio")
+                    stream["display_aspect_ratio"] = stream_data.get("display_aspect_ratio")
 
                     # capture video details from the first found video stream
                     if not video_summary and codec_type == "video":


### PR DESCRIPTION
- Added _sample_ and _display_ aspect ratio (SAR/DAR) metadata to the _Video Details_ report
    - SAR is useful with _Resize Frames_ to fix the aspect ratio of some over-the-air or DVD content 
    - In the below example, SAR specifies the scaling needed to expand the native content to the display aspect ratio 16:9
        - DAR of 16:9 means: the content should be _fit_ to this aspect ratio for display
        - The SAR of 40:33 means: the native content width needs expanding by 121% (40/33) for display
        - The width and height of 704x480 refers to the native content, it needs expanding to 853x480 
        - The consumer of the content (video player, display device, software) is expected do the expansion at display time 

```text
[Format]
filename: C:\CONTENT\\H and I-05292023-0804PM.mts
duration: 2:24:36.378189
size: 1,569,140,736
bit_rate: 1,446,816
format_name: MPEG-TS (MPEG-2 Transport Stream)

[Stream #0 video]
frame_rate: 29.97
duration: 2:24:35.904044
width: 704
height: 480
frame_count: Unknown
bit_rate: 0
codec_name: mpeg2video
pix_fmt: yuv420p
sample_aspect_ratio: 40:33
display_aspect_ratio: 16:9
```

- Added a log message when _MP4toPNG_ is used regarding long delays and appearing to freeze
    - When auto-detecting a video's PNG sequence filename format, the frame count is required
    - The video is scanned to determine the actual frame count, which takes significant time for long videos
- Added a report written to the output path when using the _Auto-Fill Duplicate Frames_ feature
    - The report shows the settings for the deduplicate along with filenames for all auto-filled frames
    - This is handy when experimenting with deduplication settings

```text
[Auto-filled Frames Report]
input path: C:\AI\CONDA\EMA-VFI-WebUI\test_assets\8 TOOLS\13 DEDUPLICATION\SOURCE
output path: C:\AI\CONDA\EMA-VFI-WebUI\test_assets\8 TOOLS\13 DEDUPLICATION\SOURCE-AD
threshold: 1800
max group: 2
search precision: 10
message: 19 duplicate frames filled with interpolated replacements at C:\AI\CONDA\EMA-VFI-WebUI\test_assets\8 TOOLS\13 DEDUPLICATION\SOURCE-AD

[Auto-Filled Files]
C:\AI\CONDA\EMA-VFI-WebUI\test_assets\8 TOOLS\13 DEDUPLICATION\SOURCE-AD\odds0005.png
C:\AI\CONDA\EMA-VFI-WebUI\test_assets\8 TOOLS\13 DEDUPLICATION\SOURCE-AD\odds0010.png
C:\AI\CONDA\EMA-VFI-WebUI\test_assets\8 TOOLS\13 DEDUPLICATION\SOURCE-AD\odds0015.png
C:\AI\CONDA\EMA-VFI-WebUI\test_assets\8 TOOLS\13 DEDUPLICATION\SOURCE-AD\odds0020.png
C:\AI\CONDA\EMA-VFI-WebUI\test_assets\8 TOOLS\13 DEDUPLICATION\SOURCE-AD\odds0025.png
C:\AI\CONDA\EMA-VFI-WebUI\test_assets\8 TOOLS\13 DEDUPLICATION\SOURCE-AD\odds0030.png
C:\AI\CONDA\EMA-VFI-WebUI\test_assets\8 TOOLS\13 DEDUPLICATION\SOURCE-AD\odds0035.png
C:\AI\CONDA\EMA-VFI-WebUI\test_assets\8 TOOLS\13 DEDUPLICATION\SOURCE-AD\odds0040.png
C:\AI\CONDA\EMA-VFI-WebUI\test_assets\8 TOOLS\13 DEDUPLICATION\SOURCE-AD\odds0045.png
C:\AI\CONDA\EMA-VFI-WebUI\test_assets\8 TOOLS\13 DEDUPLICATION\SOURCE-AD\odds0050.png
C:\AI\CONDA\EMA-VFI-WebUI\test_assets\8 TOOLS\13 DEDUPLICATION\SOURCE-AD\odds0055.png
C:\AI\CONDA\EMA-VFI-WebUI\test_assets\8 TOOLS\13 DEDUPLICATION\SOURCE-AD\odds0060.png
C:\AI\CONDA\EMA-VFI-WebUI\test_assets\8 TOOLS\13 DEDUPLICATION\SOURCE-AD\odds0065.png
C:\AI\CONDA\EMA-VFI-WebUI\test_assets\8 TOOLS\13 DEDUPLICATION\SOURCE-AD\odds0070.png
C:\AI\CONDA\EMA-VFI-WebUI\test_assets\8 TOOLS\13 DEDUPLICATION\SOURCE-AD\odds0075.png
C:\AI\CONDA\EMA-VFI-WebUI\test_assets\8 TOOLS\13 DEDUPLICATION\SOURCE-AD\odds0080.png
C:\AI\CONDA\EMA-VFI-WebUI\test_assets\8 TOOLS\13 DEDUPLICATION\SOURCE-AD\odds0085.png
C:\AI\CONDA\EMA-VFI-WebUI\test_assets\8 TOOLS\13 DEDUPLICATION\SOURCE-AD\odds0091.png
C:\AI\CONDA\EMA-VFI-WebUI\test_assets\8 TOOLS\13 DEDUPLICATION\SOURCE-AD\odds0096.png
```