### PR TITLE
Video Remixer: Add Remix Extra tab

### DIFF
--- a/guide/video_remixer_save.md
+++ b/guide/video_remixer_save.md
@@ -36,7 +36,7 @@ _Disclaimer: these are proofs of concept, but not necessarily great recommendati
 | MPEG-PS | `-c:v mpeg2video -pix_fmt yuv422p -bf 2 -b:v 10M -maxrate 10M -minrate 10M -s 640x480 -aspect 4:3` | `-c:a pcm_s16be -f vob` | video.vob | Video+sound played great (with VLC)* |
 | WMV | (left blank) | (left blank) | video.wmv | Video+sound played but was very low quality** |
 | AVI | (left blank) | (left blank) | video.avi | Video+sound played but was very low quality** |
-| MP4 | `-vf "drawtext=text='<SCENE_INFO>':x=(w-text_w)/2:y=h-(text_h*2):fontsize=22:fontcolor=yellow:fontfile='fonts/trim.ttf'" -c:v libx264 -crf 23` | `-c:a aac` | video.mp4 | Standard MP4 remix video with scene name label*** |
+| MP4 | `-vf "drawtext=text='<SCENE_INFO>':x=(w-text_w)/2:y=h-(text_h*2):fontsize=(h/20):fontcolor=yellow:fontfile='fonts/trim.ttf'" -c:v libx264 -crf 23` | `-c:a aac` | video.mp4 | Standard MP4 remix video with scene name label*** |
 
 _* The console showed many buffer underrun errors while concatenating into remix video_
 

--- a/tabs/video_remixer_ui.py
+++ b/tabs/video_remixer_ui.py
@@ -279,85 +279,91 @@ class VideoRemixer(TabBase):
                     with gr.Tab(label="Utilities"):
                         with gr.Tabs():
                             with gr.Tab("Drop Processed Scene"):
-                                gr.Markdown("**Drop Processed Scene** - Drop a scene after processing has been compeleted")
-                                scene_id_710 = gr.Number(value=-1, label="Scene Index")
+                                gr.Markdown("**_Drop a scene after processing has been already been done_**")
+                                scene_id_700 = gr.Number(value=-1, label="Scene Index")
                                 with gr.Row():
-                                    message_box710 = gr.Textbox(show_label=False, interactive=False)
-                                drop_button710 = gr.Button("Drop Scene", variant="stop").style(full_width=True)
+                                    message_box700 = gr.Textbox(show_label=False, interactive=False)
+                                drop_button700 = gr.Button("Drop Scene", variant="stop").style(full_width=True)
 
-                    with gr.Tab(label="Reduce Footprint " + SimpleIcons.CONSTRUCTION):
+                    with gr.Tab(label="Reduce Footprint"):
                         with gr.Tabs():
                             with gr.Tab(label="Remove Soft-Deleted Content"):
-                                gr.Markdown("**_Delete content that has been moved to the_** `purged_content` **_directory_**")
+                                gr.Markdown("**_Delete content set aside when remix processing selections are changed_**")
                                 with gr.Row():
-                                    gr.Checkbox(label="Permanently Delete Purged Content " + SimpleIcons.CONSTRUCTION)
+                                    delete_purged_710 = gr.Checkbox(label="Permanently Delete Purged Content")
                                     with gr.Box():
-                                        gr.Markdown("Delete content that has been set aisde in the 'purged_content' directory.")
+                                        gr.Markdown("Delete the contents of the 'purged_content' project directory.")
                                 with gr.Row():
-                                    gr.Textbox(show_label=False)
+                                    message_box710 = gr.Textbox(show_label=False)
                                 gr.Markdown("*Progress can be tracked in the console*")
                                 with gr.Row():
-                                    gr.Button(value="Delete Purged Content " + SimpleIcons.SLOW_SYMBOL, variant="stop")
-                                    gr.Button(value="Select All").style(full_width=False)
-                                    gr.Button(value="Select None").style(full_width=False)
+                                    delete_button710 = gr.Button(value="Delete Purged Content " + SimpleIcons.SLOW_SYMBOL, variant="stop")
+                                    select_all_button710 = gr.Button(value="Select All").style(full_width=False)
+                                    select_none_button710 = gr.Button(value="Select None").style(full_width=False)
+
                             with gr.Tab(label="Remove Scene Chooser Content"):
-                                gr.Markdown("**_Clear space after final scene choices have been made_**")
+                                gr.Markdown("**_Delete source PNG frame files, thumbnails and dropped scenes_**")
                                 with gr.Row():
-                                    gr.Checkbox(label="Remove Source Video Frames " + SimpleIcons.CONSTRUCTION)
+                                    delete_source_711 = gr.Checkbox(label="Remove Source Video Frames")
                                     with gr.Box():
                                         gr.Markdown("Delete source video PNG frame files used to split content into scenes.")
                                 with gr.Row():
-                                    gr.Checkbox(label="Remove Dropped Scenes " + SimpleIcons.CONSTRUCTION)
+                                    delete_dropped_711 = gr.Checkbox(label="Remove Dropped Scenes")
                                     with gr.Box():
                                         gr.Markdown("Delete Dropped Scene files used when compiling scenes after making scene choices.")
                                 with gr.Row():
-                                    gr.Checkbox(label="Remove Thumbnails " + SimpleIcons.CONSTRUCTION)
+                                    delete_thumbs_711 = gr.Checkbox(label="Remove Thumbnails")
                                     with gr.Box():
                                         gr.Markdown("Delete Thumbnails used to display scenes in Scene Chooser.")
                                 with gr.Row():
-                                    gr.Textbox(show_label=False)
+                                    message_box711 = gr.Textbox(show_label=False)
                                 gr.Markdown("*Progress can be tracked in the console*")
                                 with gr.Row():
-                                    gr.Button(value="Purge Selected Content " + SimpleIcons.SLOW_SYMBOL, variant="stop")
-                                    gr.Button(value="Select All").style(full_width=False)
-                                    gr.Button(value="Select None").style(full_width=False)
+                                    delete_button711 = gr.Button(value="Delete Selected Content " + SimpleIcons.SLOW_SYMBOL, variant="stop")
+                                    select_all_button711 = gr.Button(value="Select All").style(full_width=False)
+                                    select_none_button711 = gr.Button(value="Select None").style(full_width=False)
+
                             with gr.Tab(label="Remove Remix Video Source Content"):
                                 gr.Markdown("**_Clear space after final Remix Videos have been saved_**")
                                 with gr.Row():
