### PR TITLE
Add Scene Detection

### DIFF
--- a/split_frames.py
+++ b/split_frames.py
@@ -18,7 +18,7 @@ def main():
     parser.add_argument("--output_path", default=None, type=str,
         help="Base path for frame group directories")
     parser.add_argument("--file_ext", default="png", type=str,
-                        help="File extension, default: 'png'; any extensiion or or '*'")
+                        help="File extension, default: 'png'; any extension or or '*'")
     parser.add_argument("--type", default="precise", type=str,
         help="Split type 'precise' (default), 'resynthesis', 'inflation'")
     parser.add_argument("--num_groups", default=10, type=int, help="Number of new file groups")

--- a/split_scenes.py
+++ b/split_scenes.py
@@ -1,0 +1,250 @@
+"""Split Scenes Feature Core Code"""
+import os
+import glob
+import argparse
+import math
+import shutil
+from typing import Callable
+from webui_utils.simple_log import SimpleLog
+from webui_utils.file_utils import create_directory, is_safe_path, split_filepath
+from webui_utils.mtqdm import Mtqdm
+from resequence_files import ResequenceFiles
+
+
+# ffmpeg -framerate 1 -i png%05d.png -filter_complex "select='gt(scene,0.F)',metadata=print:file=-" -f null -
+
+
+def main():
+    """Use the Split Scenes feature from the command line"""
+    parser = argparse.ArgumentParser(description='Split a directory of PNG frame files')
+    parser.add_argument("--input_path", default=None, type=str,
+        help="Input path to PNG frame files to split")
+    parser.add_argument("--output_path", default=None, type=str,
+        help="Base path for frame group directories")
+    parser.add_argument("--file_ext", default="png", type=str,
+                        help="File extension, default: 'png'; any extensiion or or '*'")
+    parser.add_argument("--type", default="scene", type=str,
+        help="Scene detect type 'scene' (default), 'break'")
+
+    # parser.add_argument("--num_groups", default=10, type=int, help="Number of new file groups")
+    # parser.add_argument("--max_files_per_group", default=0, type=int,
+    #                     help="Maximum allowed files per group (default: 0 - no limit)")
+    # parser.add_argument("--action", default="copy", type=str,
+    #     help="Files action 'copy' (default), 'move'")
+    # parser.add_argument("--dry_run", dest="dry_run", default=False, action="store_true",
+    #                     help="Show changes that will be made")
+    parser.add_argument("--verbose", dest="verbose", default=False, action="store_true",
+        help="Show extra details")
+    args = parser.parse_args()
+
+    log = SimpleLog(args.verbose)
+    SplitFrames(args.input_path,
+                args.output_path,
+                args.file_ext,
+                args.type,
+                args.num_groups,
+                args.max_files_per_group,
+                args.action,
+                args.dry_run,
+                log.log).split()
+
+class SplitFrames:
+    """Encapsulate logic for Split Frames feature"""
+    def __init__(self,
+                input_path : str,
+                output_path : str,
+                file_ext : str,
+                type : str,
+                num_groups : int,
+                max_files : int,
+                action : str,
+                dry_run : bool,
+                log_fn : Callable | None):
+        self.input_path = input_path
+        self.output_path = output_path
+        self.file_ext = file_ext
+        self.type = type
+        self.num_groups = num_groups
+        self.max_files = max_files
+        self.action = action
+        self.dry_run = dry_run
+        self.log_fn = log_fn
+        valid_types = ["precise", "resynthesis", "inflation"]
+        valid_actions = ["copy", "move"]
+
+        if not is_safe_path(self.input_path):
+            raise ValueError("'input_path' must be a legal path")
+        if not is_safe_path(self.output_path):
+            raise ValueError("'output_path' must be a legal path")
+        if self.num_groups < 2:
+            raise ValueError("'num_groups' must be >= 2")
+        if not self.type in valid_types:
+            raise ValueError(f"'type' must be one of {', '.join([t for t in valid_types])}")
+        if not self.action in valid_actions:
+            raise ValueError(f"'action' must be one of {', '.join([t for t in valid_actions])}")
+        if self.max_files < 0:
+            raise ValueError("'max_files_per_group' must be >= 0")
+
+    def split(self) -> list:
+        """Invoke the Split Frames feature"""
+        files = sorted(glob.glob(os.path.join(self.input_path, f"*.{self.file_ext}")))
+        num_files = len(files)
+        if self.num_groups > num_files:
+            raise ValueError(f"'num_groups' must be <= source file count {num_files}")
+        num_width = len(str(num_files))
+
+        if self.max_files > 0:
+            files_per_group = self.max_files
+            needed_groups = int(math.ceil(num_files / self.max_files))
+            self.num_groups = needed_groups
+            self.log(f"overriding 'num_groups' with computed value {needed_groups}")
+        else:
+            files_per_group = int(math.ceil(num_files / self.num_groups))
+        self.log(f"Splitting files to {self.num_groups} groups of {files_per_group} files")
+
+        add_resynthesis_frames = self.type == "resynthesis"
+        add_inflation_frame = self.type == "inflation"
+
+        if self.dry_run:
+            print(f"[Dry Run] Creating base output path {self.output_path}")
+        else:
+            self.log(f"Creating base output path {self.output_path}")
+            create_directory(self.output_path)
+
+        file_groups = [[] for n in range(self.num_groups)]
+        for group in range(self.num_groups):
+            self.log(f"Collecting filenames for group {group}")
+            start_index = group * files_per_group
+            for index in range(files_per_group):
+                file_index = start_index + index
+                if file_index < num_files:
+                    file_groups[group].append(files[file_index])
+
+            if add_resynthesis_frames:
+                self.log("Adding surrounding anchor frames for resynthesis")
+                prev_group = group - 1
+                _prev_start_index = prev_group * files_per_group
+                prev_last_index = _prev_start_index + files_per_group-1
+                next_group = group + 1
+                next_start_index = next_group * files_per_group
+
+                if _prev_start_index >= 0:
+                    prev_last_file = files[prev_last_index]
+                else:
+                    prev_last_file = None
+                if next_start_index < num_files:
+                    next_start_file = files[next_start_index]
+                else:
+                    next_start_file = None
+                self.log(
+        f"Anchor files for resynthesis frames: prev '{prev_last_file}' next '{next_start_file}'")
+
+                if group == 0:
+                    self.log("Adding after anchor frame")
+                    file_groups[group] = file_groups[group] + [next_start_file]
+                elif group == self.num_groups-1:
+                    self.log("Adding before anchor frame")
+                    file_groups[group] = [prev_last_file] + file_groups[group]
+                else:
+                    self.log("Adding before and after anchor frames")
+                    file_groups[group] = [prev_last_file] + file_groups[group] + [next_start_file]
+
+            elif add_inflation_frame:
+                self.log("Adding ending anchor frame for inflation")
+                next_group = group + 1
+                next_start_index = next_group * files_per_group
+
+                if next_start_index < num_files:
+                    next_start_file = files[next_start_index]
+                else:
+                    next_start_file = None
+                self.log(
+                f"Anchor File for inflation frames: next '{next_start_file}'")
+
+                if group < self.num_groups-1:
+                    self.log("Adding after anchor frame")
+                    file_groups[group] = file_groups[group] + [next_start_file]
+
+        group_paths = []
+        with Mtqdm().open_bar(total=self.num_groups, desc="Groups") as group_bar:
+            for group in range(self.num_groups):
+                group_files = file_groups[group]
+                num_group_files = len(group_files)
+                first_index = group * files_per_group
+                last_index = ((group+1) * files_per_group) - 1
+                if last_index > num_files:
+                    last_index = num_files-1
+
+                group_name_first_index = first_index
+                group_name_last_index = last_index
+
+                if add_resynthesis_frames:
+                    if group == 0:
+                        group_name_last_index += 1
+                    elif group == self.num_groups-1:
+                        group_name_first_index -= 1
+                    else:
+                        group_name_first_index -= 1
+                        group_name_last_index += 1
+                elif add_inflation_frame:
+                    if group < self.num_groups-1:
+                        group_name_last_index += 1
+
+                group_name = f"{str(group_name_first_index).zfill(num_width)}" +\
+                    f"-{str(group_name_last_index).zfill(num_width)}"
+                group_path = os.path.join(self.output_path, group_name)
+                group_paths.append(group_path)
+
+                if self.dry_run:
+                    self.log(f"[Dry Run] Creating directory {group_path}")
+                else:
+                    self.log(f"Creating directory {group_path}")
+                    create_directory(group_path)
+
+                desc = "Copying" if self.action == "copy" else "Moving"
+                with Mtqdm().open_bar(total=num_group_files, desc=desc) as file_bar:
+                    for file in group_files:
+                        from_filepath = file
+                        _, filename, ext = split_filepath(file)
+                        to_filepath = os.path.join(group_path, filename + ext)
+                        if self.dry_run:
+                            print(f"[Dry Run] Copying {from_filepath} to {to_filepath}")
+                        else:
+                            self.log(f"Copying {from_filepath} to {to_filepath}")
+                            shutil.copy(from_filepath, to_filepath)
+                        Mtqdm().update_bar(file_bar)
+                Mtqdm().update_bar(group_bar)
+
+                if add_resynthesis_frames or add_inflation_frame:
+                    if self.dry_run:
+                        print(f"[Dry Run] Resequencing files in {group_path}")
+                    else:
+                        self.log(f"Resequencing files in {group_path}")
+                        base_filename = f"{group_name}-{self.type}-split-frame"
+                        ResequenceFiles(group_path,
+                                        self.file_ext,
+                                        base_filename,
+                                        0, 1, 1, 0, num_width,
+                                        True,
+                                        self.log).resequence()
+
+        if self.action != "copy":
+            with Mtqdm().open_bar(total=num_files, desc="Deleting") as bar:
+                for file in files:
+                    if os.path.exists(file):
+                        if self.dry_run:
+                            print(f"[Dry Run] Deleting {file}")
+                        else:
+                            self.log(f"Deleting {file}")
+                            os.remove(file)
+                    Mtqdm().update_bar(bar)
+
+        return group_paths
+
+    def log(self, message : str) -> None:
+        """Logging"""
+        if self.log_fn:
+            self.log_fn(message)
+
+if __name__ == '__main__':
+    main()

