### PR TITLE
Video Remixer: New config setting to use MP3 instead of WAV audio

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -96,6 +96,7 @@ realesrgan_settings:
   tile_pad: 10
   tiling: 256
 remixer_settings:
+  audio_format: wav
   default_crf: 23
   def_project_fps: 29.97
   default_gif_fps: 10

--- a/tabs/video_remixer_ui.py
+++ b/tabs/video_remixer_ui.py
@@ -896,7 +896,8 @@ class VideoRemixer(TabBase):
 
         if self.state.video_details["has_audio"] and not self.state.processed_content_present("audio"):
             self.log("about to create audio clips")
-            self.state.create_audio_clips(self.log, global_options)
+            audio_format = self.config.remixer_settings["audio_format"]
+            self.state.create_audio_clips(self.log, global_options, audio_format=audio_format)
             self.log("saving project after creating audio clips")
             self.state.save()
 
@@ -948,7 +949,8 @@ class VideoRemixer(TabBase):
 
         if self.state.video_details["has_audio"] and not self.state.processed_content_present("audio"):
             self.log("about to create audio clips")
-            self.state.create_audio_clips(self.log, global_options)
+            audio_format = self.config.remixer_settings["audio_format"]
+            self.state.create_audio_clips(self.log, global_options, audio_format=audio_format)
             self.log("saving project after creating audio clips")
             self.state.save()
 

--- a/video_remixer.py
+++ b/video_remixer.py
@@ -918,7 +918,7 @@ class VideoRemixerState():
 
     AUDIO_CLIPS_PATH = "AUDIO"
 
-    def create_audio_clips(self, log_fn, global_options, audio_format="wav"):
+    def create_audio_clips(self, log_fn, global_options, audio_format):
         self.audio_clips_path = os.path.join(self.clips_path, self.AUDIO_CLIPS_PATH)
         create_directory(self.audio_clips_path)
         # save the project now to preserve the newly established path

--- a/video_remixer.py
+++ b/video_remixer.py
@@ -918,7 +918,7 @@ class VideoRemixerState():
 
     AUDIO_CLIPS_PATH = "AUDIO"
 
-    def create_audio_clips(self, log_fn, global_options):
+    def create_audio_clips(self, log_fn, global_options, audio_format="wav"):
         self.audio_clips_path = os.path.join(self.clips_path, self.AUDIO_CLIPS_PATH)
         create_directory(self.audio_clips_path)
         # save the project now to preserve the newly established path
@@ -930,7 +930,7 @@ class VideoRemixerState():
                     self.scenes_path,
                     self.audio_clips_path,
                     0.0,
-                    "wav",
+                    audio_format,
                     0,
                     1,
                     edge_trim,


### PR DESCRIPTION
.WAV audio is used by default for creating remix videos. I ran into an issue where the AAC encoder didn't like the .WAV files sliced from the video for some reason and threw a fatal error. I found using MP3 instead for the audio clip circumvented the issue.

The setting is

```yaml
remixer_settings:
  audio_format: wav # or mp3
````

This workaround is recommend if you run into this issue. I don't recommend leaving is set this way since .MP3 files are lossy-encoded.