-                                    gr.Checkbox(label="Remove Resized Frames " + SimpleIcons.CONSTRUCTION)
+                                    delete_kept_712 = gr.Checkbox(label="Remove Kept Scenes")
+                                    with gr.Box():
+                                        gr.Markdown("Delete Kept Scene files used when compiling scenes after making scene choices.")
+                                with gr.Row():
+                                    delete_resized_712 = gr.Checkbox(label="Remove Resized Frames")
                                     with gr.Box():
                                         gr.Markdown("Delete Resized PNG frame files used as inputs for processing and creating remix video clips.")
                                 with gr.Row():
-                                    gr.Checkbox(label="Remove Resynthesized Frames " + SimpleIcons.CONSTRUCTION)
+                                    delete_resynth_712 = gr.Checkbox(label="Remove Resynthesized Frames")
                                     with gr.Box():
                                         gr.Markdown("Delete Resynthesized PNG frame files used as inputs for processing and creating remix video clips.")
                                 with gr.Row():
-                                    gr.Checkbox(label="Remove Inflated Frames " + SimpleIcons.CONSTRUCTION)
+                                    delete_inflated_712 = gr.Checkbox(label="Remove Inflated Frames")
                                     with gr.Box():
                                         gr.Markdown("Delete Inflated PNG frame files used as inputs for processing and creating remix video clips.")
                                 with gr.Row():
-                                    gr.Checkbox(label="Remove Upscaled Frames " + SimpleIcons.CONSTRUCTION)
+                                    delete_upscaled_712 = gr.Checkbox(label="Remove Upscaled Frames")
                                     with gr.Box():
                                         gr.Markdown("Delete Upscaled PNG frame files used as inputs for processing and creating remix video clips.")
                                 with gr.Row():
-                                    gr.Checkbox(label="Delete Audio Clips " + SimpleIcons.CONSTRUCTION)
+                                    delete_audio_712 = gr.Checkbox(label="Delete Audio Clips")
                                     with gr.Box():
                                         gr.Markdown("Delete Audio WAV/MP3 files used as inputs for creating remix video clips.")
                                 with gr.Row():
-                                    gr.Checkbox(label="Delete Video Clips " + SimpleIcons.CONSTRUCTION)
+                                    delete_video_712 = gr.Checkbox(label="Delete Video Clips")
                                     with gr.Box():
                                         gr.Markdown("Delete Video MP4 files used as inputs for creating remix video clips.")
                                 with gr.Row():
-                                    gr.Checkbox(label="Delete Remix Video Clips " + SimpleIcons.CONSTRUCTION)
+                                    delete_clips_712 = gr.Checkbox(label="Delete Remix Video Clips")
                                     with gr.Box():
                                         gr.Markdown("Delete Video+Audio MP4 files used as inputs to concatentate into the final Remix Video.")
                                 with gr.Row():
-                                    gr.Textbox(show_label=False)
+                                    message_box712 = gr.Textbox(show_label=False)
                                 gr.Markdown("*Progress can be tracked in the console*")
                                 with gr.Row():
-                                    gr.Button(value="Purge Selected Content " + SimpleIcons.SLOW_SYMBOL, variant="stop")
-                                    gr.Button(value="Select All").style(full_width=False)
-                                    gr.Button(value="Select None").style(full_width=False)
+                                    delete_button712 = gr.Button(value="Delete Selected Content " + SimpleIcons.SLOW_SYMBOL, variant="stop")
+                                    select_all_button712 = gr.Button(value="Select All").style(full_width=False)
+                                    select_none_button712 = gr.Button(value="Select None").style(full_width=False)
 
                     # with gr.Accordion(SimpleIcons.TIPS_SYMBOL + " Guide", open=False):
                     #     WebuiTips.video_remixer_save.render()
@@ -479,7 +485,37 @@ class VideoRemixer(TabBase):
 
         back_button61.click(self.back_button6, outputs=tabs_video_remixer)
 
-        drop_button710.click(self.drop_button710, inputs=scene_id_710, outputs=message_box710)
+        drop_button700.click(self.drop_button700, inputs=scene_id_700, outputs=message_box700)
+
+        delete_button710.click(self.delete_button710,
+                               inputs=delete_purged_710,
+                               outputs=message_box710)
+        select_all_button710.click(self.select_all_button710, show_progress=False,
+                                outputs=[delete_purged_710])
+        select_none_button710.click(self.select_none_button710, show_progress=False,
+                                outputs=[delete_purged_710])
+
+        delete_button711.click(self.delete_button711,
+                               inputs=[delete_source_711, delete_dropped_711, delete_thumbs_711],
+                               outputs=message_box711)
+        select_all_button711.click(self.select_all_button711, show_progress=False,
+                                outputs=[delete_source_711, delete_dropped_711, delete_thumbs_711])
+        select_none_button711.click(self.select_none_button711, show_progress=False,
+                                outputs=[delete_source_711, delete_dropped_711, delete_thumbs_711])
+
+        delete_button712.click(self.delete_button712,
+                               inputs=[delete_kept_712, delete_resized_712, delete_resynth_712,
+                                       delete_inflated_712, delete_upscaled_712, delete_audio_712,
+                                       delete_video_712, delete_clips_712],
+                                outputs=message_box712)
+        select_all_button712.click(self.select_all_button712, show_progress=False,
+                                outputs=[delete_kept_712, delete_resized_712, delete_resynth_712,
+                                         delete_inflated_712, delete_upscaled_712, delete_audio_712,
+                                         delete_video_712, delete_clips_712])
+        select_none_button712.click(self.select_none_button712, show_progress=False,
+                                outputs=[delete_kept_712, delete_resized_712, delete_resynth_712,
+                                         delete_inflated_712, delete_upscaled_712,
+                                         delete_audio_712, delete_video_712, delete_clips_712])
 
     def empty_args(self, num):
         return [None for _ in range(num)]
