### PR TITLE
Work around for interpolation engine failing to load w/o GPU

### DIFF
--- a/interpolate_engine.py
+++ b/interpolate_engine.py
@@ -60,8 +60,11 @@ class InterpolateEngine:
                 F = 32,
                 depth = [2, 2, 2, 4, 4]
             )
-        model = Model(-1)
-        model.load_model()
-        model.eval()
-        model.device()
-        return {"model" : model, "TTA" : TTA}
+        try:
+            model = Model(-1)
+            model.load_model()
+            model.eval()
+            model.device()
+            return {"model" : model, "TTA" : TTA}
+        except AssertionError as error:
+            raise RuntimeError(f"Error initializing EMA-VFI model: {error}")

--- a/webui.py
+++ b/webui.py
@@ -46,7 +46,13 @@ class WebUI:
         model = self.config.engine_settings["model"]
         gpu_ids = self.config.engine_settings["gpu_ids"]
         use_time_step = self.config.engine_settings["use_time_step"]
-        engine = InterpolateEngine(model, gpu_ids, use_time_step=use_time_step)
+
+        try:
+            engine = InterpolateEngine(model, gpu_ids, use_time_step=use_time_step)
+        except RuntimeError as error:
+            print(f"Error loading interpolation engine: {error}")
+            engine = None
+
         while True:
             print()
             if self.config.user_interface["mtqdm_use_color"]:


### PR DESCRIPTION
I have both of my gaming PCs with GPUs tied up doing video frame interpolations. I also have a recent laptop with only a trivial GPU not usable for interpolations. It would be nice to use it with _Video Remixer_ for things that don't require interpolation
- Splitting videos by scene or break
- Choosing Scenes
- Resizing
- Assembling final Remix video

This PR adds a `try` \ `except` block around the EMA-VFI engine loading, that fails without **CUDA Hardware** present. 

A message is displayed to the console, but the application continues to run. It'll work as long as no video frame interpolation feature are used.

**Note** no effort has been put (yet) into making all the EMA-VFI calls degrade gracefully so use at your own risk.
