### PR TITLE
Some minor tweaks to Video Remixer

### DIFF
--- a/tabs/video_remixer_ui.py
+++ b/tabs/video_remixer_ui.py
@@ -288,8 +288,10 @@ class VideoRemixer(TabBase):
 
         next_button1.click(self.next_button1,
                            inputs=[project_path, project_fps, split_type, scene_threshold,
-                    break_duration, break_ratio, resize_w, resize_h, crop_w, crop_h, deinterlace],
-                           outputs=[tabs_video_remixer, message_box1, project_info2, message_box2])
+                                break_duration, break_ratio, resize_w, resize_h, crop_w, crop_h,
+                                deinterlace],
+                           outputs=[tabs_video_remixer, message_box1, project_info2, message_box2,
+                                project_load_path])
 
         back_button1.click(self.back_button1, outputs=tabs_video_remixer)
 
@@ -524,7 +526,8 @@ class VideoRemixer(TabBase):
         return gr.update(selected=2), \
                gr.update(visible=True), \
                self.state.project_info2, \
-              "Next: Create Scenes, Thumbnails and Audio Clips (takes from minutes to hours)"
+              "Next: Create Scenes, Thumbnails and Audio Clips (takes from minutes to hours)", \
+              project_path
 
     def back_button1(self):
         return gr.update(selected=0)

--- a/video_remixer.py
+++ b/video_remixer.py
@@ -222,7 +222,9 @@ class VideoRemixerState():
     def save_original_video(self, prevent_overwrite=True):
         _, filename, ext = split_filepath(self.source_video)
         video_filename = filename + ext
-        project_video_path = os.path.join(self.project_path, video_filename)
+        # remove single quotes that cause issues with FFmpeg
+        filtered_filename = video_filename.replace("'", "")
+        project_video_path = os.path.join(self.project_path, filtered_filename)
 
         if os.path.exists(project_video_path) and prevent_overwrite:
             raise ValueError(

--- a/video_remixer.py
+++ b/video_remixer.py
@@ -322,6 +322,8 @@ class VideoRemixerState():
             return None
         except ValueError as error:
             return error
+        except RuntimeError as error:
+            return error
 
     THUMBNAILS_PATH = "THUMBNAILS"
 

--- a/webui_utils/video_utils.py
+++ b/webui_utils/video_utils.py
@@ -497,7 +497,11 @@ def get_detected_breaks(input_path : str, duration : float=0.5, ratio : float=0.
     end_frames = [
         int(line.split("=")[1]) for line in stdout_lines if line.startswith("lavfi.black_end")]
     if len(start_frames) != len(end_frames):
-        raise RuntimeError("unable to parse detected breaks")
+        # it could be the last break never ended
+        if len(end_frames) == len(start_frames) - 1:
+            del start_frames[-1]
+        else:
+            raise RuntimeError("unable to parse detected breaks")
 
     breaks = []
     for index, start in enumerate(start_frames):


### PR DESCRIPTION
- When copying the source video file into the remix directory, strip single quotes from the filename (for example, used as apostrophes). This is needed to avoid problems later when passing filenames to FFmpeg, where there is already a mixture of quote types in use and this wreaks havoc
- If a video ends with a break (fade to black) FFmpeg doesn't detect an end to the break, and this app was requiring a matching set of stop and end points. Now, if the end point list is short by one, i.e., the last break didn't end, the mismatched break start is deleted
- Once the project path is established, copy it back to the first tab, so it's easy to go back and reload the project (mostly helpful for development, after stopping and restarting)