--- a/split_scenes.py
+++ b/split_scenes.py
@@ -7,12 +7,9 @@ import shutil
 from typing import Callable
 from webui_utils.simple_log import SimpleLog
 from webui_utils.file_utils import create_directory, is_safe_path, split_filepath
+from webui_utils.video_utils import get_detected_scenes, get_detected_breaks, scene_list_to_ranges
 from webui_utils.mtqdm import Mtqdm
 from resequence_files import ResequenceFiles
-
-
-# ffmpeg -framerate 1 -i png%05d.png -filter_complex "select='gt(scene,0.F)',metadata=print:file=-" -f null -
-
 
 def main():
     """Use the Split Scenes feature from the command line"""
@@ -22,176 +19,74 @@ def main():
     parser.add_argument("--output_path", default=None, type=str,
         help="Base path for frame group directories")
     parser.add_argument("--file_ext", default="png", type=str,
-                        help="File extension, default: 'png'; any extensiion or or '*'")
+                        help="File extension, default: 'png'; any extension or or '*'")
     parser.add_argument("--type", default="scene", type=str,
         help="Scene detect type 'scene' (default), 'break'")
-
-    # parser.add_argument("--num_groups", default=10, type=int, help="Number of new file groups")
-    # parser.add_argument("--max_files_per_group", default=0, type=int,
-    #                     help="Maximum allowed files per group (default: 0 - no limit)")
-    # parser.add_argument("--action", default="copy", type=str,
-    #     help="Files action 'copy' (default), 'move'")
-    # parser.add_argument("--dry_run", dest="dry_run", default=False, action="store_true",
-    #                     help="Show changes that will be made")
+    parser.add_argument("--scene_threshold", default=0.5, type=float,
+                        help="Threshold between 0.0 and 1.0 for scene detection (default 0.5)")
+    parser.add_argument("--break_duration", default=0.5, type=float,
+                        help="Duration in seconds for break to be detectable (default 0.5)")
+    parser.add_argument("--break_ratio", default=0.98, type=float,
+            help="Percent 0.0 to 1.0 of frame that must be black to be detectable (default 0.98)")
     parser.add_argument("--verbose", dest="verbose", default=False, action="store_true",
         help="Show extra details")
     args = parser.parse_args()
 
     log = SimpleLog(args.verbose)
