### PR TITLE
Add non-MP4 output option for Video Remixer

### DIFF
--- a/video_remixer.py
+++ b/video_remixer.py
@@ -3,9 +3,9 @@ import os
 import shutil
 import yaml
 from yaml import Loader, YAMLError
-from webui_utils.file_utils import split_filepath, remove_directories, create_directory, get_directories, get_files
+from webui_utils.file_utils import split_filepath, remove_directories, create_directory, get_directories, get_files, purge_directories
 from webui_utils.simple_utils import seconds_to_hmsf
-from webui_utils.video_utils import details_from_group_name, get_essential_video_details, MP4toPNG, PNGtoMP4, combine_video_audio, combine_videos
+from webui_utils.video_utils import details_from_group_name, get_essential_video_details, MP4toPNG, PNGtoMP4, combine_video_audio, combine_videos, PNGtoCustom
 from webui_utils.jot import Jot
 from webui_utils.mtqdm import Mtqdm
 from split_scenes import SplitScenes
@@ -482,9 +482,27 @@ class VideoRemixerState():
         elif purge_from == "upscale":
             remove_directories([
                 self.upscale_path])
-        remove_directories([self.video_clips_path])
-        self.video_clips = []
-        self.clips = []
+        self.purge_remix_content(purge_from="audio_clips")
+
+    def purge_remix_content(self, purge_from):
+        if purge_from == "audio_clips":
+            purge_directories([
+                self.audio_clips_path,
+                self.video_clips_path,
+                self.clips_path])
+            self.audio_clips = []
+            self.video_clips = []
+            self.clips = []
+        elif purge_from == "video_clips":
+            purge_directories([
+                self.video_clips_path,
+                self.clips_path])
+            self.video_clips = []
+            self.clips = []
+        elif purge_from == "scene_clips":
+            purge_directories([
+                self.clips_path])
+            self.clips = []
 
     def processed_content_present(self, present_at):
         if present_at == "resize":
@@ -501,10 +519,10 @@ class VideoRemixerState():
             return True if os.path.exists(upscale_path) and get_directories(upscale_path) else False
         elif present_at == "audio":
             audio_clips_path = os.path.join(self.clips_path, self.AUDIO_CLIPS_PATH)
-            return True if os.path.exists(audio_clips_path) and get_directories(audio_clips_path) else False
+            return True if os.path.exists(audio_clips_path) and get_files(audio_clips_path) else False
         elif present_at == "video":
             video_clips_path = os.path.join(self.clips_path, self.VIDEO_CLIPS_PATH)
-            return True if os.path.exists(video_clips_path) and get_directories(video_clips_path) else False
+            return True if os.path.exists(video_clips_path) and get_files(video_clips_path) else False
 
     def purge_stale_processed_content(self, purge_upscale):
         # content is stale if it is present on disk but currently deselected
@@ -791,11 +809,67 @@ class VideoRemixerState():
         else:
             self.clips = sorted(get_files(self.video_clips_path))
 
