### PR TITLE
Add group processing to resize/upscale frames features

### DIFF
--- a/guide/resize_frames.md
+++ b/guide/resize_frames.md
@@ -7,8 +7,6 @@
 - Crop out VHS tape noise in a digitized video
 
 ## How It Works
-1. Set _Input Path_ to a directory on this server to the PNG files to be resized
-1. Set _Output Path_ to a directory on this server for the resized PNG files
 1. Set _Scaling Type_ to one of the available types:
     - **area** `cv2.INTER_AREA` (best quality reducing)
     - **cubic** `cv2.INTER_CUBIC` (better quality than linear)
@@ -24,9 +22,17 @@
     - Keep the default values of `-1` to match the resizing values
 1. Set _Crop X Offset_ and _Crop Y Offset_ to the cropping origin for the frames
     - Keep the default values of `-1` to automatically center the cropped portion
-1. Click _Resize Frames_
-1. When complete, the output path will contain a new set of frames
+1. Choose _Individual Path_ or _Batch Processing_
+    - If **Individual Path**
+        - Set _Input Path_ to a directory on this server to the PNG files to be resized
+        - Set _Output Path_ to a directory on this server for the resized PNG files
+    - If **Batch Processing**
+        - Set _Input Path_ to a directory on this server containing PNG frame groups to be resized
+        - Set _Output Path_ to a directory on this server for the resized PNG frame groups
+1. Click _Resize Frames_ or _Resize Batch_
+1. When complete, the output path(s) will contain a new set of frames
+- Progress can be tracked in the console
 
 ## Important
-- If cropping only, the original image dimensions must be entered into the _Scale Width_ and _Scale Height_ fields
+- If cropping only, the original image dimensions **must be** entered into the _Scale Width_ and _Scale Height_ fields for automatic centering to work
 - Cropping is performed after resizing

--- a/guide/upscale_frames.md
+++ b/guide/upscale_frames.md
@@ -13,12 +13,6 @@ Real-ESRGAN must be installed locally to use
 * The _Real-ESRGAN 4x+_ model (65MB) will automatically download on first use
 
 ## How It Works
-1. Set _Input Path_ to a directory on this server to the PNG files to be upscaled
-    - JPG, GIF and BMP files will also be upscaled if found in the path
-    - _Tip: the config setting_ `upscale_settings:file_types` _specifies the searched types_
-1. Set _Output Path_ to a directory on this server for the upscaled PNG files
-    - If Output Path is set, upscaled files are saved as sequentially indexed PNG files with a fixed filename
-    - When Output Path is left empty, upscaled files are saved to the input path using the original filename and format, and marked with the outscale amount.
 1. Set _Frame Upscale Factor_ for the desired amount of frame enlargement
     - The factor can be set between 1.0 and 8.0 in 0.05 steps
     - Real-ESRGAN will perform upscaling when _factor_ is > 1.0
@@ -34,7 +28,21 @@ Real-ESRGAN must be installed locally to use
         - Images will be upscaled in blocks then stiched together
         - Tiling _Size_ and _Padding_ (in pixels) are set using the config settings:
             - `realesrgan_settings:tiling` and `realesrgan_settings:tile_pad`
-1. Click _Upscale Frames_
+1. Choose _Individual Path_ or _Batch Processing_
+    - If **Individual Path**
+        - Set _Input Path_ to a directory on this server to the PNG files to be upscaled
+            - JPG, GIF and BMP files will also be upscaled if found in the path
+            - _Tip: the config setting_ `upscale_settings:file_types` _specifies the searched types_
+        - Set _Output Path_ to a directory on this server for the upscaled PNG files
+            - If Output Path is set, upscaled files are saved as sequentially indexed PNG files with a fixed filename
+            - When Output Path is left empty, upscaled files are saved to the input path using the original filename and format, and marked with the outscale amount.
+    - If **Batch Processing**
+        - Set _Input Path_ to a directory on this server containing PNG frame groups to be upscaled
+        - Set _Output Path_ to a directory on this server for the upscaled PNG frame groups
+
+1. Click _Upscale Frames_ or _Upscale Batch_
+- Progress can be checked in the console
+
 1. _Real-ESRGAN_ is used on each frame in the input path
     - Frames are cleaned up, and enlarged if necessary
     - The new frames are copied to the output path

--- a/tabs/resize_frames_ui.py
+++ b/tabs/resize_frames_ui.py
@@ -1,11 +1,13 @@
 """Resize Frames feature UI and event handlers"""
+import os
 from typing import Callable
 import gradio as gr
 from webui_utils.simple_config import SimpleConfig
 from webui_utils.simple_icons import SimpleIcons
-from webui_utils.file_utils import create_directory, get_files
-from webui_utils.auto_increment import AutoIncrementDirectory
-from webui_utils.ui_utils import update_splits_info
+from webui_utils.file_utils import create_directory, get_directories
+# from webui_utils.auto_increment import AutoIncrementDirectory
+# from webui_utils.ui_utils import update_splits_info
+from webui_utils.mtqdm import Mtqdm
 from webui_tips import WebuiTips
 from resize_frames import ResizeFrames as _ResizeFrames
 from tabs.tab_base import TabBase
