### PR TITLE
minor fix: opened ported project fills wrong field

### DIFF
--- a/video_remixer.py
+++ b/video_remixer.py
@@ -1235,7 +1235,7 @@ class VideoRemixerState():
         if state.project_info2:
             state.project_info2 = state.project_info2.replace(original_project_path, new_path)
         if state.project_info4:
-            state.project_info4 = state.project_info2.replace(original_project_path, new_path)
+            state.project_info4 = state.project_info4.replace(original_project_path, new_path)
         if state.summary_info6:
             state.summary_info6 = state.summary_info6.replace(original_project_path, new_path)
         state.save()


### PR DESCRIPTION
The scene selection summary gets clobbered by the project setup summary on loading a ported (moved) project