-    def create_remix_video(self, global_options):
+    def create_custom_video_clips(self, log_fn, kept_scenes, global_options, custom_video_options, custom_ext):
+        self.video_clips_path = os.path.join(self.clips_path, self.VIDEO_CLIPS_PATH)
+        create_directory(self.video_clips_path)
+
+        # TODO might need to better manage the flow of content between processing steps
+        if self.upscale:
+            scenes_base_path = self.upscale_path
+        elif self.inflate:
+            scenes_base_path = self.inflation_path
+        elif self.resynthesize:
+            scenes_base_path = self.resynthesis_path
+        elif self.resize:
+            scenes_base_path = self.resize_path
+        else:
+            scenes_base_path = self.scenes_path
+
+        video_clip_fps = 2 * self.project_fps if self.inflate else self.project_fps
+        with Mtqdm().open_bar(total=len(kept_scenes), desc="Video Clips") as bar:
+            for scene_name in kept_scenes:
+                scene_input_path = os.path.join(scenes_base_path, scene_name)
+                scene_output_filepath = os.path.join(self.video_clips_path, f"{scene_name}.{custom_ext}")
+
+                ResequenceFiles(scene_input_path,
+                                "png",
+                                "processed_frame",
+                                1,
+                                1,
+                                1,
+                                0,
+                                -1,
+                                True,
+                                log_fn).resequence()
+                PNGtoCustom(scene_input_path,
+                            None,
+                            video_clip_fps,
+                            scene_output_filepath,
+                            global_options=global_options,
+                            custom_options=custom_video_options)
+                Mtqdm().update_bar(bar)
+        self.video_clips = sorted(get_files(self.video_clips_path))
+
+    def create_custom_scene_clips(self, kept_scenes, global_options, custom_audio_options, custom_ext):
+        if self.video_details["has_audio"]:
+            with Mtqdm().open_bar(total=len(kept_scenes), desc="Remix Clips") as bar:
+                for index, scene_name in enumerate(kept_scenes):
+                    scene_video_path = self.video_clips[index]
+                    scene_audio_path = self.audio_clips[index]
+                    scene_output_filepath = os.path.join(self.clips_path, f"{scene_name}.{custom_ext}")
+                    combine_video_audio(scene_video_path, scene_audio_path,
+                                        scene_output_filepath, global_options=global_options,
+                                        output_options=custom_audio_options)
+                    Mtqdm().update_bar(bar)
+            self.clips = sorted(get_files(self.clips_path))
+        else:
+            self.clips = sorted(get_files(self.video_clips_path))
+
+    def create_remix_video(self, global_options, output_filepath):
         with Mtqdm().open_bar(total=1, desc="Saving Remix") as bar:
             Mtqdm().message(bar, "Using FFmpeg to concatenate scene clips - no ETA")
             ffcmd = combine_videos(self.clips,
-                                   self.output_filepath,
+                                   output_filepath,
                                    global_options=global_options)
             Mtqdm().update_bar(bar)
         return ffcmd

--- a/video_remixer.py
+++ b/video_remixer.py
@@ -499,6 +499,12 @@ class VideoRemixerState():
         elif present_at == "upscale":
             upscale_path = os.path.join(self.project_path, self.UPSCALE_PATH)
             return True if os.path.exists(upscale_path) and get_directories(upscale_path) else False
+        elif present_at == "audio":
+            audio_clips_path = os.path.join(self.clips_path, self.AUDIO_CLIPS_PATH)
+            return True if os.path.exists(audio_clips_path) and get_directories(audio_clips_path) else False
+        elif present_at == "video":
+            video_clips_path = os.path.join(self.clips_path, self.VIDEO_CLIPS_PATH)
+            return True if os.path.exists(video_clips_path) and get_directories(video_clips_path) else False
 
     def purge_stale_processed_content(self, purge_upscale):
         # content is stale if it is present on disk but currently deselected
@@ -511,29 +517,6 @@ class VideoRemixerState():
             self.purge_processed_content("inflate")
         elif self.processed_content_present("upscale") and (not self.upscale or purge_upscale):
             self.purge_processed_content("upscale")
-
-    AUDIO_CLIPS_PATH = "AUDIO"
-
-    def create_audio_clips(self, log_fn, global_options):
-        self.audio_clips_path = os.path.join(self.clips_path, self.AUDIO_CLIPS_PATH)
-        create_directory(self.audio_clips_path)
-
-        edge_trim = 1 if self.resynthesize else 0
-        SliceVideo(self.source_video,
-                    self.project_fps,
-                    self.scenes_path,
-                    self.audio_clips_path,
-                    0.0,
-                    "wav",
-                    0,
-                    1,
-                    edge_trim,
-                    False,
-                    0.0,
-                    0.0,
-                    log_fn,
-                    global_options=global_options).slice()
-        self.audio_clips = sorted(get_files(self.audio_clips_path))
 
     RESIZE_PATH = "SCENES-RC"
 