@@ -1080,7 +1116,7 @@ class VideoRemixer(TabBase):
     def back_button6(self):
         return gr.update(selected=5)
 
-    def drop_button710(self, scene_index):
+    def drop_button700(self, scene_index):
         if isinstance(scene_index, (int, float)):
             scene_index = int(scene_index)
             if 0 <= scene_index < len(self.state.scene_names):
@@ -1098,3 +1134,80 @@ class VideoRemixer(TabBase):
         else:
             message = f"Please enter a Scene Index to get started"
         return gr.update(visible=True, value=message)
+
+    def delete_button710(self, delete_purged):
+        if delete_purged:
+            self.log("about to remove content from 'purged_content' directory")
+            removed = self.state.delete_purged_content()
+            message = f"Removed: {removed}"
+            return gr.update(visible=True, value=message)
+
+    def select_all_button710(self):
+        return gr.update(value=True)
+
+    def select_none_button710(self):
+        return gr.update(value=False)
+
+    def delete_button711(self, delete_source, delete_dropped, delete_thumbs):
+        removed = []
+        if delete_source:
+            removed.append(self.state.delete_path(self.state.frames_path))
+        if delete_dropped:
+            removed.append(self.state.delete_path(self.state.dropped_scenes_path))
+        if delete_thumbs:
+            removed.append(self.state.delete_path(self.state.thumbnail_path))
+        removed = "\r\n".join(removed)
+        message = f"Removed:\r\n{removed}"
+        return gr.update(visible=True, value=message)
+
+    def select_all_button711(self):
+        return gr.update(value=True), \
+                gr.update(value=True), \
+                gr.update(value=True)
+
+    def select_none_button711(self):
+        return gr.update(value=False), \
+                gr.update(value=False), \
+                gr.update(value=False)
+
+    def delete_button712(self, delete_kept, delete_resized, delete_resynth, delete_inflated, delete_upscaled, delete_audio, delete_video, delete_clips):
+        removed = []
+        if delete_kept:
+            removed.append(self.state.delete_path(self.state.scenes_path))
+        if delete_resized:
+            removed.append(self.state.delete_path(self.state.resize_path))
+        if delete_resynth:
+            removed.append(self.state.delete_path(self.state.resynthesis_path))
+        if delete_inflated:
+            removed.append(self.state.delete_path(self.state.inflation_path))
+        if delete_upscaled:
+            removed.append(self.state.delete_path(self.state.upscale_path))
+        if delete_audio:
+            removed.append(self.state.delete_path(self.state.audio_clips_path))
+        if delete_video:
+            removed.append(self.state.delete_path(self.state.video_clips_path))
+        if delete_clips:
+            removed.append(self.state.delete_path(self.state.clips_path))
+        removed = "\r\n".join(removed)
+        message = f"Removed:\r\n{removed}"
+        return gr.update(visible=True, value=message)
+
+    def select_all_button712(self):
+        return gr.update(value=True), \
+                gr.update(value=True), \
+                gr.update(value=True), \
+                gr.update(value=True), \
+                gr.update(value=True), \
+                gr.update(value=True), \
+                gr.update(value=True), \
+                gr.update(value=True)
+
+    def select_none_button712(self):
+        return gr.update(value=False), \
+                gr.update(value=False), \
+                gr.update(value=False), \
+                gr.update(value=False), \
+                gr.update(value=False), \
+                gr.update(value=False), \
+                gr.update(value=False), \
+                gr.update(value=False)

--- a/tabs/video_remixer_ui.py
+++ b/tabs/video_remixer_ui.py
@@ -274,10 +274,80 @@ class VideoRemixer(TabBase):
                     with gr.Accordion(SimpleIcons.TIPS_SYMBOL + " Guide", open=False):
                         WebuiTips.video_remixer_save.render()
 
