### PR TITLE
guard against errors opening project files with missing attributes

### DIFF
--- a/tabs/video_remixer_ui.py
+++ b/tabs/video_remixer_ui.py
@@ -446,32 +446,33 @@ class VideoRemixer(TabBase):
                    *self.empty_args(26)
 
         return_to_tab = self.state.get_progress_tab()
-        scene_details = self.scene_chooser_details(self.state.current_scene)
+        scene_details = self.scene_chooser_details(self.state.tryattr("current_scene"))
+
         return gr.update(selected=return_to_tab), \
                gr.update(visible=True), \
-               self.state.video_info1, \
-               self.state.project_path, \
-               self.state.project_fps, \
-               self.state.deinterlace, \
-               self.state.split_type, \
-               self.state.scene_threshold, \
-               self.state.break_duration, \
-               self.state.break_ratio, \
-               self.state.resize_w, \
-               self.state.resize_h, \
-               self.state.crop_w, \
-               self.state.crop_h, \
-               self.state.project_info2, \
-               self.state.thumbnail_type, \
+               self.state.tryattr("video_info1"), \
+               self.state.tryattr("project_path"), \
+               self.state.tryattr("project_fps", self.config.remixer_settings["def_project_fps"]), \
+               self.state.tryattr("deinterlace", self.state.UI_SAFETY_DEFAULTS["deinterlace"]), \
+               self.state.tryattr("split_type", self.state.UI_SAFETY_DEFAULTS["split_type"]), \
+               self.state.tryattr("scene_threshold", self.state.UI_SAFETY_DEFAULTS["scene_threshold"]), \
+               self.state.tryattr("break_duration", self.state.UI_SAFETY_DEFAULTS["break_duration"]), \
+               self.state.tryattr("break_ratio", self.state.UI_SAFETY_DEFAULTS["break_ratio"]), \
+               self.state.tryattr("resize_w"), \
+               self.state.tryattr("resize_h"), \
+               self.state.tryattr("crop_w"), \
+               self.state.tryattr("crop_h"), \
+               self.state.tryattr("project_info2"), \
+               self.state.tryattr("thumbnail_type", self.state.UI_SAFETY_DEFAULTS["thumbnail_type"]), \
                *scene_details, \
-               self.state.project_info4, \
-               self.state.resize, \
-               self.state.resynthesize, \
-               self.state.inflate, \
-               self.state.upscale, \
-               self.state.upscale_option, \
-               self.state.summary_info6, \
-               self.state.output_filepath
+               self.state.tryattr("project_info4"), \
+               self.state.tryattr("resize", self.state.UI_SAFETY_DEFAULTS["resize"]), \
+               self.state.tryattr("resynthesize", self.state.UI_SAFETY_DEFAULTS["resynthesize"]), \
+               self.state.tryattr("inflate", self.state.UI_SAFETY_DEFAULTS["inflate"]), \
+               self.state.tryattr("upscale", self.state.UI_SAFETY_DEFAULTS["upscale"]), \
+               self.state.tryattr("upscale_option", self.state.UI_SAFETY_DEFAULTS["upscale_option"]), \
+               self.state.tryattr("summary_info6"), \
+               self.state.tryattr("output_filepath")
 
     ### REMIX SETTINGS EVENT HANDLERS
 

--- a/video_remixer.py
+++ b/video_remixer.py
@@ -18,7 +18,6 @@ from interpolate_series import InterpolateSeries
 from resequence_files import ResequenceFiles
 from upscale_series import UpscaleSeries
 
-
 class VideoRemixerState():
     def __init__(self):
         # set at various stages
@@ -89,20 +88,36 @@ class VideoRemixerState():
     def reset(self):
         self.__init__()
 
+    UI_SAFETY_DEFAULTS = {
+        "project_fps" : 29.97,
+        "deinterlace" : False,
+        "split_type" : "Scene",
+        "scene_threshold" : 0.6,
+        "break_duration" : 2.0,
+        "break_ratio" : 0.98,
+        "thumbnail_type" : "JPG",
+        "resize" : True,
+        "resynthesize" : True,
+        "inflate" : True,
+        "upscale" : True,
+        "upscale_option" : "2X"
+    }
+
     # set project settings UI defaults in case the project is reopened
     # otherwise some UI elements get set to None on reopened new projects
     def set_project_ui_defaults(self, default_fps):
         self.project_fps = default_fps
-        self.split_type = "Scene"
-        self.scene_threshold = 0.6
-        self.break_duration = 2.0
-        self.break_ratio = 0.98
-        self.thumbnail_type = "JPG"
-        self.resynthesize = True
-        self.inflate = True
-        self.resize = True
-        self.upscale = True
-        self.upscale_option = "2X"
+        self.deinterlace = self.UI_SAFETY_DEFAULTS["deinterlace"]
+        self.split_type = self.UI_SAFETY_DEFAULTS["split_type"]
+        self.scene_threshold = self.UI_SAFETY_DEFAULTS["scene_threshold"]
+        self.break_duration = self.UI_SAFETY_DEFAULTS["break_duration"]
+        self.break_ratio = self.UI_SAFETY_DEFAULTS["break_ratio"]
+        self.thumbnail_type = self.UI_SAFETY_DEFAULTS["thumbnail_type"]
+        self.resize = self.UI_SAFETY_DEFAULTS["resize"]
+        self.resynthesize = self.UI_SAFETY_DEFAULTS["resynthesize"]
+        self.inflate = self.UI_SAFETY_DEFAULTS["inflate"]
+        self.upscale = self.UI_SAFETY_DEFAULTS["upscale"]
+        self.upscale_option = self.UI_SAFETY_DEFAULTS["upscale_option"]
 
     # how far progressed into project and the tab ID to return to on re-opening
     PROGRESS_STEPS = {
@@ -891,3 +906,6 @@ class VideoRemixerState():
                 else:
                     message = error
                 raise ValueError(message)
+
+    def tryattr(self, attribute : str, default=None):
+        return getattr(self, attribute) if hasattr(self, attribute) else default


### PR DESCRIPTION
If opening a project.yaml file that's missing an important attribute, use a default value instead