### PR TITLE
Fix some issues with splitting and merging

### DIFF
--- a/guide/gif_to_mp4.md
+++ b/guide/gif_to_mp4.md
@@ -11,7 +11,7 @@
 Two third-party packages are required to use this feature:
 * FFmpeg for file conversion [free download](https://ffmpeg.org/download.html)
     - `ffmpeg.exe` and `ffprobe.exe` must be available on the system path
-* Real-ESRGAN for frame restoration/upscaling [see wiki page](https://github.com/jhogsett/VFIformer-WebUI/wiki/Installing-Real-ESRGAN-Add-On)
+* Real-ESRGAN for frame restoration/upscaling [see wiki page](https://github.com/jhogsett/EMA-VFI-WebUI/wiki/Installing-Real-ESRGAN-Add-On)
     - The `realesrgan` directory must be copied to the `EMA-VFI-WebUI` directory
 
 ## How it works

--- a/guide/merge_frames.md
+++ b/guide/merge_frames.md
@@ -1,4 +1,4 @@
-**Merge Frames** - Merge a previously split set of of PNG framess
+**Merge Frames** - Merge a previously split set of of PNG frames
 
 ## Uses
 - Recombine groups after a large processing run

--- a/guide/merge_frames.md
+++ b/guide/merge_frames.md
@@ -26,9 +26,10 @@
 - **Precise**
     - _Files Action_ is _Combine_:
         - Merges all files found in the group directories
-        - Files retain their original filenames
-            - _Note: if the group name is unchanged from the original split, the files are renamed to avoid a file naming clash_
-        - Files within groups can differ from the original group count
+        - **If the group names are unchanged since the original split:**
+            - The files will be **renamed** and merged, assuming they have been processed by a feature likke _Upscale Frames_ that may change filenames but not file counts
+        - **If the group names are not frame indexes (renamed):**
+            - The files will be merged _as-is_ without renaming, assuming they may have been processed by hand, for example, deleting unwanted frames or groups
     - _Files Action_ is _Revert_:
         - Merges all files found in the group directories
         - Files retain their original filenames

--- a/guide/merge_frames.md
+++ b/guide/merge_frames.md
@@ -27,6 +27,7 @@
     - _Files Action_ is _Combine_:
         - Merges all files found in the group directories
         - Files retain their original filenames
+            - _Note: if the group name is unchanged from the original split, the files are renamed to avoid a file naming clash_
         - Files within groups can differ from the original group count
     - _Files Action_ is _Revert_:
         - Merges all files found in the group directories

--- a/guide/resize_frames.md
+++ b/guide/resize_frames.md
@@ -27,5 +27,6 @@
 1. Click _Resize Frames_
 1. When complete, the output path will contain a new set of frames
 
-## Note
+## Important
+- If cropping only, the original image dimensions must be entered into the _Scale Width_ and _Scale Height_ fields
 - Cropping is performed after resizing

--- a/guide/simplify_png_files.md
+++ b/guide/simplify_png_files.md
@@ -1,4 +1,4 @@
-**Simplify PNG Files** - Remove Interfering PNG Chunks
+**Clean PNG Files** - Remove Interfering PNG Chunks
 
 ## Why It's Needed
 

--- a/guide/video_blender_new_project.md
+++ b/guide/video_blender_new_project.md
@@ -1,4 +1,4 @@
-**Video Blender New Project** - Automated setup of a new Video Blender project
+**Video Blender New Project** - Automated set up of a new Video Blender project
 
 ## How To Use
 

--- a/split_frames.py
+++ b/split_frames.py
@@ -167,7 +167,9 @@ class SplitFrames:
                 num_group_files = len(group_files)
                 first_index = group * files_per_group
                 last_index = ((group+1) * files_per_group) - 1
-                if last_index > num_files:
+
+                # deal with a possibly incomplete last group
+                if last_index >= num_files:
                     last_index = num_files-1
 
                 group_name_first_index = first_index


### PR DESCRIPTION
In the case of _combining_ a _precise_ split, there are two possible use cases:
- The files were originally split to be processed in a way that doesn't change the file counts but changes the filenames, like _Upscale Frames_
- The files were originally split to be manually handled, for example, to delete unwanted frames and groups

The merge should be able to handle both situations
- If the group name is recognizable as a `first-last` frame index, it's treated as the first kind
    - the files are all expected to be present, and are renamed to prevent a filename clash
- Otherwise it's treated as the second kind
    - frame files and whole group directories can be deleted 