@@ -703,6 +686,54 @@ class VideoRemixerState():
         _, filename, _ = split_filepath(self.source_video)
         return os.path.join(self.project_path, f"{filename}-remixed.mp4")
 
+    # find scenes that are empty now after processing and should be automatically dropped
+    # this can happen when resynthesis and/or inflation are used on scenes with only a few frames
+    def drop_empty_processed_scenes(self, kept_scenes):
+        # TODO might need to better manage the flow of content between processing steps
+        if self.upscale:
+            scenes_base_path = self.upscale_path
+        elif self.inflate:
+            scenes_base_path = self.inflation_path
+        elif self.resynthesize:
+            scenes_base_path = self.resynthesis_path
+        elif self.resize:
+            scenes_base_path = self.resize_path
+        else:
+            scenes_base_path = self.scenes_path
+        with Mtqdm().open_bar(total=len(kept_scenes), desc="Checking Clips") as bar:
+            for scene_name in kept_scenes:
+                scene_input_path = os.path.join(scenes_base_path, scene_name)
+                files = get_files(scene_input_path)
+                if len(files) == 0:
+                    self.scene_states[scene_name] = "Drop"
+                    current_path = os.path.join(self.scenes_path, scene_name)
+                    dropped_path = os.path.join(self.dropped_scenes_path, scene_name)
+                    shutil.move(current_path, dropped_path)
+                Mtqdm().update_bar(bar)
+
+    AUDIO_CLIPS_PATH = "AUDIO"
+
+    def create_audio_clips(self, log_fn, global_options):
+        self.audio_clips_path = os.path.join(self.clips_path, self.AUDIO_CLIPS_PATH)
+        create_directory(self.audio_clips_path)
+
+        edge_trim = 1 if self.resynthesize else 0
+        SliceVideo(self.source_video,
+                    self.project_fps,
+                    self.scenes_path,
+                    self.audio_clips_path,
+                    0.0,
+                    "wav",
+                    0,
+                    1,
+                    edge_trim,
+                    False,
+                    0.0,
+                    0.0,
+                    log_fn,
+                    global_options=global_options).slice()
+        self.audio_clips = sorted(get_files(self.audio_clips_path))
+
     VIDEO_CLIPS_PATH = "VIDEO"
 
     def create_video_clips(self, log_fn, kept_scenes, global_options):
@@ -722,10 +753,11 @@ class VideoRemixerState():
             scenes_base_path = self.scenes_path
 
         video_clip_fps = 2 * self.project_fps if self.inflate else self.project_fps
-        with Mtqdm().open_bar(total=len(kept_scenes), desc="Remix Clips") as bar:
+        with Mtqdm().open_bar(total=len(kept_scenes), desc="Video Clips") as bar:
             for scene_name in kept_scenes:
                 scene_input_path = os.path.join(scenes_base_path, scene_name)
                 scene_output_filepath = os.path.join(self.video_clips_path, f"{scene_name}.mp4")
+
                 ResequenceFiles(scene_input_path,
                                 "png",
                                 "processed_frame",
@@ -737,8 +769,8 @@ class VideoRemixerState():
                                 True,
                                 log_fn).resequence()
                 PNGtoMP4(scene_input_path,
-                                 None,
-                                 video_clip_fps,
+                                None,
+                                video_clip_fps,
                                 scene_output_filepath,
                                 crf=self.output_quality,
                                 global_options=global_options)
@@ -747,7 +779,7 @@ class VideoRemixerState():
 
     def create_scene_clips(self, kept_scenes, global_options):
         if self.video_details["has_audio"]:
-            with Mtqdm().open_bar(total=len(kept_scenes), desc="Merge Clips") as bar:
+            with Mtqdm().open_bar(total=len(kept_scenes), desc="Remix Clips") as bar:
                 for index, scene_name in enumerate(kept_scenes):
                     scene_video_path = self.video_clips[index]
                     scene_audio_path = self.audio_clips[index]

