### PR TITLE
Merging a 'precise' split in 'combine' mode should ignore file count

### DIFF
--- a/deduplicate_frames.py
+++ b/deduplicate_frames.py
@@ -230,6 +230,7 @@ class DeduplicateFrames:
 
             # remove duplicates from full list of frame files
             all_filenames = frame_filenames.copy()
+            deleted_files = []
             dupe_count = 0
             for index, group in enumerate(dupe_groups):
                 self.log(f"processing group #{index+1}")
@@ -244,6 +245,7 @@ class DeduplicateFrames:
                 for filepath in dupes:
                     self.log(f"excluding {filepath}")
                     frame_filenames.remove(filepath)
+                    deleted_files.append(filepath)
                     dupe_count += 1
 
             with Mtqdm().open_bar(total=len(frame_filenames), desc="Copying") as bar:
@@ -259,7 +261,8 @@ class DeduplicateFrames:
             self.log(message)
             if not suppress_output:
                 print(message)
-            return message, dupe_groups, all_filenames
+            return message, dupe_groups, all_filenames, deleted_files
+
         except RuntimeError as error:
             message = f"Error generating report: {error}"
             self.log(message)
@@ -274,7 +277,7 @@ class DeduplicateFrames:
         # repurpose max_dupes for auto-fill to mean: skip auto-fill on groups larger than this size
         ignore_over_size = self.max_dupes
         self.max_dupes = 0
-        _, dupe_groups, frame_filenames = self.invoke_delete(True,
+        _, dupe_groups, frame_filenames, _ = self.invoke_delete(True,
                                                              max_size_for_delete=ignore_over_size)
 
         self.log(f"beginning processing of {len(dupe_groups)} duplicate frame groups")

--- a/guide/merge_frames.md
+++ b/guide/merge_frames.md
@@ -27,8 +27,11 @@
     - _Files Action_ is _Combine_:
         - Merges all files found in the group directories
         - Files retain their original filenames
+        - Files within groups can differ from the original group count
     - _Files Action_ is _Revert_:
-        - Same as _Combine_
+        - Merges all files found in the group directories
+        - Files retain their original filenames
+        - **Files within groups must match the original group count**
 - **Resynthesize**
     - _Files Action_ is _Combine:_
         - Merges the _resynthesized_ set of files found in the group directories

--- a/merge_frames.py
+++ b/merge_frames.py
@@ -117,13 +117,16 @@ class MergeFrames:
     def merge_precise(self, num_width, group_names):
         with Mtqdm().open_bar(total=len(group_names), desc="Groups") as group_bar:
             for group_name in group_names:
-                first_index, last_index, _ = self.details_from_group_name(group_name)
-                group_size = last_index - first_index + 1
-                expected_files = group_size
                 group_files = self.group_files(group_name)
-                if len(group_files) != expected_files:
-                    raise RuntimeError(
-                        f"expected {expected_files} files in {group_name} but found {len(group_files)}")
+
+                if self.action == "revert":
+                    # if reverting, expect to be able to undo the split without changes
+                    first_index, last_index, _ = self.details_from_group_name(group_name)
+                    group_size = last_index - first_index + 1
+                    expected_files = group_size
+                    if len(group_files) != expected_files:
+                        raise RuntimeError(
+                    f"expected {expected_files} files in {group_name} but found {len(group_files)}")
 
                 with Mtqdm().open_bar(total=len(group_files), desc="Copying") as file_bar:
                     for file in group_files:
@@ -483,9 +486,6 @@ class MergeFrames:
                             os.replace(file, original_filename)
                         Mtqdm().update_bar(bar)
                 Mtqdm().update_bar(group_bar)
-
-
-
 
     def validate_input_path(self):
         """returns the list of group names"""

--- a/tabs/dedupe_frames_ui.py
+++ b/tabs/dedupe_frames_ui.py
@@ -9,7 +9,7 @@ from webui_tips import WebuiTips
 from interpolate_engine import InterpolateEngine
 from tabs.tab_base import TabBase
 from deduplicate_frames import DeduplicateFrames
-from webui_utils.auto_increment import AutoIncrementDirectory
+from webui_utils.auto_increment import AutoIncrementDirectory, AutoIncrementFilename
 
 class DedupeFrames(TabBase):
     """Encapsulates UI elements and events for the Deduplicate Frames feature"""
@@ -41,7 +41,7 @@ class DedupeFrames(TabBase):
                 threshold = gr.Slider(value=default_threshold, minimum=min_threshold,
                     maximum=max_threshold, step=threshold_step, label="Detection Threshold")
                 max_dupes = gr.Slider(value=def_max_dupes, minimum=0, maximum=max_max_dupes, step=1,
-                    label="Maximum Duplicates Per Group (0 = no limit, 1 = no duplicates allowed)")
+                        label="Maximum Group Size to Delete (0 = no limit, 1 = no delete)")
             with gr.Row():
                 dedupe_button = gr.Button("Deduplicate Frames", variant="primary")
             with gr.Row():
@@ -62,13 +62,30 @@ class DedupeFrames(TabBase):
                 if not output_path:
                     base_output_path = self.config.directories["output_deduplication"]
                     output_path, _ = AutoIncrementDirectory(base_output_path).next_directory("run")
-                message, _, _ = DeduplicateFrames(None,
-                                            input_path,
-                                            output_path,
-                                            threshold,
-                                            max_dupes,
-                                            None,
-                                            self.log).invoke_delete(suppress_output=True)
+
+                # repurpose max_dupes for delete to mean: skip delete on groups larger than this size
+                ignore_over_size = max_dupes
+                max_dupes = 0
+                message, _, _, deleted_files = DeduplicateFrames(None,
+                                                                input_path,
+                                                                output_path,
+                                                                threshold,
+                                                                max_dupes,
+                                                                None,
+                                                                self.log).invoke_delete(
+                                                                    suppress_output=True,
+                                                            max_size_for_delete=ignore_over_size)
+                report = self.create_delete_report(input_path,
+                                                     output_path,
+                                                     threshold,
+                                                     ignore_over_size,
+                                                     message,
+                                                     deleted_files)
+
+                report_filepath, _ = AutoIncrementFilename(output_path, "txt").next_filename(
+                                                                        "remove-report", "txt")
+                with open(report_filepath, "w", encoding="UTF-8") as file:
+                    file.write(report)
                 return gr.update(value=message, visible=True)
 
             except RuntimeError as error:
@@ -76,3 +93,18 @@ class DedupeFrames(TabBase):
 f"""Error deduplicating frames:
 {error}"""
                 return gr.update(value=message, visible=True)
+
+    def create_delete_report(self, input_path : str, output_path : str, threshold : int,
+                    max_dupes : int, message : str, deleted_files : list) -> str:
+        report = []
+        report.append("[Removed Frames Report]")
+        report.append(f"input path: {input_path}")
+        report.append(f"output path: {output_path}")
+        report.append(f"threshold: {threshold}")
+        report.append(f"max group: {max_dupes}")
+        report.append(f"message: {message}")
+        report.append("")
+        report.append("[Removed Files]")
+        report += deleted_files
+        return "\r\n".join(report)
+


### PR DESCRIPTION
- When merging a _precise_ split with action _combine_, skip the check for group file count
    - assume the files may have been modified in any way, including files being added/removed or groups being removed
    - this enables splitting content for preselection review purposes and simply deleting unwanted groups and recombining
- In comparison, when the action is _revert_, the group files counts must match (no change to this behavior in this PR)