-                ## SAVE REMIX
-                with gr.Tab("Remix Extra", id=7):
-                    gr.Markdown("**Extra Remix Features**")
-                    with gr.Tab(label="Advanced Functions " + SimpleIcons.CONSTRUCTION):
+                ## Remix Extras
+                with gr.Tab("Remix Extras", id=7):
+                    with gr.Tab(label="Project Clean Up"):
+                        with gr.Tabs():
+                            with gr.Tab(label="Remove Soft-Deleted Content"):
+                                with gr.Row():
+                                    gr.Checkbox(label="Permently Delete Purged Content " + SimpleIcons.CONSTRUCTION)
+                                    with gr.Box():
+                                        gr.Markdown("Delete content that has been set aisde in the 'purged_content' directory.")
+                                with gr.Row():
+                                    gr.Textbox(show_label=False)
+                                gr.Markdown("*Progress can be tracked in the console*")
+                                with gr.Row():
+                                    gr.Button(value="Delete Purged Content " + SimpleIcons.SLOW_SYMBOL, variant="stop")
+                                    gr.Button(value="Select All").style(full_width=False)
+                                    gr.Button(value="Select None").style(full_width=False)
+                            with gr.Tab(label="Remove Scene Chooser Content"):
+                                with gr.Row():
+                                    gr.Checkbox(label="Remove Source Video Frames " + SimpleIcons.CONSTRUCTION)
+                                    with gr.Box():
+                                        gr.Markdown("Delete source video PNG frame files used to split content into scenes.")
+                                with gr.Row():
+                                    gr.Checkbox(label="Remove Dropped Scenes " + SimpleIcons.CONSTRUCTION)
+                                    with gr.Box():
+                                        gr.Markdown("Delete Dropped Scene files used when compiling scenes after making scene choices.")
+                                with gr.Row():
+                                    gr.Checkbox(label="Remove Thumbnails " + SimpleIcons.CONSTRUCTION)
+                                    with gr.Box():
+                                        gr.Markdown("Delete Thumbnails used to display scenes in Scene Chooser.")
+                                with gr.Row():
+                                    gr.Textbox(show_label=False)
+                                gr.Markdown("*Progress can be tracked in the console*")
+                                with gr.Row():
+                                    gr.Button(value="Purge Selected Content " + SimpleIcons.SLOW_SYMBOL, variant="stop")
+                                    gr.Button(value="Select All").style(full_width=False)
+                                    gr.Button(value="Select None").style(full_width=False)
+                            with gr.Tab(label="Remove Remix Video Content"):
+                                with gr.Row():
+                                    gr.Checkbox(label="Remove Resized Frames " + SimpleIcons.CONSTRUCTION)
+                                    with gr.Box():
+                                        gr.Markdown("Delete Resized PNG frame files used as inputs for processing and creating remix video clips.")
+                                with gr.Row():
+                                    gr.Checkbox(label="Remove Resynthesized Frames " + SimpleIcons.CONSTRUCTION)
+                                    with gr.Box():
+                                        gr.Markdown("Delete Resynthesized PNG frame files used as inputs for processing and creating remix video clips.")
+                                with gr.Row():
+                                    gr.Checkbox(label="Remove Inflated Frames " + SimpleIcons.CONSTRUCTION)
+                                    with gr.Box():
+                                        gr.Markdown("Delete Inflated PNG frame files used as inputs for processing and creating remix video clips.")
+                                with gr.Row():
+                                    gr.Checkbox(label="Remove Upscaled Frames " + SimpleIcons.CONSTRUCTION)
+                                    with gr.Box():
+                                        gr.Markdown("Delete Upscaled PNG frame files used as inputs for processing and creating remix video clips.")
+                                with gr.Row():
+                                    gr.Checkbox(label="Delete Audio Clips " + SimpleIcons.CONSTRUCTION)
+                                    with gr.Box():
+                                        gr.Markdown("Delete Audio WAV/MP3 files used as inputs for creating remix video clips.")
+                                with gr.Row():
+                                    gr.Checkbox(label="Delete Video Clips " + SimpleIcons.CONSTRUCTION)
+                                    with gr.Box():
+                                        gr.Markdown("Delete Video MP4 files used as inputs for creating remix video clips.")
+                                with gr.Row():
+                                    gr.Checkbox(label="Delete Remix Video Clips " + SimpleIcons.CONSTRUCTION)
+                                    with gr.Box():
+                                        gr.Markdown("Delete Video+Audio MP4 files used as inputs to concatentate into the final Remix Video.")
+                                with gr.Row():
+                                    gr.Textbox(show_label=False)
+                                gr.Markdown("*Progress can be tracked in the console*")
+                                with gr.Row():
+                                    gr.Button(value="Purge Selected Content " + SimpleIcons.SLOW_SYMBOL, variant="stop")
+                                    gr.Button(value="Select All").style(full_width=False)
+                                    gr.Button(value="Select None").style(full_width=False)
+
+                    with gr.Tab(label="Expert"):
                         with gr.Tabs():
                             with gr.Tab(label="Set Bulk Scene Status " + SimpleIcons.CONSTRUCTION):
                                 gr.Markdown("**Set Scenes Status**\r\n- _Keep_, _Drop_ or _Hide_ a series of scenes")
@@ -327,55 +397,8 @@ class VideoRemixer(TabBase):
                                 # - resized, resynthesized, inflated, upscaled, audio clips
                                 gr.Markdown("**Purge Scene**\r\n- Drop a scene after processing has been compeleted")
                                 gr.Button("Purge Scene ", variant="primary").style(full_width=True)
-                    with gr.Tab(label="Project Clean Up " + SimpleIcons.WARNING):
-                        with gr.Box():
-                            gr.Markdown("## After Scene Choices are Final and Processing is Completed")
-                            with gr.Row():
-                                gr.Checkbox(label="Purge Source Video Frames " + SimpleIcons.CONSTRUCTION)
-                                with gr.Box():
-                                    gr.Markdown("Save space by deleting source video PNG frame files used to compile kept scenes for remix processing.\r\n⚠️**Choose Only if your kept scene choices are final.**")
-                            with gr.Row():
-                                gr.Checkbox(label="Purge Dropped Scenes " + SimpleIcons.CONSTRUCTION)
-                                with gr.Box():
-                                    gr.Markdown("Save space by deleting Dropped Scene files, that are used when changing kept scene choices.\r\n⚠️**Choose Only if your kept scene choices are final.**")
-                            with gr.Row():
-                                gr.Checkbox(label="Purge Thumbnails " + SimpleIcons.CONSTRUCTION)
-                                with gr.Box():
-                                    gr.Markdown("Save space by deleting Thumbnail, that are used when making kept scene choices.\r\n⚠️**Choose Only if your kept scene choices are final.**")
-                        with gr.Box():
-                            gr.Markdown("## After Remix Video(s) have been Saved and Project is Concluded")
-                            with gr.Row():
-                                gr.Checkbox(label="Purge Resized Frames " + SimpleIcons.CONSTRUCTION)
-                                with gr.Box():
-                                    gr.Markdown("Save space by deleting resized PNG frame files, that are used when making creating the remix video.\r\n⚠️**Choose Only if you will never use the resized frames again.**")
-                            with gr.Row():
-                                gr.Checkbox(label="Purge Resynthesized Frames " + SimpleIcons.CONSTRUCTION)
-                                with gr.Box():
-                                    gr.Markdown("Save space by deleting resynthesized PNG frame files, that are used when making creating the remix video.\r\n⚠️**Choose Only if you will never use the resynthesized frames again.**")
-                            with gr.Row():
-                                gr.Checkbox(label="Purge Inflated Frames " + SimpleIcons.CONSTRUCTION)
-                                with gr.Box():
-                                    gr.Markdown("Save space by deleting inflated PNG frame files, that are used when making creating the remix video.\r\n⚠️**Choose Only if you will never use the inflated frames again.**")
-                            with gr.Row():
-                                gr.Checkbox(label="Purge Upscaled Frames " + SimpleIcons.CONSTRUCTION)
-                                with gr.Box():
-                                    gr.Markdown("Save space by deleting upscaled PNG frame files, that are used when making creating the remix video.\r\n⚠️**Choose Only if you will never use the upscaled frames again.**")
-                            with gr.Row():
-                                gr.Checkbox(label="Purge Audio Clips " + SimpleIcons.CONSTRUCTION)
-                                with gr.Box():
-                                    gr.Markdown("Save space by deleting audio clip .WAV files, that are used when making creating the remix video.\r\n⚠️**Choose Only if you will never use the audio clips again.**")
-                            with gr.Row():
-                                gr.Checkbox(label="Purge Video Clips " + SimpleIcons.CONSTRUCTION)
-                                with gr.Box():
-                                    gr.Markdown("Save space by deleting video clip .MP4 files, that are used when making creating the remix video.\r\n⚠️**Choose Only if you will never use the video clips again.**")
-                            with gr.Row():
-                                gr.Checkbox(label="Purge Remix Videos " + SimpleIcons.CONSTRUCTION)
-                                with gr.Box():
-                                    gr.Markdown("Save space by deleting remix video+audio .MP4 files, that are concatenated to save the remix video.\r\n⚠️**Choose Only if you will never use the video clips again.**")
-                        with gr.Row():
-                            gr.Button(value="Purge Selected Items " + SimpleIcons.CONSTRUCTION, variant="stop")
-                            gr.Button(value="Select All").style(full_width=False)
-                            gr.Button(value="Select None").style(full_width=False)
+
+
                     # with gr.Accordion(SimpleIcons.TIPS_SYMBOL + " Guide", open=False):
                     #     WebuiTips.video_remixer_save.render()
 

