### PR TITLE
fix revert of unprocessed resynth split w uneven groups

### DIFF
--- a/guide/simplify_png_files.md
+++ b/guide/simplify_png_files.md
@@ -1,12 +1,18 @@
-**Simplify PNG Files** - Remove Optional PNG Chunks
+**Simplify PNG Files** - Remove Interfering PNG Chunks
 
 ## Why It's Needed
 
-* PNG files sometimes include optional color calibration data used by modern browsers to enhance the colors on the display device.
-* When mixing and matching PNG files with and without the optional data, images can appear to not match when using _Video Blender_
-* PNG files are rewritten inluding only the original RGB color data
+* PNG files sometimes include optional _data chunks_ that can interfere with use in _Video Blender_ or video editing software
+    * _Examples:_
+    * Display color calibration data
+    * Display aspect ratio data
+* When using PNG from different workflows, non-matching frames can cause confusion
+    * Frames to appear not to match when using _Frame Chooser_
+    * Frames have different shapes when using sofware such as _Premiere Pro_
+* PNG files are rewritten inluding only the essential RGB color data
 
 ## How It Works
 1. Set _PNG files path_ to the path on this server containing the PNG files
 1. Click _Clean_
 1. Each PNG file will be rewritten excluding optional data
+    - Tip: As a bonus, the PNG files usually have a smaller file size

--- a/merge_frames.py
+++ b/merge_frames.py
@@ -165,8 +165,15 @@ class MergeFrames:
             for group_index, group_name in enumerate(group_names):
                 group_expected_files = expected_files
 
-                if group_index == 0 or group_index == len(group_names)-1:
-                    group_expected_files -=1 # one fewer frame; outer frames can't have anchor frames
+                if group_index == 0:
+                    # one fewer frame; outer frames can't have anchor frames
+                    group_expected_files -=1
+                elif group_index == len(group_names)-1:
+                    # get this group's file count, as it may be truncated being the final group
+                    # next, have one fewer frame; outer frames can't have anchor frames
+                    first_index, last_index, _ = self.details_from_group_name(group_name)
+                    group_size = last_index - first_index
+                    group_expected_files = group_size + 1
 
                 group_files = self.group_files(group_name)
                 if len(group_files) != group_expected_files:


### PR DESCRIPTION
While using the _Merge Frames_ feature to undo a _resynthesis_ split, it expected the wrong number of files in the last group
- fix: for the last group, reread the group size from the group name instead of using the standard for other groups.