@@ -24,13 +26,7 @@ class ResizeFrames(TabBase):
             gr.Markdown(SimpleIcons.PINCHING_HAND +\
                         " Reduce, Enlarge and Crop Frames",
                 elem_id="tabheading")
-            with gr.Row():
-                input_path_text = gr.Text(max_lines=1,
-                    placeholder="Path on this server to the frame PNG files",
-                    label="Input Path")
-                output_path_text = gr.Text(max_lines=1,
-                    placeholder="Where to place the resized frames",
-                    label="Output Path")
+
             with gr.Box():
                 with gr.Row():
                     with gr.Column():
@@ -42,6 +38,7 @@ class ResizeFrames(TabBase):
                         with gr.Row():
                             scale_width = gr.Number(value=None, label="Scale Width")
                             scale_height = gr.Number(value=None, label="Scale Height")
+
             with gr.Box():
                 with gr.Row():
                     with gr.Column():
@@ -59,14 +56,79 @@ class ResizeFrames(TabBase):
                                                     info="Use -1 for auto-centering")
                             crop_offset_y = gr.Number(value=-1, label="Crop Y Offset",
                                                     info="Use -1 for auto-centering")
-            gr.Markdown("*Progress can be tracked in the console*")
-            resize_button = gr.Button("Resize Frames " + SimpleIcons.SLOW_SYMBOL,
-                                       variant="primary")
+            with gr.Tabs():
+                with gr.Tab(label="Individual Path"):
+                    with gr.Row():
+                        input_path_text = gr.Text(max_lines=1,
+                            placeholder="Path on this server to the frame PNG files",
+                            label="Input Path")
+                        output_path_text = gr.Text(max_lines=1,
+                            placeholder="Where to place the resized frames",
+                            label="Output Path")
+                    gr.Markdown("*Progress can be tracked in the console*")
+                    resize_button = gr.Button("Resize Frames " + SimpleIcons.SLOW_SYMBOL,
+                                                variant="primary")
+
+                with gr.Tab(label="Batch Processing"):
+                    with gr.Row():
+                        input_path_batch = gr.Text(max_lines=1,
+                            placeholder="Path on this server to the groups of frame PNG files",
+                            label="Input Path")
+                        output_path_batch = gr.Text(max_lines=1,
+                            placeholder="Where to place the resized frame groups",
+                            label="Output Path")
+                    gr.Markdown("*Progress can be tracked in the console*")
+                    resize_batch = gr.Button("Resize Batch " + SimpleIcons.SLOW_SYMBOL,
+                                                variant="primary")
+
             with gr.Accordion(SimpleIcons.TIPS_SYMBOL + " Guide", open=False):
                 WebuiTips.resize_frames.render()
+
         resize_button.click(self.resize_frames,
             inputs=[input_path_text, output_path_text, scale_type, scale_width, scale_height,
                     crop_type, crop_width, crop_height, crop_offset_x, crop_offset_y])
+        resize_batch.click(self.resize_batch,
+            inputs=[input_path_batch, output_path_batch, scale_type, scale_width, scale_height,
+                    crop_type, crop_width, crop_height, crop_offset_x, crop_offset_y])
+
+    def resize_batch(self,
+                       input_path : str,
+                       output_path : str,
+                       scale_type : str,
+                       scale_width : int,
+                       scale_height : int,
+                       crop_type : str,
+                       crop_width : int,
+                       crop_height : int,
+                       crop_offset_x : int,
+                       crop_offset_y : int):
+        """Resize Frame Groups button handler"""
+        if input_path and output_path:
+            self.log(f"beginning batch ResizeFrames processing with input_path={input_path}" +\
+                     f" output_path={output_path}")
+            group_names = get_directories(input_path)
+            self.log(f"found {len(group_names)} groups to process")
+
+            if group_names:
+                self.log(f"creating group output path {output_path}")
+                create_directory(output_path)
+
+                with Mtqdm().open_bar(total=len(group_names), desc="Resize Group") as bar:
+                    for group_name in group_names:
+                        group_input_path = os.path.join(input_path, group_name)
+                        group_output_path = os.path.join(output_path, group_name)
+                        self.resize_frames(group_input_path,
+                                           group_output_path,
+                                           scale_type,
+                                           scale_width,
+                                           scale_height,
+                                           crop_type,
+                                           crop_width,
+                                           crop_height,
+                                           crop_offset_x,
+                                           crop_offset_y)
+                        Mtqdm().update_bar(bar)
+
 
     def resize_frames(self,
                        input_path : str,
@@ -86,8 +148,7 @@ class ResizeFrames(TabBase):
                     f" scale_width={scale_width} scale_height={scale_height}" +\
                     f" crop_type={crop_type} crop_width={crop_width}" +\
                     f" crop_height={crop_height} crop_offset_x={crop_offset_x}" +\
-                    f" crop_offset_y={crop_offset_y}"
-                    )
+                    f" crop_offset_y={crop_offset_y}")
             _ResizeFrames(input_path,
                          output_path,
                          int(scale_width),


### PR DESCRIPTION
Due to the addition of the _Split Frames_ and _Split Scenes_ features, large sets of PNG frame files can now be separated into groups for processing in batches. 

Add the ability to process batches of frames. This PR adds batch processing to the _Upscale Frames_ and _Resize Frames_ tabs.
