### PR TITLE
Video Remixer: Prevent paths from getting out of sync

### DIFF
--- a/tabs/video_remixer_ui.py
+++ b/tabs/video_remixer_ui.py
@@ -777,6 +777,7 @@ class VideoRemixer(TabBase):
         if self.state.upscale_option != None and self.state.upscale_option != upscale_option:
             upscale_option_changed = True
         self.state.upscale_option = upscale_option
+        self.state.setup_processing_paths()
         self.log("saving project after storing processing choices")
         self.state.save()
 


### PR DESCRIPTION
Somehow I got a project out of sync with some of the processing path variables not set. This PR centralizes establishing the processing paths in a function, and uses it to reestablish the paths on reloading a project.