### PR TITLE
Added to Video Remixer: Portable Projects

### DIFF
--- a/tabs/video_remixer_ui.py
+++ b/tabs/video_remixer_ui.py
@@ -438,13 +438,13 @@ class VideoRemixer(TabBase):
             return gr.update(selected=0), \
                    gr.update(visible=True,
         value="Enter a path to a Video Remixer project directory on this server to get started"), \
-                   *self.empty_args(26)
+                   *self.empty_args(27)
 
         if not os.path.exists(project_path):
             return gr.update(selected=0), \
                    gr.update(visible=True,
                              value=f"Directory {project_path} was not found"), \
-                   *self.empty_args(26)
+                   *self.empty_args(27)
 
         try:
             project_file = self.state.determine_project_filepath(project_path)
@@ -452,7 +452,7 @@ class VideoRemixer(TabBase):
             return gr.update(selected=0), \
                    gr.update(visible=True,
                              value=error), \
-                   *self.empty_args(26)
+                   *self.empty_args(27)
 
         try:
             self.state = VideoRemixerState.load(project_file)
@@ -461,14 +461,24 @@ class VideoRemixer(TabBase):
             return gr.update(selected=0), \
                    gr.update(visible=True,
                              value=error), \
-                   *self.empty_args(26)
+                   *self.empty_args(27)
 
-        entered_path, _, _ = split_filepath(project_file)
-        if self.state.project_path != entered_path:
-            return gr.update(selected=0), \
-                   gr.update(visible=True,
-        value=f"Portability will be added later, for now open from: '{self.state.project_path}'"), \
-                   *self.empty_args(26)
+        if self.state.project_ported(project_file):
+            try:
+                self.state = VideoRemixerState.load_ported(self.state.project_path, project_file)
+            except ValueError as error:
+                self.log(f"error opening ported project at {project_file}: {error}")
+                return gr.update(selected=0), \
+                    gr.update(visible=True,
+                                value=error), \
+                    *self.empty_args(27)
+
+        # entered_path, _, _ = split_filepath(project_file)
+        # if self.state.project_path != entered_path:
+        #     return gr.update(selected=0), \
+        #            gr.update(visible=True,
+        # value=f"Portability will be added later, for now open from: '{self.state.project_path}'"), \
+        #            *self.empty_args(27)
 
         return_to_tab = self.state.get_progress_tab()
         scene_details = self.scene_chooser_details(self.state.tryattr("current_scene"))

--- a/video_remixer.py
+++ b/video_remixer.py
@@ -1053,6 +1053,100 @@ class VideoRemixerState():
             Mtqdm().update_bar(bar)
         return ffcmd
 
