### PR TITLE
Account for resynthesized content

### DIFF
--- a/guide/slice_video.md
+++ b/guide/slice_video.md
@@ -19,6 +19,8 @@
     - Leave blank to store the sliced files within the original scene directories
 1. Adjust _Output Scale Factor_ as necessary
     - _Tip: Sliced files can grow large - a small size is recommended_
+1. Leave _Edge Trim_ Unchecked
+    - If slicing based on resynthesized content, check this box to account for removed outer frames
 1. Choose a _Slice Type_
     - _See below for a table of Slice Types and descriptions_
 1. Choose a _MP4 Quality_

--- a/tabs/slice_video_ui.py
+++ b/tabs/slice_video_ui.py
@@ -47,6 +47,8 @@ class SliceVideo(TabBase):
                 output_scale = gr.Slider(minimum=0.0, maximum=max_scale_factor,
                     step=0.05, value=def_scale_factor, label="Output Scale Factor",
                     info="Output frames will be downscaled by this factor")
+                edge_trim = gr.Checkbox(value=False, label="Edge Trim",
+                                info="Remove outer frames for resynthesized content")
             with gr.Row():
                 slice_type = gr.Radio(value="mp4", choices=["mp4", "gif", "wav", "mp3", "jpg"],
                             label="Slice Type", info="See the guide for details about each type")
@@ -60,7 +62,7 @@ class SliceVideo(TabBase):
                 WebuiTips.slice_video.render()
 
         slice_video.click(self.slice_video, inputs=[input_path, input_frame_rate, group_path,
-                                output_path, output_scale, slice_type, mp4_quality, gif_frame_rate])
+                    output_path, output_scale, slice_type, mp4_quality, gif_frame_rate, edge_trim])
 
     def slice_video(self,
                         input_path : str,
@@ -70,9 +72,13 @@ class SliceVideo(TabBase):
                         output_scale : float,
                         slice_type : str,
                         mp4_quality : int,
-                        gif_frame_rate : int):
+                        gif_frame_rate : int,
+                        edge_trim : bool):
         """Slice Video button handler"""
         if input_path and group_path:
+            # if compensating for video resynthesis, set edge trim to "1"
+            # to leave out the (now missing) outer frames when slicing
+            trim = 1 if edge_trim else 0
             _SliceVideo(input_path,
                         input_fps,
                         group_path,
@@ -81,4 +87,5 @@ class SliceVideo(TabBase):
                         slice_type,
                         mp4_quality,
                         gif_frame_rate,
+                        trim,
                         self.log).slice()


### PR DESCRIPTION
When split frame groups are resynthesized, the outermost frames are not reproduced. If using the _Slice Video_ feature to recapture matching audio, the reduction of frames should be accounted for to ensure a 1:1 match between audio and video content.

This feature adds a checkbox to the _Slice Video_ tab to adjust sliced content for resynthesized scenes.