--- a/tabs/video_remixer_ui.py
+++ b/tabs/video_remixer_ui.py
@@ -281,7 +281,8 @@ class VideoRemixer(TabBase):
                             with gr.Tab("Drop Processed Scene"):
                                 gr.Markdown("**Drop Processed Scene** - Drop a scene after processing has been compeleted")
                                 scene_id_710 = gr.Number(value=-1, label="Scene Index")
-                                message_box710 = gr.Textbox(show_label=False, interactive=False)
+                                with gr.Row():
+                                    message_box710 = gr.Textbox(show_label=False, interactive=False)
                                 drop_button710 = gr.Button("Drop Scene", variant="stop").style(full_width=True)
 
                     with gr.Tab(label="Reduce Footprint " + SimpleIcons.CONSTRUCTION):

--- a/tabs/video_remixer_ui.py
+++ b/tabs/video_remixer_ui.py
@@ -229,7 +229,7 @@ class VideoRemixer(TabBase):
                     with gr.Accordion(SimpleIcons.TIPS_SYMBOL + " Guide", open=False):
                         WebuiTips.video_remixer_processing.render()
 
-                ## REMIX VIDEOS
+                ## SAVE REMIX
                 with gr.Tab("Save Remix", id=6):
                     gr.Markdown("**Ready to Finalize Scenes and Save Remixed Video**")
                     with gr.Row():
@@ -274,6 +274,111 @@ class VideoRemixer(TabBase):
 
                     with gr.Accordion(SimpleIcons.TIPS_SYMBOL + " Guide", open=False):
                         WebuiTips.video_remixer_save.render()