+    # returns validated version of path and files, and an optional messages str
+    def ensure_valid_populated_path(self, description : str, path : str, files : list | None=None):
+        if not path:
+            return None, None, None
+
+        messages = Jot()
+        if not os.path.exists(path):
+            messages.add(f"{description} path '{path}' not found - recreating")
+            create_directory(path)
+
+        path_files = get_files(path)
+        file_count = len(files)
+        path_file_count = len(path_files)
+
+        if not files and not path_files:
+            return path, [], messages.report()
+
+        if not files and path_files:
+            messages.add(f"{description} path '{path}' has {path_file_count} files unknown to the project. The files are being ignored (safe to delete).")
+            return path, [], messages.report()
+
+        if path_file_count != file_count:
+            messages.add(f"{description} path '{path}' should have {file_count} files but has {path_file_count}. The files are being ignored (safe to delete).")
+            return path, [], messages.report()
+
+        # TODO further possible checks: files have bytes, files are found to be the right binary type, etc
+
+        return path, files, messages.report()
+
+    # returns validated version of path, and an optional messages str
+    def ensure_valid_path(self, description : str, path : str, files : list | None=None):
+        if not path:
+            return None, None
+
+        messages = Jot()
+        if not os.path.exists(path):
+            messages.add(f"{description} path '{path}' not found - recreating")
+            create_directory(path)
+
+        return path, messages.report()
+
+    def post_load_integrity_check(self):
+        messages = Jot()
+
+        self.thumbnail_path, self.thumbnails, message = self.ensure_valid_populated_path("Thumbnails", self.thumbnail_path, self.thumbnails)
+        if message:
+            messages.add(message)
+
+        self.clips_path, self.clips, message = self.ensure_valid_populated_path("Clips", self.clips_path, self.clips)
+        if message:
+            messages.add(message)
+
+        self.audio_clips_path, self.audio_clips, message = self.ensure_valid_populated_path("Audio Clips", self.audio_clips_path, self.audio_clips)
+        if message:
+            messages.add(message)
+
+        self.video_clips_path, self.video_clips, message = self.ensure_valid_populated_path("Video Clips", self.video_clips_path, self.video_clips)
+        if message:
+            messages.add(message)
+
+        self.dropped_scenes_path, message = self.ensure_valid_path("Dropped Scenes", self.dropped_scenes_path)
+        if message:
+            messages.add(message)
+
+        self.frames_path, message = self.ensure_valid_path("Frames Path", self.frames_path)
+        if message:
+            messages.add(message)
+
+        self.inflation_path, message = self.ensure_valid_path("Inflation Path", self.inflation_path)
+        if message:
+            messages.add(message)
+
+        self.inflation_path, message = self.ensure_valid_path("Inflation Path", self.inflation_path)
+        if message:
+            messages.add(message)
+
+        self.resize_path, message = self.ensure_valid_path("Resize Path", self.resize_path)
+        if message:
+            messages.add(message)
+
+        self.resynthesis_path, message = self.ensure_valid_path("Resynthesis Path", self.resynthesis_path)
+        if message:
+            messages.add(message)
+
+        self.scenes_path, message = self.ensure_valid_path("Scenes Path", self.scenes_path)
+        if message:
+            messages.add(message)
+
+        self.upscale_path, message = self.ensure_valid_path("Upscale Path", self.upscale_path)
+        if message:
+            messages.add(message)
+
+        return messages.report()
+
     @staticmethod
     def load(filepath : str):
         with open(filepath, "r") as file:
@@ -1083,9 +1177,6 @@ class VideoRemixerState():
                     message = error
                 raise ValueError(message)
 
-
-# ported_profile_file should have document stripped before being used for paths
-
     @staticmethod
     def load_ported(original_project_path, ported_project_file : str):
         original_project_path, _ = os.path.split(original_project_path)
@@ -1097,21 +1188,59 @@ class VideoRemixerState():
         backup_filepath = \
             AutoIncrementBackupFilename(ported_project_file, backup_path).next_filepath()
         shutil.copy(ported_project_file, backup_filepath)
+
+        # lose the last path segement, that's the actual project directory
         new_path, _ = os.path.split(new_path)
+        original_project_path
+
+        if new_path[-1] != "\\":
+            new_path += "\\"
+        if original_project_path[-1] != "\\":
+            original_project_path += "\\"
 
         lines = []
         with open(ported_project_file, "r", encoding="UTF-8") as file:
             lines = file.readlines()
         new_lines = []
 
+        # Some values are saved within double-doubles, causing them to appear in the .yaml file
+        # with properly esscaped backslashes, for example the info fields and file paths.
+        # Some values are saved raw with no quotes, and no esscaping is needed by the yaml parser
+        # When reading the .yaml file as a text file and attempting to update all the old paths,
+        # both representations are presented the same way, so there's no way to separately update
+        # the escaped ones from the non-escaped ones
+        skip_lines = ["video_info1", "project_info2", "project_info4", "summary_info6"]
+        # this fix only happens to work because on the first line when these have multiple lines
+
         for line in lines:
