### PR TITLE
Video Remixer: Need a good default for min frames per scene

### DIFF
--- a/video_remixer.py
+++ b/video_remixer.py
@@ -126,6 +126,7 @@ class VideoRemixerState():
         self.inflate = self.UI_SAFETY_DEFAULTS["inflate"]
         self.upscale = self.UI_SAFETY_DEFAULTS["upscale"]
         self.upscale_option = self.UI_SAFETY_DEFAULTS["upscale_option"]
+        self.min_frames_per_scene = self.UI_SAFETY_DEFAULTS["min_frames_per_scene"]
 
     # how far progressed into project and the tab ID to return to on re-opening
     PROGRESS_STEPS = {


### PR DESCRIPTION
Reopened a project that has only advanced past the 2nd tab (_Remix Settings_) so no `min_frames_per_scene` has been set in the project. On the _Set Up Project_ tab, the on-screen value was blank.