+
+                ## SAVE REMIX
+                with gr.Tab("Remix Extra", id=7):
+                    gr.Markdown("**Extra Remix Features**")
+                    with gr.Tab(label="Advanced Functions " + SimpleIcons.CONSTRUCTION):
+                        with gr.Tabs():
+                            with gr.Tab(label="Set Bulk Scene Status " + SimpleIcons.CONSTRUCTION):
+                                gr.Markdown("**Set Scenes Status**\r\n- _Keep_, _Drop_ or _Hide_ a series of scenes")
+                                # starting scene ID
+                                # ending scene ID
+                                # status Keep, Drop , Hide
+                                # goes through range setting status, does not compile scenes
+                                gr.Button("Set Scene Range " + SimpleIcons.CONSTRUCTION, variant="primary").style(full_width=True)
+                            with gr.Tab(label="Unhide Scenes " + SimpleIcons.CONSTRUCTION):
+                                gr.Markdown("**Unhide Hidden Scenes**\r\n- Unhide all scenes with _Hide_ status")
+                                # goes through all scene choices
+                                # sets hidden ones to dropped
+                                gr.Button("Unhide All " + SimpleIcons.CONSTRUCTION, variant="primary").style(full_width=True)
+                            with gr.Tab(label="Split Scene " + SimpleIcons.CONSTRUCTION):
+                                gr.Markdown("**Split Scene**\r\n- Split a scene in two at a specific frame")
+                                # scene ID
+                                # frame index within scene, -1 = half-way
+                                # uncompile scenes
+                                # create new scene names based on the frame index
+                                # rename the current folder to its new name
+                                # create a new folder with the second new name
+                                # move the files to the new folder
+                                # update lists with the renamed and new scene: scene names, scene states
+                                # delete the original thumbnail
+                                # create new thumbnails for both scenes
+                                # update the thumbnail list with the renamed and new scene
+                                gr.Button("Split Scene " + SimpleIcons.CONSTRUCTION, variant="primary").style(full_width=True)
+                            with gr.Tab(label="Fuse Scenes " + SimpleIcons.CONSTRUCTION):
+                                # first scene ID
+                                # last scene ID
+                                # - go through the range of scenes
+                                # - compute the new label based on the scene labels
+                                # - rename the scene directory to the new name
+                                # - go through the remaining scene directories
+                                # - move the files to the first directory and delete the directory
+                                # - update lists with the renamed and deleted scenes: scene names, scene states
+                                # - delete all of the original thumbnails
+                                # - create a new thumbnail from the new consolidated scene
+                                # - update the thumbnail list with the renamed and deleted scenes
+                                gr.Markdown("**Fuse Scenes**\r\n- Combine range of scenes into one scene")
+                                gr.Button("Fuse Scenes " + SimpleIcons.CONSTRUCTION, variant="primary").style(full_width=True)
+                            with gr.Tab("Purge Scene " + SimpleIcons.CONSTRUCTION):
+                                # scene ID
+                                # moves the scene to dropped frames
+                                # sets the scene dropped
+                                # deletes the scene from:
+                                # - resized, resynthesized, inflated, upscaled, audio clips
+                                gr.Markdown("**Purge Scene**\r\n- Drop a scene after processing has been compeleted")
+                                gr.Button("Purge Scene ", variant="primary").style(full_width=True)
+                    with gr.Tab(label="Project Clean Up " + SimpleIcons.WARNING):
+                        with gr.Box():
+                            gr.Markdown("## After Scene Choices are Final and Processing is Completed")
+                            with gr.Row():
+                                gr.Checkbox(label="Purge Source Video Frames " + SimpleIcons.CONSTRUCTION)
+                                with gr.Box():
+                                    gr.Markdown("Save space by deleting source video PNG frame files used to compile kept scenes for remix processing.\r\n⚠️**Choose Only if your kept scene choices are final.**")
+                            with gr.Row():
+                                gr.Checkbox(label="Purge Dropped Scenes " + SimpleIcons.CONSTRUCTION)
+                                with gr.Box():
+                                    gr.Markdown("Save space by deleting Dropped Scene files, that are used when changing kept scene choices.\r\n⚠️**Choose Only if your kept scene choices are final.**")
+                            with gr.Row():
+                                gr.Checkbox(label="Purge Thumbnails " + SimpleIcons.CONSTRUCTION)
+                                with gr.Box():
+                                    gr.Markdown("Save space by deleting Thumbnail, that are used when making kept scene choices.\r\n⚠️**Choose Only if your kept scene choices are final.**")
+                        with gr.Box():
+                            gr.Markdown("## After Remix Video(s) have been Saved and Project is Concluded")
+                            with gr.Row():
+                                gr.Checkbox(label="Purge Resized Frames " + SimpleIcons.CONSTRUCTION)
+                                with gr.Box():
+                                    gr.Markdown("Save space by deleting resized PNG frame files, that are used when making creating the remix video.\r\n⚠️**Choose Only if you will never use the resized frames again.**")
+                            with gr.Row():
+                                gr.Checkbox(label="Purge Resynthesized Frames " + SimpleIcons.CONSTRUCTION)
+                                with gr.Box():
+                                    gr.Markdown("Save space by deleting resynthesized PNG frame files, that are used when making creating the remix video.\r\n⚠️**Choose Only if you will never use the resynthesized frames again.**")
+                            with gr.Row():
+                                gr.Checkbox(label="Purge Inflated Frames " + SimpleIcons.CONSTRUCTION)
+                                with gr.Box():
+                                    gr.Markdown("Save space by deleting inflated PNG frame files, that are used when making creating the remix video.\r\n⚠️**Choose Only if you will never use the inflated frames again.**")
+                            with gr.Row():
+                                gr.Checkbox(label="Purge Upscaled Frames " + SimpleIcons.CONSTRUCTION)
+                                with gr.Box():
+                                    gr.Markdown("Save space by deleting upscaled PNG frame files, that are used when making creating the remix video.\r\n⚠️**Choose Only if you will never use the upscaled frames again.**")
+                            with gr.Row():
+                                gr.Checkbox(label="Purge Audio Clips " + SimpleIcons.CONSTRUCTION)
+                                with gr.Box():
+                                    gr.Markdown("Save space by deleting audio clip .WAV files, that are used when making creating the remix video.\r\n⚠️**Choose Only if you will never use the audio clips again.**")
+                            with gr.Row():
+                                gr.Checkbox(label="Purge Video Clips " + SimpleIcons.CONSTRUCTION)
+                                with gr.Box():
+                                    gr.Markdown("Save space by deleting video clip .MP4 files, that are used when making creating the remix video.\r\n⚠️**Choose Only if you will never use the video clips again.**")
+                            with gr.Row():
+                                gr.Checkbox(label="Purge Remix Videos " + SimpleIcons.CONSTRUCTION)
+                                with gr.Box():
+                                    gr.Markdown("Save space by deleting remix video+audio .MP4 files, that are concatenated to save the remix video.\r\n⚠️**Choose Only if you will never use the video clips again.**")
+                        with gr.Row():
+                            gr.Button(value="Purge Selected Items " + SimpleIcons.CONSTRUCTION, variant="stop")
+                            gr.Button(value="Select All").style(full_width=False)
+                            gr.Button(value="Select None").style(full_width=False)
+                    # with gr.Accordion(SimpleIcons.TIPS_SYMBOL + " Guide", open=False):
+                    #     WebuiTips.video_remixer_save.render()
 
         next_button00.click(self.next_button00,
                            inputs=video_path,

--- a/tabs/video_remixer_ui.py
+++ b/tabs/video_remixer_ui.py
@@ -274,13 +274,22 @@ class VideoRemixer(TabBase):
                     with gr.Accordion(SimpleIcons.TIPS_SYMBOL + " Guide", open=False):
                         WebuiTips.video_remixer_save.render()
 
-                ## Remix Extras
-                with gr.Tab("Remix Extras", id=7):
-                    with gr.Tab(label="Project Clean Up"):
+                ## Remix Extra
+                with gr.Tab("Remix Extra", id=7):
+                    with gr.Tab(label="Expert"):
+                        with gr.Tabs():
+                            with gr.Tab("Drop Processed Scene"):
+                                gr.Markdown("**Drop Processed Scene** - Drop a scene after processing has been compeleted")
+                                scene_id_710 = gr.Number(value=-1, label="Scene Index")
+                                message_box710 = gr.Textbox(show_label=False, interactive=False)
+                                drop_button710 = gr.Button("Drop Scene", variant="stop").style(full_width=True)
+
+                    with gr.Tab(label="Project Clean Up " + SimpleIcons.CONSTRUCTION):
                         with gr.Tabs():
                             with gr.Tab(label="Remove Soft-Deleted Content"):
+                                gr.Markdown("**_Delete content that has been moved to the_** `purged_content` **_directory_**")
                                 with gr.Row():
-                                    gr.Checkbox(label="Permently Delete Purged Content " + SimpleIcons.CONSTRUCTION)
+                                    gr.Checkbox(label="Permanently Delete Purged Content " + SimpleIcons.CONSTRUCTION)
                                     with gr.Box():
                                         gr.Markdown("Delete content that has been set aisde in the 'purged_content' directory.")
                                 with gr.Row():
@@ -291,6 +300,7 @@ class VideoRemixer(TabBase):
                                     gr.Button(value="Select All").style(full_width=False)
                                     gr.Button(value="Select None").style(full_width=False)
                             with gr.Tab(label="Remove Scene Chooser Content"):
+                                gr.Markdown("**_Clear space after final scene choices have been made_**")
                                 with gr.Row():
                                     gr.Checkbox(label="Remove Source Video Frames " + SimpleIcons.CONSTRUCTION)
                                     with gr.Box():
@@ -310,7 +320,8 @@ class VideoRemixer(TabBase):
                                     gr.Button(value="Purge Selected Content " + SimpleIcons.SLOW_SYMBOL, variant="stop")
                                     gr.Button(value="Select All").style(full_width=False)
                                     gr.Button(value="Select None").style(full_width=False)
-                            with gr.Tab(label="Remove Remix Video Content"):
+                            with gr.Tab(label="Remove Remix Video Source Content"):
+                                gr.Markdown("**_Clear space after final Remix Videos have been saved_**")
                                 with gr.Row():
                                     gr.Checkbox(label="Remove Resized Frames " + SimpleIcons.CONSTRUCTION)
                                     with gr.Box():
@@ -346,58 +357,6 @@ class VideoRemixer(TabBase):
                                     gr.Button(value="Purge Selected Content " + SimpleIcons.SLOW_SYMBOL, variant="stop")
                                     gr.Button(value="Select All").style(full_width=False)
                                     gr.Button(value="Select None").style(full_width=False)
-
-                    with gr.Tab(label="Expert"):
-                        with gr.Tabs():
-                            with gr.Tab(label="Set Bulk Scene Status " + SimpleIcons.CONSTRUCTION):
-                                gr.Markdown("**Set Scenes Status**\r\n- _Keep_, _Drop_ or _Hide_ a series of scenes")
-                                # starting scene ID
-                                # ending scene ID
-                                # status Keep, Drop , Hide
-                                # goes through range setting status, does not compile scenes
-                                gr.Button("Set Scene Range " + SimpleIcons.CONSTRUCTION, variant="primary").style(full_width=True)
-                            with gr.Tab(label="Unhide Scenes " + SimpleIcons.CONSTRUCTION):
-                                gr.Markdown("**Unhide Hidden Scenes**\r\n- Unhide all scenes with _Hide_ status")
-                                # goes through all scene choices
-                                # sets hidden ones to dropped
-                                gr.Button("Unhide All " + SimpleIcons.CONSTRUCTION, variant="primary").style(full_width=True)
-                            with gr.Tab(label="Split Scene " + SimpleIcons.CONSTRUCTION):
-                                gr.Markdown("**Split Scene**\r\n- Split a scene in two at a specific frame")
-                                # scene ID
-                                # frame index within scene, -1 = half-way
-                                # uncompile scenes
-                                # create new scene names based on the frame index
-                                # rename the current folder to its new name
-                                # create a new folder with the second new name
-                                # move the files to the new folder
-                                # update lists with the renamed and new scene: scene names, scene states
-                                # delete the original thumbnail
-                                # create new thumbnails for both scenes
-                                # update the thumbnail list with the renamed and new scene
-                                gr.Button("Split Scene " + SimpleIcons.CONSTRUCTION, variant="primary").style(full_width=True)
-                            with gr.Tab(label="Fuse Scenes " + SimpleIcons.CONSTRUCTION):
-                                # first scene ID
-                                # last scene ID
-                                # - go through the range of scenes
-                                # - compute the new label based on the scene labels
-                                # - rename the scene directory to the new name
-                                # - go through the remaining scene directories
-                                # - move the files to the first directory and delete the directory
-                                # - update lists with the renamed and deleted scenes: scene names, scene states
-                                # - delete all of the original thumbnails
-                                # - create a new thumbnail from the new consolidated scene
-                                # - update the thumbnail list with the renamed and deleted scenes
-                                gr.Markdown("**Fuse Scenes**\r\n- Combine range of scenes into one scene")
-                                gr.Button("Fuse Scenes " + SimpleIcons.CONSTRUCTION, variant="primary").style(full_width=True)
-                            with gr.Tab("Purge Scene " + SimpleIcons.CONSTRUCTION):
-                                # scene ID
-                                # moves the scene to dropped frames
-                                # sets the scene dropped
-                                # deletes the scene from:
-                                # - resized, resynthesized, inflated, upscaled, audio clips
-                                gr.Markdown("**Purge Scene**\r\n- Drop a scene after processing has been compeleted")
-                                gr.Button("Purge Scene ", variant="primary").style(full_width=True)
-
 
                     # with gr.Accordion(SimpleIcons.TIPS_SYMBOL + " Guide", open=False):
                     #     WebuiTips.video_remixer_save.render()
@@ -518,6 +477,8 @@ class VideoRemixer(TabBase):
                         outputs=message_box61)
 
         back_button61.click(self.back_button6, outputs=tabs_video_remixer)
