### PR TITLE
Video Remix Clean up

### DIFF
--- a/tabs/video_remixer_ui.py
+++ b/tabs/video_remixer_ui.py
@@ -215,7 +215,7 @@ class VideoRemixer(TabBase):
                     message_box5 = gr.Textbox(
                         value="Next: Perform all Processing Steps (takes from hours to days)",
                                               show_label=False, interactive=False)
-                    gr.Markdown("*Progress can be tracked in the console*")
+                    gr.Markdown(SimpleIcons.WARNING + " Make backups if redoing this step. Processed content may be purged based on the above settings.\r\n*Progress can be tracked in the console*")
                     with gr.Row():
                         back_button5 = gr.Button(value="< Back", variant="secondary").\
                             style(full_width=False)

--- a/tabs/video_remixer_ui.py
+++ b/tabs/video_remixer_ui.py
@@ -747,17 +747,14 @@ class VideoRemixer(TabBase):
 
     # User has clicked Process Remix from Processing Options
     def next_button5(self, resynthesize, inflate, resize, upscale, upscale_option):
-        global_options = self.config.ffmpeg_settings["global_options"]
         self.state.resynthesize = resynthesize
         self.state.inflate = inflate
         self.state.resize = resize
         self.state.upscale = upscale
-
         upscale_option_changed = False
         if self.state.upscale_option != None and self.state.upscale_option != upscale_option:
             upscale_option_changed = True
         self.state.upscale_option = upscale_option
-
         self.log("saving project after storing processing choices")
         self.state.save()
 

--- a/video_remixer.py
+++ b/video_remixer.py
@@ -778,9 +778,18 @@ class VideoRemixerState():
                                                     output_basename, "png")
                 Mtqdm().update_bar(bar)
 
+    def remix_filename_suffix(self):
+        label = "remix"
+        label += "-rc" if self.resize else "-or"
+        label += "-re" if self.resynthesize else ""
+        label += "-in" if self.inflate else ""
+        label += "-up" + self.upscale_option[0] if self.upscale else ""
+        return label
+
     def default_remix_filepath(self):
         _, filename, _ = split_filepath(self.source_video)
-        return os.path.join(self.project_path, f"{filename}-remixed.mp4")
+        suffix = self.remix_filename_suffix()
+        return os.path.join(self.project_path, f"{filename}-{suffix}.mp4")
 
     # find scenes that are empty now after processing and should be automatically dropped
     # this can happen when resynthesis and/or inflation are used on scenes with only a few frames


### PR DESCRIPTION
- Display a message on the _Processing Options_ tab about backing up content. About it:
    - After creating a remix video, if using the _Processing Options_ tab again with different settings, previous processed content may be purged because it is _stale_
    - Back up any important previously processed content, e.g. by renaming a directory such as `SCENES-RC` to something else `SCENES-RC-saved` 
- Prepare a smarter default filename for the remix video based. About it:
    - The suggested filename now includes a suffix based on the chosen processing options
    - This makes it easier to try different options without overwrite previous remix videos