-    SplitFrames(args.input_path,
+    SplitScenes(args.input_path,
                 args.output_path,
                 args.file_ext,
                 args.type,
-                args.num_groups,
-                args.max_files_per_group,
-                args.action,
-                args.dry_run,
+                args.scene_threshold,
+                args.break_duration,
+                args.break_ratio,
                 log.log).split()
 
-class SplitFrames:
-    """Encapsulate logic for Split Frames feature"""
+class SplitScenes:
+    """Encapsulate logic for Split Scenes feature"""
     def __init__(self,
                 input_path : str,
                 output_path : str,
                 file_ext : str,
                 type : str,
-                num_groups : int,
-                max_files : int,
-                action : str,
-                dry_run : bool,
+                scene_threshold : float,
+                break_duration : float,
+                break_ratio : float,
                 log_fn : Callable | None):
         self.input_path = input_path
         self.output_path = output_path
         self.file_ext = file_ext
         self.type = type
-        self.num_groups = num_groups
-        self.max_files = max_files
-        self.action = action
-        self.dry_run = dry_run
+        self.scene_threshold = scene_threshold
+        self.break_duration = break_duration
+        self.break_ratio = break_ratio
+        self.dry_run = False
         self.log_fn = log_fn
-        valid_types = ["precise", "resynthesis", "inflation"]
-        valid_actions = ["copy", "move"]
+        valid_types = ["scene", "break"]
 
         if not is_safe_path(self.input_path):
             raise ValueError("'input_path' must be a legal path")
         if not is_safe_path(self.output_path):
             raise ValueError("'output_path' must be a legal path")
-        if self.num_groups < 2:
-            raise ValueError("'num_groups' must be >= 2")
         if not self.type in valid_types:
             raise ValueError(f"'type' must be one of {', '.join([t for t in valid_types])}")
-        if not self.action in valid_actions:
-            raise ValueError(f"'action' must be one of {', '.join([t for t in valid_actions])}")
-        if self.max_files < 0:
-            raise ValueError("'max_files_per_group' must be >= 0")
 
-    def split(self) -> list:
-        """Invoke the Split Frames feature"""
+    def split_scenes(self):
         files = sorted(glob.glob(os.path.join(self.input_path, f"*.{self.file_ext}")))
         num_files = len(files)
-        if self.num_groups > num_files:
-            raise ValueError(f"'num_groups' must be <= source file count {num_files}")
         num_width = len(str(num_files))
-
-        if self.max_files > 0:
-            files_per_group = self.max_files
-            needed_groups = int(math.ceil(num_files / self.max_files))
-            self.num_groups = needed_groups
-            self.log(f"overriding 'num_groups' with computed value {needed_groups}")
-        else:
-            files_per_group = int(math.ceil(num_files / self.num_groups))
-        self.log(f"Splitting files to {self.num_groups} groups of {files_per_group} files")
-
-        add_resynthesis_frames = self.type == "resynthesis"
-        add_inflation_frame = self.type == "inflation"
-
-        if self.dry_run:
-            print(f"[Dry Run] Creating base output path {self.output_path}")
-        else:
-            self.log(f"Creating base output path {self.output_path}")
-            create_directory(self.output_path)
-
-        file_groups = [[] for n in range(self.num_groups)]
-        for group in range(self.num_groups):
-            self.log(f"Collecting filenames for group {group}")
-            start_index = group * files_per_group
-            for index in range(files_per_group):
-                file_index = start_index + index
-                if file_index < num_files:
-                    file_groups[group].append(files[file_index])
-
-            if add_resynthesis_frames:
-                self.log("Adding surrounding anchor frames for resynthesis")
-                prev_group = group - 1
-                _prev_start_index = prev_group * files_per_group
-                prev_last_index = _prev_start_index + files_per_group-1
-                next_group = group + 1
-                next_start_index = next_group * files_per_group
-
-                if _prev_start_index >= 0:
-                    prev_last_file = files[prev_last_index]
-                else:
-                    prev_last_file = None
-                if next_start_index < num_files:
-                    next_start_file = files[next_start_index]
-                else:
-                    next_start_file = None
-                self.log(
-        f"Anchor files for resynthesis frames: prev '{prev_last_file}' next '{next_start_file}'")
-
-                if group == 0:
-                    self.log("Adding after anchor frame")
-                    file_groups[group] = file_groups[group] + [next_start_file]
-                elif group == self.num_groups-1:
-                    self.log("Adding before anchor frame")
-                    file_groups[group] = [prev_last_file] + file_groups[group]
-                else:
-                    self.log("Adding before and after anchor frames")
-                    file_groups[group] = [prev_last_file] + file_groups[group] + [next_start_file]
-
-            elif add_inflation_frame:
-                self.log("Adding ending anchor frame for inflation")
-                next_group = group + 1
-                next_start_index = next_group * files_per_group
-
-                if next_start_index < num_files:
-                    next_start_file = files[next_start_index]
-                else:
-                    next_start_file = None
-                self.log(
-                f"Anchor File for inflation frames: next '{next_start_file}'")
-
-                if group < self.num_groups-1:
-                    self.log("Adding after anchor frame")
-                    file_groups[group] = file_groups[group] + [next_start_file]
+        self.log(f"calling `get_detected_scenes` with input path '{self.input_path}' threshold '{self.scene_threshold}'")
+        scenes = get_detected_scenes(self.input_path, self.scene_threshold)
+        ranges = scene_list_to_ranges(scenes)
 
         group_paths = []
-        with Mtqdm().open_bar(total=self.num_groups, desc="Groups") as group_bar:
-            for group in range(self.num_groups):
-                group_files = file_groups[group]
-                num_group_files = len(group_files)
-                first_index = group * files_per_group
-                last_index = ((group+1) * files_per_group) - 1
-                if last_index > num_files:
-                    last_index = num_files-1
-
-                group_name_first_index = first_index
-                group_name_last_index = last_index
-
-                if add_resynthesis_frames:
-                    if group == 0:
-                        group_name_last_index += 1
-                    elif group == self.num_groups-1:
-                        group_name_first_index -= 1
-                    else:
-                        group_name_first_index -= 1
-                        group_name_last_index += 1
-                elif add_inflation_frame:
-                    if group < self.num_groups-1:
-                        group_name_last_index += 1
-
-                group_name = f"{str(group_name_first_index).zfill(num_width)}" +\
-                    f"-{str(group_name_last_index).zfill(num_width)}"
+        with Mtqdm().open_bar(total=len(ranges), desc="Scenes") as scene_bar:
+            for _range in ranges:
+                first_index = _range["first_frame"]
+                last_index = _range["last_frame"]
+                group_size = _range["scene_size"]
+                group_name = f"{str(first_index).zfill(num_width)}" +\
+                            f"-{str(last_index).zfill(num_width)}"
                 group_path = os.path.join(self.output_path, group_name)
                 group_paths.append(group_path)
 
@@ -201,45 +96,66 @@ class SplitFrames:
                     self.log(f"Creating directory {group_path}")
                     create_directory(group_path)
 
-                desc = "Copying" if self.action == "copy" else "Moving"
-                with Mtqdm().open_bar(total=num_group_files, desc=desc) as file_bar:
-                    for file in group_files:
-                        from_filepath = file
-                        _, filename, ext = split_filepath(file)
+                desc = "Copying" # if self.action == "copy" else "Moving"
+                with Mtqdm().open_bar(total=group_size, desc=desc) as file_bar:
+                    for index in range(first_index, last_index+1):
+                        frame_file = files[index]
+                        from_filepath = frame_file
+                        _, filename, ext = split_filepath(frame_file)
                         to_filepath = os.path.join(group_path, filename + ext)
+
                         if self.dry_run:
                             print(f"[Dry Run] Copying {from_filepath} to {to_filepath}")
                         else:
                             self.log(f"Copying {from_filepath} to {to_filepath}")
                             shutil.copy(from_filepath, to_filepath)
                         Mtqdm().update_bar(file_bar)
-                Mtqdm().update_bar(group_bar)
+                Mtqdm().update_bar(scene_bar)
 
-                if add_resynthesis_frames or add_inflation_frame:
-                    if self.dry_run:
-                        print(f"[Dry Run] Resequencing files in {group_path}")
-                    else:
-                        self.log(f"Resequencing files in {group_path}")
-                        base_filename = f"{group_name}-{self.type}-split-frame"
-                        ResequenceFiles(group_path,
-                                        self.file_ext,
-                                        base_filename,
-                                        0, 1, 1, 0, num_width,
-                                        True,
-                                        self.log).resequence()
-
-        if self.action != "copy":
-            with Mtqdm().open_bar(total=num_files, desc="Deleting") as bar:
-                for file in files:
-                    if os.path.exists(file):
-                        if self.dry_run:
-                            print(f"[Dry Run] Deleting {file}")
-                        else:
-                            self.log(f"Deleting {file}")
-                            os.remove(file)
-                    Mtqdm().update_bar(bar)
+        # if self.action != "copy":
+        #     with Mtqdm().open_bar(total=num_files, desc="Deleting") as bar:
+        #         for file in files:
+        #             if os.path.exists(file):
+        #                 if self.dry_run:
+        #                     print(f"[Dry Run] Deleting {file}")
+        #                 else:
+        #                     self.log(f"Deleting {file}")
+        #                     os.remove(file)
+        #             Mtqdm().update_bar(bar)
 
         return group_paths
+
+    def split_breaks(self):
+        # files = sorted(glob.glob(os.path.join(self.input_path, f"*.{self.file_ext}")))
+        # num_files = len(files)
+        # num_width = len(str(num_files))
+        pass
+
+    def split(self) -> list:
+        """Invoke the Split Scenes feature"""
+        # files = sorted(glob.glob(os.path.join(self.input_path, f"*.{self.file_ext}")))
+        # num_files = len(files)
+        # num_width = len(str(num_files))
+
+        if self.type == "scene":
+            if self.scene_threshold < 0.0 or self.scene_threshold > 1.0:
+                raise ValueError("'scene_threshold' must be between 0.0 and 1.0")
+            self.split_scenes()
+        else:
+            if self.break_duration < 0.0:
+                raise ValueError("'break_duration' >= 0.0")
+            if self.break_ratio < 0.0 or self.break_ratio > 1.0:
+                raise ValueError("'break_ratio' must be between 0.0 and 1.0")
+            self.split_breaks()
+
+        if self.dry_run:
+            print(f"[Dry Run] Creating base output path {self.output_path}")
+        else:
+            self.log(f"Creating base output path {self.output_path}")
+            create_directory(self.output_path)
+
+
+
 
     def log(self, message : str) -> None:
         """Logging"""

--- a/split_scenes.py
+++ b/split_scenes.py
@@ -2,14 +2,12 @@
 import os
 import glob
 import argparse
-import math
 import shutil
 from typing import Callable
 from webui_utils.simple_log import SimpleLog
 from webui_utils.file_utils import create_directory, is_safe_path, split_filepath
 from webui_utils.video_utils import get_detected_scenes, get_detected_breaks, scene_list_to_ranges
 from webui_utils.mtqdm import Mtqdm
-from resequence_files import ResequenceFiles
 
 def main():
     """Use the Split Scenes feature from the command line"""
@@ -22,10 +20,10 @@ def main():
                         help="File extension, default: 'png'; any extension or or '*'")
     parser.add_argument("--type", default="scene", type=str,
         help="Scene detect type 'scene' (default), 'break'")
