### PR TITLE
Misc clean up

### DIFF
--- a/webui_utils/mtqdm.py
+++ b/webui_utils/mtqdm.py
@@ -110,7 +110,8 @@ class Mtqdm:
         self.current_palette = name
 
     def get_palette(self, name : str):
-        return self.alt_palettes[name] if self.alternation else self.palettes[name]
+        palette_set = self.alt_palettes if self.alternation else self.palettes
+        return palette_set.get(name, palette_set.get("default"))
 
     def get_position(self):
         return self.position
@@ -333,14 +334,21 @@ class MtqdmTester():
         Mtqdm().set_palette("random")
         self.test_bars_2(min, max, delay)
 
+    def test_bars_7(self, min, max, delay):
+        Mtqdm().set_palette("doesnotexist")
+        self.test_bars_2(min, max, delay)
 
-def main():
-    # MtqdmTester().test_bars_1(9, 3, 0.01)
-    #MtqdmTester().test_bars_2(5, 15, 0.1)
-    # MtqdmTester().test_bars_3(10, 10, .001)
-    # MtqdmTester().test_bars_4("rainbow", 5, Mtqdm.MAX_BARS, 10, 1.0)
-    # MtqdmTester().test_bars_5(5, 15, 0.1)
-    MtqdmTester().test_bars_6(5, 10, 0.1)
+    def run_test(self, test : int):
+        {
+            1 : lambda : self.test_bars_1(9, 3, 0.01),
+            2 : lambda : self.test_bars_2(5, 15, 0.1),
+            3 : lambda : self.test_bars_3(10, 10, .001),
+            4 : lambda : self.test_bars_4("rainbow", 5, Mtqdm.MAX_BARS, 10, 1.0),
+            5 : lambda : self.test_bars_5(5, 15, 0.1),
+            6 : lambda : self.test_bars_6(5, 10, 0.1),
+            7 : lambda : self.test_bars_7(5, 10, 0.1),
+        }[test]()
 
 if __name__ == '__main__':
-    main()
+    while True:
+        MtqdmTester().run_test(int(input(f"Mtqdm Test (1..7)):")))

--- a/webui_utils/video_utils.py
+++ b/webui_utils/video_utils.py
@@ -164,6 +164,8 @@ def get_frame_count(input_path : str) -> int:
                     global_options="-v quiet")
     result = ffcmd.run(stdout=subprocess.PIPE)
     stdout = result[0].decode("UTF-8").strip()
+    # sometimes it's output twice
+    stdout = stdout.splitlines()[0]
     return int(stdout)
 
 def get_frame_rate(input_path : str) -> float:

--- a/webui_utils/video_utils.py
+++ b/webui_utils/video_utils.py
@@ -58,7 +58,7 @@ def MP4toPNG(input_path : str,  # pylint: disable=invalid-name
     """Encapsulate logic for the MP4 to PNG Sequence feature"""
     pattern = filename_pattern or determine_output_pattern(input_path)
     if deinterlace:
-        filter = f"bwdif=mode=send_field:parity=auto:deint=all,fps={frame_rate * 2}"
+        filter = f"bwdif=mode=send_field:parity=auto:deint=all,fps={frame_rate}"
     else:
         filter = f"fps={frame_rate}"
 


### PR DESCRIPTION
- fix an issue with MP4 to PNG with auto determination of the PNG sequence output pattern, where `ffprobe` returns two lines for frame count causing a parsing error
- disable auto doubling the frame rate when deinterlacing; seems to be unnecessary
- use the default palette if the set palette name is not recognized
