### PR TITLE
Add marked custom remix videos as standard

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -102,6 +102,8 @@ remixer_settings:
   default_gif_fps: 10
   gif_end_delay: 1.0
   gif_factor: 10
+  marked_ffmpeg_video: -vf "drawtext=text='<SCENE_INFO>':x=(w-text_w)/2:y=(text_h*1):fontsize=(h/22):fontcolor=white@0.9:fontfile='fonts/trim.ttf':box=1:boxcolor=black@0.5:boxborderw=5" -c:v libx264 -crf 28
+  marked_ffmpeg_audio: -c:a aac
   max_project_fps: 60.0
   max_thumb_size: 512
   maximum_crf: 28

--- a/video_remixer.py
+++ b/video_remixer.py
@@ -903,17 +903,18 @@ class VideoRemixerState():
                                                     output_basename, "png")
                 Mtqdm().update_bar(bar)
 
-    def remix_filename_suffix(self):
+    def remix_filename_suffix(self, extra_suffix):
         label = "remix"
         label += "-rc" if self.resize else "-or"
         label += "-re" if self.resynthesize else ""
         label += "-in" if self.inflate else ""
         label += "-up" + self.upscale_option[0] if self.upscale else ""
+        label += "-" + extra_suffix if extra_suffix else ""
         return label
 
-    def default_remix_filepath(self):
+    def default_remix_filepath(self, extra_suffix=""):
         _, filename, _ = split_filepath(self.source_video)
-        suffix = self.remix_filename_suffix()
+        suffix = self.remix_filename_suffix(extra_suffix)
         return os.path.join(self.project_path, f"{filename}-{suffix}.mp4")
 
     # drop a kept scene after scene compiling has already been done


### PR DESCRIPTION
New tab on the _Save Remix_ tab: "Create Marked Remix"
- like _Create Custom Remix_ but prepopulates the _video_ and _audio_ FFmpeg commands to draw scene info as shown in the screenshot

![Screenshot 2023-08-08 083314](https://github.com/jhogsett/EMA-VFI-WebUI/assets/825994/7cfa6082-7c2b-4790-8e96-9f885a47aa2f)

Scene Info
- Scene Index
- Scene Name
- Scene Time in source video
- Scene Duration

New `config.yaml` settings:
- `marked_ffmpeg_video` default marked remix _video_ command line for FFmpeg
- `marked_ffmpeg_audio` default marked remix _audio_ command line for FFmpeg