### PR TITLE
Video Remixer: move purged content instead of deleting

### DIFF
--- a/guide/video_remixer_processing.md
+++ b/guide/video_remixer_processing.md
@@ -15,6 +15,11 @@
 1. Click _Process Remix_ to kick off the processing
 - Progress can be tracked in the console
 
+## Note
+- Content may be _purged_ (soft-deleted) when clicking _Process Remix_
+    - Previous process content not currently needed is set aside
+- Purged content my be recovered from the `purged_content` project directory
+
 ## ⚠️Important⚠️
 - **THIS PROCESS COULD BE SLOW, POSSIBLY MANY HOURS OR DAYS!!!**
 - The browser window does NOT need to be left open

--- a/tabs/video_remixer_ui.py
+++ b/tabs/video_remixer_ui.py
@@ -219,7 +219,6 @@ class VideoRemixer(TabBase):
                     message_box5 = gr.Textbox(
                         value="Next: Perform all Processing Steps (takes from hours to days)",
                                               show_label=False, interactive=False)
-                    gr.Markdown(SimpleIcons.WARNING + " Make backups if redoing this step. Processed content may be purged based on the above settings.\r\n*Progress can be tracked in the console*")
                     with gr.Row():
                         back_button5 = gr.Button(value="< Back", variant="secondary").\
                             style(full_width=False)
@@ -902,7 +901,7 @@ class VideoRemixer(TabBase):
             self.state.save()
 
         # always recreate video and scene clips
-        self.state.purge_remix_content(purge_from="video_clips")
+        self.state.clean_remix_content(purge_from="video_clips")
 
         self.log(f"about to create video clips")
         self.state.create_video_clips(self.log, kept_scenes, global_options)
@@ -959,7 +958,7 @@ class VideoRemixer(TabBase):
         output_ext = output_ext[1:]
 
         # always recreate video and scene clips
-        self.state.purge_remix_content(purge_from="video_clips")
+        self.state.clean_remix_content(purge_from="video_clips")
 
         self.log(f"about to create video clips")
         self.state.create_custom_video_clips(self.log, kept_scenes, global_options,

--- a/webui_utils/file_utils.py
+++ b/webui_utils/file_utils.py
@@ -50,7 +50,7 @@ def remove_files(path : str, unsafe=False):
                 os.remove(file)
 
 # remove the files found in each of the passed directories (no recursion)
-def purge_directories(dirs : list):
+def clean_directories(dirs : list):
     for _dir in dirs:
         remove_files(_dir)
 


### PR DESCRIPTION
When content needs to be removed automatically, for example, if _Resynthesize_ frames are not needed to process a remix, they are now moved to an  auto-incrementing `purgedN` directory under the project directory `purged_content`.
- Formerly content was removed by permanently deleting it 😱
- This change helps prevent hours/days of processing work from being accidentally lost
- Note: The `purged_content` folder can potentially grow very large so should be checked periodically

