### PR TITLE
Add a split frames report

### DIFF
--- a/split_frames.py
+++ b/split_frames.py
@@ -80,7 +80,7 @@ class SplitFrames:
         if self.max_files < 0:
             raise ValueError("'max_files_per_group' must be >= 0")
 
-    def split(self) -> None:
+    def split(self) -> list:
         """Invoke the Split Frames feature"""
         files = sorted(glob.glob(os.path.join(self.input_path, f"*.{self.file_ext}")))
         num_files = len(files)
@@ -160,6 +160,7 @@ class SplitFrames:
                     self.log("Adding after anchor frame")
                     file_groups[group] = file_groups[group] + [next_start_file]
 
+        group_paths = []
         with Mtqdm().open_bar(total=self.num_groups, desc="Groups") as group_bar:
             for group in range(self.num_groups):
                 group_files = file_groups[group]
@@ -187,6 +188,7 @@ class SplitFrames:
                 group_name = f"{str(group_name_first_index).zfill(num_width)}" +\
                     f"-{str(group_name_last_index).zfill(num_width)}"
                 group_path = os.path.join(self.output_path, group_name)
+                group_paths.append(group_path)
 
                 if self.dry_run:
                     self.log(f"[Dry Run] Creating directory {group_path}")
@@ -231,6 +233,8 @@ class SplitFrames:
                             self.log(f"Deleting {file}")
                             os.remove(file)
                     Mtqdm().update_bar(bar)
+
+        return group_paths
 
     def log(self, message : str) -> None:
         """Logging"""

--- a/tabs/split_frames_ui.py
+++ b/tabs/split_frames_ui.py
@@ -7,6 +7,7 @@ from webui_tips import WebuiTips
 from interpolate_engine import InterpolateEngine
 from tabs.tab_base import TabBase
 from split_frames import SplitFrames as _SplitFrames
+from webui_utils.auto_increment import AutoIncrementFilename
 
 class SplitFrames(TabBase):
     """Encapsulates UI elements and events for the Split Frames feature"""
@@ -51,7 +52,7 @@ class SplitFrames(TabBase):
                         action_type : str):
         """Split button handler"""
         if input_path and output_path:
-            _SplitFrames(
+            group_paths = _SplitFrames(
                 input_path,
                 output_path,
                 "png",
@@ -60,3 +61,37 @@ class SplitFrames(TabBase):
                 max_files,
                 action_type.lower(),
                 False, self.log).split()
+
+            report = self.create_split_report(input_path,
+                                              output_path,
+                                              split_type,
+                                              num_groups,
+                                              max_files,
+                                              action_type,
+                                              group_paths)
+
+            report_filepath, _ = AutoIncrementFilename(output_path, "txt").next_filename(
+                                                                    "split-frames-report", "txt")
+            with open(report_filepath, "w", encoding="UTF-8") as file:
+                file.write(report)
+
+    def create_split_report(self,
+                            input_path : str,
+                            output_path : str,
+                            split_type : str,
+                            num_groups : str,
+                            max_files : str,
+                            action_type,
+                            group_paths):
+        report = []
+        report.append("[Split Frames Report]")
+        report.append(f"input path: {input_path}")
+        report.append(f"output path: {output_path}")
+        report.append(f"split type: {split_type}")
+        report.append(f"num groups: {num_groups}")
+        report.append(f"max files: {max_files}")
+        report.append(f"action type: {action_type}")
+        report.append("")
+        report.append("[Split Group Directories]")
+        report += group_paths
+        return "\r\n".join(report)


### PR DESCRIPTION
- ensure the original split details are not lost 
- the report lists the split settings used and the list of new group directories

```text
[Split Frames Report]
input path: C:\AI\CONDA\EMA-VFI-WebUI\test_assets\8 TOOLS\17 SPLIT FRAMES\PRE-SPLIT FRAMES
output path: C:\AI\CONDA\EMA-VFI-WebUI\test_assets\8 TOOLS\17 SPLIT FRAMES\UITEST
split type: Resynthesis
num groups: 3
max files: 0
action type: Copy

[Split Group Directories]
C:\AI\CONDA\EMA-VFI-WebUI\test_assets\8 TOOLS\17 SPLIT FRAMES\UITEST\000-050
C:\AI\CONDA\EMA-VFI-WebUI\test_assets\8 TOOLS\17 SPLIT FRAMES\UITEST\049-100
C:\AI\CONDA\EMA-VFI-WebUI\test_assets\8 TOOLS\17 SPLIT FRAMES\UITEST\099-149
```