--- a/webui_utils/file_utils.py
+++ b/webui_utils/file_utils.py
@@ -36,6 +36,18 @@ def remove_directories(dirs : list):
         if dir and is_safe_path(dir) and os.path.exists(dir):
             shutil.rmtree(dir)
 
+# remove the files found in the passed directory (no recursion)
+def remove_files(path : str):
+    if path and is_safe_path(path) and os.path.exists(path):
+        files = get_files(path)
+        for file in files:
+            os.remove(file)
+
+# remove the files found in each of the passed directories (no recursion)
+def purge_directories(dirs : list):
+    for _dir in dirs:
+        remove_files(_dir)
+
 _duplicate_directory_progress = None
 def _copy(source_path, dest_path):
     global _duplicate_directory_progress

--- a/webui_utils/video_utils.py
+++ b/webui_utils/video_utils.py
@@ -44,7 +44,22 @@ def PNGtoMP4(input_path : str, # pylint: disable=invalid-name
     pattern = filename_pattern or determine_input_pattern(input_path)
     ffcmd = FFmpeg(
         inputs= {os.path.join(input_path, pattern) : f"-framerate {frame_rate}"},
-        outputs={output_filepath : f"-c:v libx264 -r {frame_rate} -pix_fmt yuv420p -crf {crf}"},
+        outputs={output_filepath : f"-r {frame_rate} -pix_fmt yuv420p -c:v libx264 -crf {crf}"},
+        global_options="-y " + global_options)
+    cmd = ffcmd.cmd
+    ffcmd.run()
+    return cmd
+
+def PNGtoCustom(input_path : str, # pylint: disable=invalid-name
+                filename_pattern : str,
+                frame_rate : float,
+                output_filepath : str,
+                global_options : str="",
+                custom_options : str=""):
+    pattern = filename_pattern or determine_input_pattern(input_path)
+    ffcmd = FFmpeg(
+        inputs= {os.path.join(input_path, pattern) : f"-framerate {frame_rate}"},
+        outputs={output_filepath : f"-r {frame_rate} -pix_fmt yuv420p {custom_options}"},
         global_options="-y " + global_options)
     cmd = ffcmd.cmd
     ffcmd.run()
@@ -643,15 +658,17 @@ def decode_aspect(aspect):
     except ZeroDivisionError:
         raise ValueError(f"the aspect '{aspect}' is not valid'")
 
+# presumes AAC audio output
 def combine_video_audio(video_path : str,
                         audio_path : str,
                         output_filepath : str,
-                        global_options : str = ""):
+                        global_options : str = "",
+                        output_options : str = "-c:a aac"):
 # ffmpeg -y -i "MALE Me-TV-03192023-0335PM[000001-001245].wav" -i "MALE Me-TV-03192023-0335PM[000001-001245].mp4" -c:v copy -c:a aac output1.mp4
     ffcmd = FFmpeg(
         inputs= {video_path : None,
                  audio_path : None},
-        outputs={output_filepath : "-c:v copy -c:a aac"},
+        outputs={output_filepath : f"-c:v copy {output_options}"},
         global_options="-y " + global_options)
     cmd = ffcmd.cmd
     ffcmd.run()


### PR DESCRIPTION
Added tabs on the _Save Remix_ tab to choose between default MP4 output and Custom output.

![Screenshot 2023-07-16 073138](https://github.com/jhogsett/EMA-VFI-WebUI/assets/825994/56795b59-11a3-453b-88ee-41a59897d984)

For example, to produce a MPG video, I used:
custom video options: (none)
custom audio options: `-codec:a mp3`
filename: something.`mpg`

This should work for other formats too, making ay kind of content FFmpeg can output, using the high-quality WAV and PNG files crated by _Video Remixer_.

Custom Video Options
- passed to FFmpeg when creating video from the remix PNG files
- added to the command line ahead of the output filename

Custom Audio Options
- passed to FFmpeg when merging the above video clips with the WAV audio files
- added to the command line ahead of the output filename