-    parser.add_argument("--scene_threshold", default=0.5, type=float,
-                        help="Threshold between 0.0 and 1.0 for scene detection (default 0.5)")
-    parser.add_argument("--break_duration", default=0.5, type=float,
-                        help="Duration in seconds for break to be detectable (default 0.5)")
+    parser.add_argument("--scene_threshold", default=0.6, type=float,
+                        help="Threshold between 0.0 and 1.0 for scene detection (default 0.6)")
+    parser.add_argument("--break_duration", default=1.0, type=float,
+                        help="Duration in seconds for break to be detectable (default 1.0)")
     parser.add_argument("--break_ratio", default=0.98, type=float,
             help="Percent 0.0 to 1.0 of frame that must be black to be detectable (default 0.98)")
     parser.add_argument("--verbose", dest="verbose", default=False, action="store_true",
@@ -75,7 +73,8 @@ class SplitScenes:
         files = sorted(glob.glob(os.path.join(self.input_path, f"*.{self.file_ext}")))
         num_files = len(files)
         num_width = len(str(num_files))
-        self.log(f"calling `get_detected_scenes` with input path '{self.input_path}' threshold '{self.scene_threshold}'")
+        self.log(f"calling `get_detected_scenes` with input path '{self.input_path}'" +\
+                 f" threshold '{self.scene_threshold}'")
         scenes = get_detected_scenes(self.input_path, self.scene_threshold)
         ranges = scene_list_to_ranges(scenes)
 
@@ -126,10 +125,59 @@ class SplitScenes:
         return group_paths
 
     def split_breaks(self):
-        # files = sorted(glob.glob(os.path.join(self.input_path, f"*.{self.file_ext}")))
-        # num_files = len(files)
-        # num_width = len(str(num_files))
-        pass
+        files = sorted(glob.glob(os.path.join(self.input_path, f"*.{self.file_ext}")))
+        num_files = len(files)
+        num_width = len(str(num_files))
+        self.log(f"calling `get_detected_breaks` with input path '{self.input_path}'" +\
+                 f" duration '{self.break_duration}' ratio '{self.break_ratio}'")
+        scenes = get_detected_breaks(self.input_path, self.break_duration, self.break_ratio)
+        ranges = scene_list_to_ranges(scenes)
+
+        group_paths = []
+        with Mtqdm().open_bar(total=len(ranges), desc="Scenes") as scene_bar:
+            for _range in ranges:
+                first_index = _range["first_frame"]
+                last_index = _range["last_frame"]
+                group_size = _range["scene_size"]
+                group_name = f"{str(first_index).zfill(num_width)}" +\
+                            f"-{str(last_index).zfill(num_width)}"
+                group_path = os.path.join(self.output_path, group_name)
+                group_paths.append(group_path)
+
+                if self.dry_run:
+                    self.log(f"[Dry Run] Creating directory {group_path}")
+                else:
+                    self.log(f"Creating directory {group_path}")
+                    create_directory(group_path)
+
+                desc = "Copying" # if self.action == "copy" else "Moving"
+                with Mtqdm().open_bar(total=group_size, desc=desc) as file_bar:
+                    for index in range(first_index, last_index+1):
+                        frame_file = files[index]
+                        from_filepath = frame_file
+                        _, filename, ext = split_filepath(frame_file)
+                        to_filepath = os.path.join(group_path, filename + ext)
+
+                        if self.dry_run:
+                            print(f"[Dry Run] Copying {from_filepath} to {to_filepath}")
+                        else:
+                            self.log(f"Copying {from_filepath} to {to_filepath}")
+                            shutil.copy(from_filepath, to_filepath)
+                        Mtqdm().update_bar(file_bar)
+                Mtqdm().update_bar(scene_bar)
+
+        # if self.action != "copy":
+        #     with Mtqdm().open_bar(total=num_files, desc="Deleting") as bar:
+        #         for file in files:
+        #             if os.path.exists(file):
+        #                 if self.dry_run:
+        #                     print(f"[Dry Run] Deleting {file}")
+        #                 else:
+        #                     self.log(f"Deleting {file}")
+        #                     os.remove(file)
+        #             Mtqdm().update_bar(bar)
+
+        return group_paths
 
     def split(self) -> list:
         """Invoke the Split Scenes feature"""

--- a/webui_utils/video_utils.py
+++ b/webui_utils/video_utils.py
@@ -403,13 +403,15 @@ def get_detected_breaks(input_path : str, duration : float=0.5, ratio : float=0.
         breaks.append(int((start + end) / 2))
     return breaks
 
-def scene_list_to_ranges(scene_list):
+def scene_list_to_ranges(scene_list, num_files):
     last_scene_index = 0
     result = []
     for scene_frame in scene_list:
         first_frame = last_scene_index
-        scene_size = scene_frame - last_scene_index
-        last_frame = first_frame + scene_size - 1
+        last_frame = scene_frame - 1
+        if last_frame >= num_files:
+            last_frame = num_files - 1
+        scene_size = (last_frame - first_frame) + 1
         result.append({
             "first_frame" : first_frame,
             "last_frame" : last_frame,


### PR DESCRIPTION
## Added command-line script to split PNG frames by _Scene_ or _Break_

Split by Scene
- Scene changes detected by FFmpeg **_scdet_** filter
- Specify `--type scene` (default)
- Specify `--scene_threshold F` (0.0 to 1.0 - default 0.6)
- Example:

`> python split_scenes.py --input_path c:\frames --output_path c:\frames\scenes --type scene --scene_threshold 0.6` 

Split by Break
- Scene changes detected by FFmpeg **_blackdetect_** filter
- Specify `--type break`
- Specify `--break_duration F` (minimum break duration in seconds, default 2.0)
- Specify `--break_ratio R` (ratio 0.0 to 1.0 of black vs. non-black pixels, default 0.98)
- Example:

`> python split_scenes.py --input_path c:\frames --output_path c:\frames\scenes --type break --break_duration 2.0 --break_ratio 0.98` 

The _Merge Frames_ feature in the UI has also been updated to able to merge these split groups as a _precise combine_.