+
+        drop_button710.click(self.drop_button710, inputs=scene_id_710, outputs=message_box710)
 
     def empty_args(self, num):
         return [None for _ in range(num)]
@@ -1117,3 +1078,22 @@ class VideoRemixer(TabBase):
 
     def back_button6(self):
         return gr.update(selected=5)
+
+    def drop_button710(self, scene_index):
+        if isinstance(scene_index, (int, float)):
+            scene_index = int(scene_index)
+            if 0 <= scene_index < len(self.state.scene_names):
+                removed = self.state.force_drop_processed_scene(scene_index)
+                self.log(f"removed files: {removed}")
+
+                self.log(
+            f"saving project after using force_drop_processed_scene for scene index {scene_index}")
+                self.state.save()
+
+                removed = "\r\n".join(removed)
+                message = f"Removed:\r\n{removed}"
+            else:
+                message = f"Please enter a Scene Index from 0 to {len(self.state.scene_names)-1}"
+        else:
+            message = f"Please enter a Scene Index to get started"
+        return gr.update(visible=True, value=message)

--- a/tabs/video_remixer_ui.py
+++ b/tabs/video_remixer_ui.py
@@ -847,7 +847,7 @@ class VideoRemixer(TabBase):
     def scene_chooser_details(self, scene_index):
         if not self.state.thumbnails:
             self.log(f"thumbnails don't exist yet in scene_chooser_details()")