-            new_line = line.replace(original_project_path, new_path)
+            skip = False
+            for skip_line in skip_lines:
+                if line.startswith(skip_line):
+                    skip = True
+                    break
+            if skip:
+                new_line = line
+            else:
+                new_line = line.replace(original_project_path, new_path)
             new_lines.append(new_line)
 
         with open(ported_project_file, "w", encoding="UTF-8") as file:
             file.writelines(new_lines)
 
-        return VideoRemixerState.load(ported_project_file)
+        state = VideoRemixerState.load(ported_project_file)
+
+        # fix up the skipped lines
+        if state.video_info1:
+            state.video_info1 = state.video_info1.replace(original_project_path, new_path)
+        if state.project_info2:
+            state.project_info2 = state.project_info2.replace(original_project_path, new_path)
+        if state.project_info4:
+            state.project_info4 = state.project_info2.replace(original_project_path, new_path)
+        if state.summary_info6:
+            state.summary_info6 = state.summary_info6.replace(original_project_path, new_path)
+        state.save()
+
+        return state
 
     def tryattr(self, attribute : str, default=None):
         return getattr(self, attribute) if hasattr(self, attribute) else default

--- a/webui_utils/auto_increment.py
+++ b/webui_utils/auto_increment.py
@@ -1,6 +1,7 @@
 """Classes for managing auto-incrementing files and directories"""
 import os
-from .file_utils import get_files, get_directories, is_safe_path
+import glob
+from .file_utils import get_files, get_directories, is_safe_path, split_filepath
 
 class AutoIncrementFilename():
     """Encapsulates logic to create new unique sequentially-numbered filenames"""
@@ -46,3 +47,18 @@ class AutoIncrementDirectory():
                 raise ValueError("'basename' must be a non-empty string")
         else:
             raise ValueError("'basename' must be a string")
+
+class AutoIncrementBackupFilename():
+    """Encapsulates logic to save a uniquely numbered backup file"""
+    def __init__(self, filepath : str, backup_path : str):
+        self.filepath = filepath
+        self.backup_path = backup_path
+
+    def next_filepath(self):
+        _, filename, ext = split_filepath(self.filepath)
+        filename_filter = f"{filename}*{ext}"
+        filepath = os.path.join(self.backup_path, filename_filter)
+        files = glob.glob(filepath)
+        count = len(files)
+        next_filename = f"{filename}{count+1}{ext}"
+        return os.path.join(self.backup_path, next_filename )

--- a/webui_utils/jot.py
+++ b/webui_utils/jot.py
@@ -22,6 +22,7 @@ class Jot():
     def down(self, text=BLANK):
         """Jot down something in the report, turns argument into a string"""
         self.lines.append(str(text))
+    add = down
 
     def grab(self):
         """Grab a current version of the report"""
@@ -31,6 +32,7 @@ class Jot():
             _report.append(self.BLANK)
         _report += self.lines
         return "\r\n".join(_report)
+    report = grab
 
     def keep(self):
         """Keep the report on disk if there's a filename, returns the lines list"""
@@ -38,9 +40,11 @@ class Jot():
             with open(self.file, "w", encoding="UTF-8") as file:
                 file.write(self.grab())
         return self.lines
+    save = keep
 
     def wipe(self):
         """Wipe out the current report, returns the former lines list"""
         lines_before = self.lines
         self.lines = []
         return lines_before
+    clear = wipe


### PR DESCRIPTION
TL;DR: _Video Remixer_ projects can be moved **intact** and reopened 

- When opening a project, the stored project path is compared to the opened one
    - If they differ, the `project.yaml` file is updated to reflect the new project path
    - All paths are rehomed to the new root project path
- Also, integrity checks have been added on opening a project
    - On opening, the various paths in use are checked against what's on disk
    - Missing paths are recreated
    - Paths with missing or partial content are presumed empty (excess files are not purged)
    - This makes it "safe" to open projects in just about any degraded state
    - Note: missing content is not checked for nor considered for recreation
