### PR TITLE
Video Remixer clean up

### DIFF
--- a/slice_video.py
+++ b/slice_video.py
@@ -110,7 +110,8 @@ class SliceVideo:
             create_directory(self.output_path)
 
         self.log("using slice_video (may cause long delay while processing request)")
-        with Mtqdm().open_bar(total=len(group_names), desc="Slice") as bar:
+        pbar_desc = f"Slice {self.type}"
+        with Mtqdm().open_bar(total=len(group_names), desc=pbar_desc) as bar:
             for group_name in group_names:
                 first_index, last_index, num_width = details_from_group_name(group_name)
                 output_path = self.output_path or os.path.join(self.group_path, group_name)

--- a/video_remixer.py
+++ b/video_remixer.py
@@ -1098,7 +1098,7 @@ class VideoRemixerState():
             create_directory(path)
 
         path_files = get_files(path)
-        file_count = len(files)
+        file_count = len(files) if files else 0
         path_file_count = len(path_files)
 
         if not files and not path_files:


### PR DESCRIPTION
- Show "Slice gif" or "Slice wav" instead of just "Slice" in the progress bar description
- Post-load integrity check fails in cases where there should not yet be files in some paths