-            return self.empty_args(6)
+            return self.empty_args(5)
         try:
             scene_name, thumbnail_path, scene_state, scene_info = \
                 self.state.scene_chooser_details(scene_index)
@@ -1156,8 +1156,12 @@ class VideoRemixer(TabBase):
             removed.append(self.state.delete_path(self.state.dropped_scenes_path))
         if delete_thumbs:
             removed.append(self.state.delete_path(self.state.thumbnail_path))
-        removed = "\r\n".join(removed)
-        message = f"Removed:\r\n{removed}"
+        removed = [_ for _ in removed if _]
+        if removed:
+            removed_str = "\r\n".join(removed)
+            message = f"Removed:\r\n{removed_str}"
+        else:
+            message = f"Removed: None"
         return gr.update(visible=True, value=message)
 
     def select_all_button711(self):
@@ -1188,8 +1192,12 @@ class VideoRemixer(TabBase):
             removed.append(self.state.delete_path(self.state.video_clips_path))
         if delete_clips:
             removed.append(self.state.delete_path(self.state.clips_path))
-        removed = "\r\n".join(removed)
-        message = f"Removed:\r\n{removed}"
+        removed = [_ for _ in removed if _]
+        if removed:
+            removed_str = "\r\n".join(removed)
+            message = f"Removed:\r\n{removed_str}"
+        else:
+            message = f"Removed: None"
         return gr.update(visible=True, value=message)
 
     def select_all_button712(self):

--- a/tabs/video_remixer_ui.py
+++ b/tabs/video_remixer_ui.py
@@ -276,7 +276,7 @@ class VideoRemixer(TabBase):
 
                 ## Remix Extra
                 with gr.Tab("Remix Extra", id=7):
-                    with gr.Tab(label="Expert"):
+                    with gr.Tab(label="Utilities"):
                         with gr.Tabs():
                             with gr.Tab("Drop Processed Scene"):
                                 gr.Markdown("**Drop Processed Scene** - Drop a scene after processing has been compeleted")
@@ -284,7 +284,7 @@ class VideoRemixer(TabBase):
                                 message_box710 = gr.Textbox(show_label=False, interactive=False)
                                 drop_button710 = gr.Button("Drop Scene", variant="stop").style(full_width=True)
 
-                    with gr.Tab(label="Project Clean Up " + SimpleIcons.CONSTRUCTION):
+                    with gr.Tab(label="Reduce Footprint " + SimpleIcons.CONSTRUCTION):
                         with gr.Tabs():
                             with gr.Tab(label="Remove Soft-Deleted Content"):
                                 gr.Markdown("**_Delete content that has been moved to the_** `purged_content` **_directory_**")

--- a/video_remixer.py
+++ b/video_remixer.py
@@ -589,7 +589,24 @@ class VideoRemixerState():
 
     def delete_purged_content(self):
         purged_root_path = os.path.join(self.project_path, self.PURGED_CONTENT)
-        shutil.rmtree(purged_root_path)
+        if os.path.exists(purged_root_path):
+            with Mtqdm().open_bar(total=1, desc="Deleting") as bar:
+                Mtqdm().message(bar, "Removing purged content - No ETA")
+                shutil.rmtree(purged_root_path)
+                Mtqdm().update_bar(bar)
+            return purged_root_path
+        else:
+            return None
+
+    def delete_path(self, path):
+        if os.path.exists(path):
+            with Mtqdm().open_bar(total=1, desc="Deleting") as bar:
+                Mtqdm().message(bar, "Removing project content - No ETA")
+                shutil.rmtree(path)
+                Mtqdm().update_bar(bar)
+            return path
+        else:
+            return None
 
     def purge_processed_content(self, purge_from):
         if purge_from == self.RESIZE_STEP:

--- a/video_remixer.py
+++ b/video_remixer.py
@@ -577,13 +577,19 @@ class VideoRemixerState():
     INFLATE_STEP = "inflate"
     UPSCALE_STEP = "upscale"
 
+    PURGED_CONTENT = "purged_content"
+
     def purge_paths(self, path_list : list):
-        purged_root_path = os.path.join(self.project_path, "purged_content")
+        purged_root_path = os.path.join(self.project_path, self.PURGED_CONTENT)
         create_directory(purged_root_path)
         purged_path, _ = AutoIncrementDirectory(purged_root_path).next_directory("purged")
         for path in path_list:
             if path and os.path.exists(path):
                 shutil.move(path, purged_path)
+
+    def delete_purged_content(self):
+        purged_root_path = os.path.join(self.project_path, self.PURGED_CONTENT)
+        shutil.rmtree(purged_root_path)
 
     def purge_processed_content(self, purge_from):
         if purge_from == self.RESIZE_STEP:

--- a/webui_utils/file_utils.py
+++ b/webui_utils/file_utils.py
@@ -118,6 +118,17 @@ def get_files(path : str, extension : list | str | None=None) -> list:
     else:
         raise ValueError("'path' must be a string")
 
+def get_matching_files(path : str, filespec : str) -> list:
+    """Get a list of files in path matching 'filespec', which can be a filename or wildcard"""
+    if isinstance(path, str):
+        if isinstance(filespec, str):
+            full_path = os.path.join(path, filespec)
+            return _get_files(full_path)
+        else:
+            raise ValueError("'filespec' must be a string")
+    else:
+        raise ValueError("'path' must be a string")
+
 def get_directories(path : str) -> list:
     """Get a list of directories in the path"""
     if isinstance(path, str):


### PR DESCRIPTION
New tab for Video Remixer: **Remix Extra**
- Utilities
    - Drop processed Scene
        - Drop a scene from Remix Video without reprocessing
- Reduce Footprint
    - Remove Soft-Deleted Content
        - Clears disk space by emptying the `purged_content` directory
    - Remove Scene Chooser Content
        - Used after scene choices are final to remove source frames, dropped scenes and thumbnails
    - Remove Remove Video Source Content
        - Used after Remix Video is final to remove all produced project content (except project file and remix videos)