### PR TITLE
Video Remixer: better handling of project reset

### DIFF
--- a/create_ui.py
+++ b/create_ui.py
@@ -104,9 +104,9 @@ def create_ui(config : SimpleConfig,
             ChangeFPS(config, engine, log.log).render_tab()
             GIFtoMP4(config, engine, log.log).render_tab()
             with gr.Tab(SimpleIcons.GEAR + "Application"):
-                Options(config, engine, log.log, restart_fn).render_tab()
-                Resources(config, engine, log.log).render_tab()
                 LogViewer(config, engine, log.log, log).render_tab()
+                Resources(config, engine, log.log).render_tab()
+                Options(config, engine, log.log, restart_fn).render_tab()
 
         if config.user_interface["show_header"]:
             app_footer.render()

--- a/tabs/video_remixer_ui.py
+++ b/tabs/video_remixer_ui.py
@@ -572,7 +572,8 @@ class VideoRemixer(TabBase):
 
         choose_button701.click(self.choose_button701,
                                inputs=[first_scene_id_701, last_scene_id_701, scene_state_701],
-                               outputs=message_box701)
+                               outputs=[tabs_video_remixer, message_box701, scene_index, scene_label,
+                                       scene_image, scene_state, scene_info])
 
         split_button702.click(self.split_button702, inputs=scene_id_702,
                               outputs=[tabs_video_remixer, message_box702, scene_index, scene_label,
@@ -1280,14 +1281,17 @@ class VideoRemixer(TabBase):
             scene_name = self.state.scene_names[scene_index]
             self.state.scene_states[scene_name] = scene_state
 
+        self.state.current_scene = first_scene_index
+
         first_scene_name = self.state.scene_names[first_scene_index]
         last_scene_name = self.state.scene_names[last_scene_index]
-
         message = f"Scenes {first_scene_name} through {last_scene_name} set to '{scene_state}'"
         self.log(f"saving project after {message}")
         self.state.save()
 
-        return gr.update(visible=True, value=message)
+        return gr.update(selected=3), \
+            gr.update(visible=True, value=message), \
+            *self.scene_chooser_details(self.state.current_scene)
 
     def split_button702(self, scene_index):
         global_options = self.config.ffmpeg_settings["global_options"]

--- a/tabs/video_remixer_ui.py
+++ b/tabs/video_remixer_ui.py
@@ -79,7 +79,7 @@ class VideoRemixer(TabBase):
                     with gr.Box():
                         video_info1 = gr.Markdown("Video Details")
                     with gr.Row():
-                        project_path = gr.Textbox(label="Project Path",
+                        project_path = gr.Textbox(label="Set Project Path",
                                             placeholder="Path on this server to store project data")
                     with gr.Row():
                         project_fps = gr.Slider(label="Remix Frame Rate", value=def_project_fps,

--- a/tabs/video_remixer_ui.py
+++ b/tabs/video_remixer_ui.py
@@ -130,7 +130,9 @@ class VideoRemixer(TabBase):
         value="Next: Create Scenes, Thumbnails and Audio Clips (takes from minutes to hours)",
                                     show_label=False, visible=True, interactive=False)
 
-                    gr.Markdown("⚠️**Important: Redoing this step will purge and recreate content!** *Progress can be tracked in the console*")
+                    gr.Markdown(
+                        "⚠️**Important: Redoing this step will purge and recreate content!**" +
+                        " *Progress can be tracked in the console*")
                     with gr.Row():
                         back_button2 = gr.Button(value="< Back", variant="secondary").\
                             style(full_width=False)
@@ -211,21 +213,29 @@ class VideoRemixer(TabBase):
                     with gr.Row():
                         resize = gr.Checkbox(label="Fix Aspect Ratio", value=True)
                         with gr.Box():
-                            gr.Markdown("Frames are resized then cropped according to project settings")
+                            gr.Markdown(
+                                "Frames are resized then cropped according to project settings")
                     with gr.Row():
                         resynthesize = gr.Checkbox(label="Resynthesize Frames",value=True)
                         with gr.Box():
-                            gr.Markdown("Frames are recreated by AI interpolation of neighboring frames\r\n- Scene outermost frames are lost during resynthesis\r\n- Audio clips are adjusted to compensate for lost frames")
+                            gr.Markdown(
+                            "Frames are recreated by AI interpolation of neighboring frames\r\n" +
+                            "- Scene outermost frames are lost during resynthesis\r\n" +
+                            "- Audio clips are adjusted to compensate for lost frames")
                     with gr.Row():
                         inflate = gr.Checkbox(label="Inflate New Frames",value=True)
                         with gr.Box():
-                            gr.Markdown("New frames are inserted by AI interpolation for smooth motion\r\n- Project FPS is doubled when inflation is used\r\n- Audio clips do not need adjusting for inflation")
+                            gr.Markdown(
+                            "New frames are inserted by AI interpolation for smooth motion\r\n" +
+                            "- Project FPS is doubled when inflation is used\r\n" +
+                            "- Audio clips do not need adjusting for inflation")
                     with gr.Row():
                         upscale = gr.Checkbox(label="Upscale Frames", value=True)
                         upscale_option = gr.Radio(label="Upscale By", value="2X",
                                                   choices=["1X", "2X", "4X"])
                         with gr.Box():
-                            gr.Markdown("Frames are cleansed and enlarged using AI - Real-ESRGAN 4x+\r\n")
+                            gr.Markdown(
+                                "Frames are cleansed and enlarged using AI - Real-ESRGAN 4x+\r\n")
                     message_box5 = gr.Textbox(
                         value="Next: Perform all Processing Steps (takes from hours to days)",
                                               show_label=False, interactive=False)
@@ -273,8 +283,9 @@ class VideoRemixer(TabBase):
                             custom_audio_options = gr.Textbox(
                                 label="Custom FFmpeg Audio Output Options",
                         info="Passed to FFmpeg as output audio settings when combining with video")
-                            output_filepath_custom = gr.Textbox(label="Output Filepath", max_lines=1,
-                                    info="Enter a path and filename for the remixed video")
+                            output_filepath_custom = gr.Textbox(label="Output Filepath",
+                                                                max_lines=1,
+                                            info="Enter a path and filename for the remixed video")
                             with gr.Row():
                                 message_box61 = gr.Textbox(value=None, show_label=False,
                                                           interactive=False)
@@ -294,8 +305,9 @@ class VideoRemixer(TabBase):
                             marked_audio_options = gr.Textbox(value=marked_ffmpeg_audio,
                                 label="Marked FFmpeg Audio Output Options",
                         info="Passed to FFmpeg as output audio settings when combining with video")
-                            output_filepath_marked = gr.Textbox(label="Output Filepath", max_lines=1,
-                                    info="Enter a path and filename for the remixed video")
+                            output_filepath_marked = gr.Textbox(label="Output Filepath",
+                                                                max_lines=1,
+                                            info="Enter a path and filename for the remixed video")
                             with gr.Row():
                                 message_box62 = gr.Textbox(value=None, show_label=False,
                                                           interactive=False)
@@ -316,124 +328,172 @@ class VideoRemixer(TabBase):
                         with gr.Tab(label="Utilities", id=0):
                             with gr.Tabs() as tabs_remix_extra_utils:
                                 with gr.Tab("Drop Processed Scene", id=0):
-                                    gr.Markdown("**_Drop a scene after processing has been already been done_**")
+                                    gr.Markdown(
+                                "**_Drop a scene after processing has been already been done_**")
                                     scene_id_700 = gr.Number(value=-1, label="Scene Index")
                                     with gr.Row():
-                                        message_box700 = gr.Textbox(show_label=False, interactive=False)
-                                    drop_button700 = gr.Button("Drop Scene", variant="stop").style(full_width=False)
+                                        message_box700 = gr.Textbox(show_label=False,
+                                                                    interactive=False)
+                                    drop_button700 = gr.Button("Drop Scene", variant="stop").\
+                                        style(full_width=False)
 
                                 with gr.Tab("Choose Scene Range", id=1):
                                     gr.Markdown("**_Keep or Drop a range of scenes_**")
                                     with gr.Row():
                                         first_scene_id_701 = gr.Number(value=-1,
-                                                                        label="Starting Scene Index")
+                                                                    label="Starting Scene Index")
                                         last_scene_id_701 = gr.Number(value=-1,
-                                                                        label="Ending Scene Index")
+                                                                    label="Ending Scene Index")
                                     with gr.Row():
-                                        scene_state_701 = gr.Radio(label="Scenes Choice", value=None,
-                                                                        choices=["Keep", "Drop"])
+                                        scene_state_701 = gr.Radio(label="Scenes Choice",
+                                                                   value=None,
+                                                                   choices=["Keep", "Drop"])
                                     with gr.Row():
-                                        message_box701 = gr.Textbox(show_label=False, interactive=False)
-                                    choose_button701 = gr.Button("Choose Scene Range", variant="stop").style(full_width=False)
+                                        message_box701 = gr.Textbox(show_label=False,
+                                                                    interactive=False)
+                                    choose_button701 = gr.Button("Choose Scene Range",
+                                                            variant="stop").style(full_width=False)
 
                                 with gr.Tab("Split Scene", id=2):
                                     gr.Markdown("**_Split a Scene in two at the 50% point_**")
                                     scene_id_702 = gr.Number(value=-1, label="Scene Index")
                                     with gr.Row():
-                                        message_box702 = gr.Textbox(show_label=False, interactive=False)
-                                    split_button702 = gr.Button("Split Scene", variant="stop").style(full_width=False)
+                                        message_box702 = gr.Textbox(show_label=False,
+                                                                    interactive=False)
+                                    split_button702 = gr.Button("Split Scene", variant="stop").\
+                                        style(full_width=False)
 
                         with gr.Tab(label="Reduce Footprint", id=1):
                             with gr.Tabs():
                                 with gr.Tab(label="Remove Soft-Deleted Content"):
-                                    gr.Markdown("**_Delete content set aside when remix processing selections are changed_**")
+                                    gr.Markdown(
+                    "**_Delete content set aside when remix processing selections are changed_**")
                                     with gr.Row():
-                                        delete_purged_710 = gr.Checkbox(label="Permanently Delete Purged Content")
+                                        delete_purged_710 = gr.Checkbox(
+                                            label="Permanently Delete Purged Content")
                                         with gr.Box():
-                                            gr.Markdown("Delete the contents of the 'purged_content' project directory.")
+                                            gr.Markdown(
+                                "Delete the contents of the 'purged_content' project directory.")
                                     with gr.Row():
                                         message_box710 = gr.Textbox(show_label=False)
                                     gr.Markdown("*Progress can be tracked in the console*")
                                     with gr.Row():
-                                        delete_button710 = gr.Button(value="Delete Purged Content " + SimpleIcons.SLOW_SYMBOL, variant="stop")
-                                        select_all_button710 = gr.Button(value="Select All").style(full_width=False)
-                                        select_none_button710 = gr.Button(value="Select None").style(full_width=False)
+                                        delete_button710 = gr.Button(value="Delete Purged Content "\
+                                                        + SimpleIcons.SLOW_SYMBOL, variant="stop")
+                                        select_all_button710 = gr.Button(value="Select All").\
+                                            style(full_width=False)
+                                        select_none_button710 = gr.Button(value="Select None").\
+                                            style(full_width=False)
 
                                 with gr.Tab(label="Remove Scene Chooser Content"):
-                                    gr.Markdown("**_Delete source PNG frame files, thumbnails and dropped scenes_**")
+                                    gr.Markdown(
+                            "**_Delete source PNG frame files, thumbnails and dropped scenes_**")
                                     with gr.Row():
-                                        delete_source_711 = gr.Checkbox(label="Remove Source Video Frames")
+                                        delete_source_711 = gr.Checkbox(
+                                            label="Remove Source Video Frames")
                                         with gr.Box():
-                                            gr.Markdown("Delete source video PNG frame files used to split content into scenes.")
+                                            gr.Markdown(
+                        "Delete source video PNG frame files used to split content into scenes.")
                                     with gr.Row():
-                                        delete_dropped_711 = gr.Checkbox(label="Remove Dropped Scenes")
+                                        delete_dropped_711 = gr.Checkbox(
+                                            label="Remove Dropped Scenes")
                                         with gr.Box():
-                                            gr.Markdown("Delete Dropped Scene files used when compiling scenes after making scene choices.")
+                                            gr.Markdown(
+                "Delete Dropped Scene files used when compiling scenes after making scene choices.")
                                     with gr.Row():
                                         delete_thumbs_711 = gr.Checkbox(label="Remove Thumbnails")
                                         with gr.Box():
-                                            gr.Markdown("Delete Thumbnails used to display scenes in Scene Chooser.")
+                                            gr.Markdown(
+                                    "Delete Thumbnails used to display scenes in Scene Chooser.")
                                     with gr.Row():
                                         message_box711 = gr.Textbox(show_label=False)
                                     gr.Markdown("*Progress can be tracked in the console*")
                                     with gr.Row():
-                                        delete_button711 = gr.Button(value="Delete Selected Content " + SimpleIcons.SLOW_SYMBOL, variant="stop")
-                                        select_all_button711 = gr.Button(value="Select All").style(full_width=False)
-                                        select_none_button711 = gr.Button(value="Select None").style(full_width=False)
+                                        delete_button711 = gr.Button(
+                                            value="Delete Selected Content " +\
+                                                SimpleIcons.SLOW_SYMBOL, variant="stop")
+                                        select_all_button711 = gr.Button(value="Select All").\
+                                            style(full_width=False)
+                                        select_none_button711 = gr.Button(value="Select None").\
+                                            style(full_width=False)
 
                                 with gr.Tab(label="Remove Remix Video Source Content"):
-                                    gr.Markdown("**_Clear space after final Remix Videos have been saved_**")
+                                    gr.Markdown(
+                                    "**_Clear space after final Remix Videos have been saved_**")
                                     with gr.Row():
                                         delete_kept_712 = gr.Checkbox(label="Remove Kept Scenes")
                                         with gr.Box():
-                                            gr.Markdown("Delete Kept Scene files used when compiling scenes after making scene choices.")
+                                            gr.Markdown(
+                "Delete Kept Scene files used when compiling scenes after making scene choices.")
                                     with gr.Row():
-                                        delete_resized_712 = gr.Checkbox(label="Remove Resized Frames")
+                                        delete_resized_712 = gr.Checkbox(
+                                            label="Remove Resized Frames")
                                         with gr.Box():
-                                            gr.Markdown("Delete Resized PNG frame files used as inputs for processing and creating remix video clips.")
+                                            gr.Markdown(
+    "Delete Resized PNG frame files used as inputs for processing and creating remix video clips.")
                                     with gr.Row():
-                                        delete_resynth_712 = gr.Checkbox(label="Remove Resynthesized Frames")
+                                        delete_resynth_712 = gr.Checkbox(
+                                            label="Remove Resynthesized Frames")
                                         with gr.Box():
-                                            gr.Markdown("Delete Resynthesized PNG frame files used as inputs for processing and creating remix video clips.")
+                                            gr.Markdown(
+                                        "Delete Resynthesized PNG frame files used as inputs " +\
+                                        "for processing and creating remix video clips.")
                                     with gr.Row():
-                                        delete_inflated_712 = gr.Checkbox(label="Remove Inflated Frames")
+                                        delete_inflated_712 = gr.Checkbox(
+                                            label="Remove Inflated Frames")
                                         with gr.Box():
-                                            gr.Markdown("Delete Inflated PNG frame files used as inputs for processing and creating remix video clips.")
+                                            gr.Markdown(
+    "Delete Inflated PNG frame files used as inputs for processing and creating remix video clips.")
                                     with gr.Row():
-                                        delete_upscaled_712 = gr.Checkbox(label="Remove Upscaled Frames")
+                                        delete_upscaled_712 = gr.Checkbox(
+                                            label="Remove Upscaled Frames")
                                         with gr.Box():
-                                            gr.Markdown("Delete Upscaled PNG frame files used as inputs for processing and creating remix video clips.")
+                                            gr.Markdown(
+    "Delete Upscaled PNG frame files used as inputs for processing and creating remix video clips.")
                                     with gr.Row():
                                         delete_audio_712 = gr.Checkbox(label="Delete Audio Clips")
                                         with gr.Box():
-                                            gr.Markdown("Delete Audio WAV/MP3 files used as inputs for creating remix video clips.")
+                                            gr.Markdown(
+                        "Delete Audio WAV/MP3 files used as inputs for creating remix video clips.")
                                     with gr.Row():
                                         delete_video_712 = gr.Checkbox(label="Delete Video Clips")
                                         with gr.Box():
-                                            gr.Markdown("Delete Video MP4 files used as inputs for creating remix video clips.")
+                                            gr.Markdown(
+                            "Delete Video MP4 files used as inputs for creating remix video clips.")
                                     with gr.Row():
-                                        delete_clips_712 = gr.Checkbox(label="Delete Remix Video Clips")
+                                        delete_clips_712 = gr.Checkbox(
+                                            label="Delete Remix Video Clips")
                                         with gr.Box():
-                                            gr.Markdown("Delete Video+Audio MP4 files used as inputs to concatentate into the final Remix Video.")
+                                            gr.Markdown(
+        "Delete Video+Audio MP4 files used as inputs to concatentate into the final Remix Video.")
                                     with gr.Row():
                                         message_box712 = gr.Textbox(show_label=False)
                                     gr.Markdown("*Progress can be tracked in the console*")
                                     with gr.Row():
-                                        delete_button712 = gr.Button(value="Delete Selected Content " + SimpleIcons.SLOW_SYMBOL, variant="stop")
-                                        select_all_button712 = gr.Button(value="Select All").style(full_width=False)
-                                        select_none_button712 = gr.Button(value="Select None").style(full_width=False)
+                                        delete_button712 = gr.Button(
+                                            value="Delete Selected Content " +\
+                                                SimpleIcons.SLOW_SYMBOL, variant="stop")
+                                        select_all_button712 = gr.Button(value="Select All").\
+                                            style(full_width=False)
+                                        select_none_button712 = gr.Button(value="Select None").\
+                                            style(full_width=False)
 
                                 with gr.Tab(label="Remove All Processed Content"):
-                                    gr.Markdown("**_Delete all processed project content (except videos)_**")
+                                    gr.Markdown(
+                                    "**_Delete all processed project content (except videos)_**")
                                     with gr.Row():
-                                        delete_all_713 = gr.Checkbox(label="Permanently Delete Processed Content")
+                                        delete_all_713 = gr.Checkbox(
+                                            label="Permanently Delete Processed Content")
                                         with gr.Box():
-                                            gr.Markdown("Deletes all created project content. **Does not delete original and remixed videos.**")
+                                            gr.Markdown(
+            "Deletes all created project content. **Does not delete original and remixed videos.**")
                                     with gr.Row():
                                         message_box713 = gr.Textbox(show_label=False)
                                     gr.Markdown("*Progress can be tracked in the console*")
                                     with gr.Row():
-                                        delete_button713 = gr.Button(value="Delete Processed Content " + SimpleIcons.SLOW_SYMBOL, variant="stop")
+                                        delete_button713 = gr.Button(
+                                            value="Delete Processed Content " +\
+                                                SimpleIcons.SLOW_SYMBOL, variant="stop")
 
                     # with gr.Accordion(SimpleIcons.TIPS_SYMBOL + " Guide", open=False):
                     #     WebuiTips.video_remixer_save.render()
@@ -572,8 +632,8 @@ class VideoRemixer(TabBase):
 
         choose_button701.click(self.choose_button701,
                                inputs=[first_scene_id_701, last_scene_id_701, scene_state_701],
-                               outputs=[tabs_video_remixer, message_box701, scene_index, scene_label,
-                                       scene_image, scene_state, scene_info])
+                               outputs=[tabs_video_remixer, message_box701, scene_index,
+                                        scene_label, scene_image, scene_state, scene_info])
 
         split_button702.click(self.split_button702, inputs=scene_id_702,
                               outputs=[tabs_video_remixer, message_box702, scene_index, scene_label,
@@ -706,7 +766,8 @@ class VideoRemixer(TabBase):
             self.state.tryattr("project_fps", self.config.remixer_settings["def_project_fps"]), \
             self.state.tryattr("deinterlace", self.state.UI_SAFETY_DEFAULTS["deinterlace"]), \
             self.state.tryattr("split_type", self.state.UI_SAFETY_DEFAULTS["split_type"]), \
-            self.state.tryattr("scene_threshold", self.state.UI_SAFETY_DEFAULTS["scene_threshold"]), \
+            self.state.tryattr("scene_threshold", \
+                               self.state.UI_SAFETY_DEFAULTS["scene_threshold"]), \
             self.state.tryattr("break_duration", self.state.UI_SAFETY_DEFAULTS["break_duration"]), \
             self.state.tryattr("break_ratio", self.state.UI_SAFETY_DEFAULTS["break_ratio"]), \
             self.state.tryattr("resize_w"), \
@@ -715,7 +776,8 @@ class VideoRemixer(TabBase):
             self.state.tryattr("crop_h"), \
             self.state.tryattr("project_info2"), \
             self.state.tryattr("thumbnail_type", self.state.UI_SAFETY_DEFAULTS["thumbnail_type"]), \
-            self.state.tryattr("min_frames_per_scene", self.state.UI_SAFETY_DEFAULTS["min_frames_per_scene"]), \
+            self.state.tryattr("min_frames_per_scene", \
+                               self.state.UI_SAFETY_DEFAULTS["min_frames_per_scene"]), \
             *scene_details, \
             self.state.tryattr("project_info4"), \
             self.state.tryattr("resize", self.state.UI_SAFETY_DEFAULTS["resize"]), \
@@ -1041,7 +1103,8 @@ class VideoRemixer(TabBase):
 
             if self.state.resynthesize:
                 if self.state.processed_content_present(self.state.RESYNTH_STEP):
-                    jot.down(f"Using processed resynthesized scenes in {self.state.resynthesis_path}")
+                    jot.down(
+                        f"Using processed resynthesized scenes in {self.state.resynthesis_path}")
                 else:
                     self.state.resynthesize_scenes(self.log,
                                                 kept_scenes,
@@ -1125,7 +1188,8 @@ class VideoRemixer(TabBase):
 
         # create audio clips only if they do not already exist
         # this depends on the audio clips being purged at the time the scene selection are compiled
-        if self.state.video_details["has_audio"] and not self.state.processed_content_present("audio"):
+        if self.state.video_details["has_audio"] and not \
+                self.state.processed_content_present("audio"):
             self.log("about to create audio clips")
             audio_format = self.config.remixer_settings["audio_format"]
             self.state.create_audio_clips(self.log, global_options, audio_format=audio_format)
@@ -1299,21 +1363,27 @@ class VideoRemixer(TabBase):
 
         if not isinstance(scene_index, (int, float)):
             message = f"Please enter a Scene Index to get started"
-            return gr.update(selected=7), gr.update(visible=True, value=message), *self.empty_args(5)
+            return gr.update(selected=7), \
+                gr.update(visible=True, value=message), \
+                *self.empty_args(5)
 
         num_scenes = len(self.state.scene_names)
         last_scene = num_scenes - 1
         scene_index = int(scene_index)
         if scene_index < 0 or scene_index > last_scene:
             message = f"Please enter a Scene Index from 0 to {last_scene}"
-            return gr.update(selected=7), gr.update(visible=True, value=message), *self.empty_args(5)
+            return gr.update(selected=7), \
+                gr.update(visible=True, value=message), \
+                *self.empty_args(5)
 
         scene_name = self.state.scene_names[scene_index]
         first_frame, last_frame, num_width = details_from_group_name(scene_name)
         num_frames = (last_frame - first_frame) + 1
         if num_frames < 2:
             message = f"Scene must have at least two frames to be split"
-            return gr.update(selected=7), gr.update(visible=True, value=message), *self.empty_args(5)
+            return gr.update(selected=7), \
+                gr.update(visible=True, value=message), \
+                *self.empty_args(5)
 
         # ensure the split is at least at the 50% point
         split_frame = math.ceil(num_frames * split_point)
@@ -1321,12 +1391,14 @@ class VideoRemixer(TabBase):
 
         new_lower_first_frame = first_frame
         new_lower_last_frame = first_frame + (split_frame - 1)
-        new_lower_scene_name = VideoRemixerState.encode_scene_label(num_width, new_lower_first_frame, new_lower_last_frame, 0, 0)
+        new_lower_scene_name = VideoRemixerState.encode_scene_label(num_width,
+                                                new_lower_first_frame, new_lower_last_frame, 0, 0)
         self.log(f"new lower scene name: {new_lower_scene_name}")
 
         new_upper_first_frame = first_frame + split_frame
         new_upper_last_frame = last_frame
-        new_upper_scene_name = VideoRemixerState.encode_scene_label(num_width, new_upper_first_frame, new_upper_last_frame, 0, 0)
+        new_upper_scene_name = VideoRemixerState.encode_scene_label(num_width,
+                                                new_upper_first_frame, new_upper_last_frame, 0, 0)
         self.log(f"new upper scene name: {new_upper_scene_name}")
 
         original_scene_path = os.path.join(self.state.scenes_path, scene_name)
@@ -1340,8 +1412,11 @@ class VideoRemixer(TabBase):
         frame_files = sorted(get_files(original_scene_path))
         num_frame_files = len(frame_files)
         if num_frame_files != num_frames:
-            message = f"Mismatch between expected frames ({num_frames}) and found frames ({num_frame_files}) in scene path '{original_scene_path}'"
-            return gr.update(selected=7), gr.update(visible=True, value=message), *self.empty_args(5)
+            message = f"Mismatch between expected frames ({num_frames}) and found frames " + \
+                f"({num_frame_files}) in scene path '{original_scene_path}'"
+            return gr.update(selected=7), \
+                gr.update(visible=True, value=message), \
+                    *self.empty_args(5)
 
         messages = Jot()
 
@@ -1389,10 +1464,12 @@ class VideoRemixer(TabBase):
         os.remove(thumbnail_file)
         messages.add(f"Deleted thumbnail {thumbnail_file}")
         self.log(f"about to create thumbnail for new lower scene {new_lower_scene_name}")
-        self.state.create_thumbnail(new_lower_scene_name, self.log, global_options, self.config.remixer_settings)
+        self.state.create_thumbnail(new_lower_scene_name, self.log, global_options,
+                                    self.config.remixer_settings)
         messages.add(f"Created thumbnail for scene {new_lower_scene_name}")
         self.log(f"about to create thumbnail for new upper scene {new_upper_scene_name}")
-        self.state.create_thumbnail(new_upper_scene_name, self.log, global_options, self.config.remixer_settings)
+        self.state.create_thumbnail(new_upper_scene_name, self.log, global_options,
+                                    self.config.remixer_settings)
         self.state.thumbnails = sorted(get_files(self.state.thumbnail_path))
         messages.add(f"Created thumbnail for scene {new_upper_scene_name}")
 
@@ -1443,7 +1520,15 @@ class VideoRemixer(TabBase):
                 gr.update(value=False), \
                 gr.update(value=False)
 
-    def delete_button712(self, delete_kept, delete_resized, delete_resynth, delete_inflated, delete_upscaled, delete_audio, delete_video, delete_clips):
+    def delete_button712(self,
+                         delete_kept,
+                         delete_resized,
+                         delete_resynth,
+                         delete_inflated,
+                         delete_upscaled,
+                         delete_audio,
+                         delete_video,
+                         delete_clips):
         removed = []
         if delete_kept:
             removed.append(self.state.delete_path(self.state.scenes_path))

--- a/tabs/video_remixer_ui.py
+++ b/tabs/video_remixer_ui.py
@@ -130,7 +130,7 @@ class VideoRemixer(TabBase):
         value="Next: Create Scenes, Thumbnails and Audio Clips (takes from minutes to hours)",
                                     show_label=False, visible=True, interactive=False)
 
-                    gr.Markdown("*Progress can be tracked in the console*")
+                    gr.Markdown("⚠️**Important: Redoing this step will purge and recreate content!** *Progress can be tracked in the console*")
                     with gr.Row():
                         back_button2 = gr.Button(value="< Back", variant="secondary").\
                             style(full_width=False)

--- a/tabs/video_remixer_ui.py
+++ b/tabs/video_remixer_ui.py
@@ -124,7 +124,7 @@ class VideoRemixer(TabBase):
                                     info="Choose 'GIF' for whole-scene animations (slow to render)")
                         min_frames_per_scene = gr.Number(label="Minimum Frames Per Scene",
                                     precision=0, value=def_min_frames,
-                        info="consolidates very small scenes info the next (0 to disable)")
+                        info="Consolidates very small scenes info the next (0 to disable)")
                     with gr.Row():
                         message_box2 = gr.Textbox(
         value="Next: Create Scenes, Thumbnails and Audio Clips (takes from minutes to hours)",

--- a/video_remixer.py
+++ b/video_remixer.py
@@ -388,7 +388,8 @@ class VideoRemixerState():
         path = state["path"]
         num_width = state["num_width"]
         first, last, _ = VideoRemixerState.decode_scene_label(scene_label)
-        new_scene_label = VideoRemixerState.encode_scene_label(num_width, first, last, 0, new_contents)
+        new_scene_label = VideoRemixerState.encode_scene_label(num_width, first, last, 0,
+                                                               new_contents)
         scene_label_path = os.path.join(path, scene_label)
         new_scene_label_path = os.path.join(path, new_scene_label)
         log_fn(f"renaming {scene_label_path} to {new_scene_label_path}")
@@ -413,7 +414,10 @@ class VideoRemixerState():
                  "log_fn" : log_fn}
         with Mtqdm().open_bar(total=1, desc="Shrink") as bar:
             Mtqdm().message(bar, "Shrinking small scenes - no ETA")
-            shrunk_container_data = shrink(container_data, self.min_frames_per_scene, VideoRemixerState.move_frames, VideoRemixerState.remove_scene, VideoRemixerState.rename_scene, state)
+            shrunk_container_data = shrink(container_data, self.min_frames_per_scene,
+                                           VideoRemixerState.move_frames,
+                                           VideoRemixerState.remove_scene,
+                                           VideoRemixerState.rename_scene, state)
             Mtqdm().update_bar(bar)
         log_fn(f"shrunk container data: {shrunk_container_data}")
 
@@ -562,7 +566,8 @@ class VideoRemixerState():
                 ((last_index + 1) - first_index) / self.project_fps,
                 self.project_fps)
             keep_state = True if scene_state == "Keep" else False
-            return scene_name, thumbnail_path, scene_state, scene_position, scene_start, scene_duration, keep_state
+            return scene_name, thumbnail_path, scene_state, scene_position, scene_start, \
+                scene_duration, keep_state
         except ValueError as error:
             raise ValueError(
                 f"ValueError encountered while computing scene chooser details: {error}")
@@ -765,7 +770,8 @@ class VideoRemixerState():
             self.purge_processed_content(self.RESYNTH_STEP)
         if self.processed_content_present(self.INFLATE_STEP) and not self.inflate:
             self.purge_processed_content(self.INFLATE_STEP)
-        if self.processed_content_present(self.UPSCALE_STEP) and (not self.upscale or purge_upscale):
+        if self.processed_content_present(self.UPSCALE_STEP) and \
+                (not self.upscale or purge_upscale):
             self.purge_processed_content(self.UPSCALE_STEP)
 
     def processed_content_incomplete(self, present_at):
@@ -1150,7 +1156,12 @@ class VideoRemixerState():
         else:
             self.clips = sorted(get_files(self.video_clips_path))
 
-    def create_custom_video_clips(self, log_fn, kept_scenes, global_options, custom_video_options, custom_ext):
+    def create_custom_video_clips(self,
+                                  log_fn,
+                                  kept_scenes,
+                                  global_options,
+                                  custom_video_options,
+                                  custom_ext):
         self.video_clips_path = os.path.join(self.clips_path, self.VIDEO_CLIPS_PATH)
         create_directory(self.video_clips_path)
 
@@ -1170,7 +1181,8 @@ class VideoRemixerState():
         with Mtqdm().open_bar(total=len(kept_scenes), desc="Video Clips") as bar:
             for scene_name in kept_scenes:
                 scene_input_path = os.path.join(scenes_base_path, scene_name)
-                scene_output_filepath = os.path.join(self.video_clips_path, f"{scene_name}.{custom_ext}")
+                scene_output_filepath = os.path.join(self.video_clips_path,
+                                                     f"{scene_name}.{custom_ext}")
 
                 use_custom_video_options = custom_video_options
                 # handle some custom text substitutions
@@ -1211,13 +1223,18 @@ class VideoRemixerState():
                 Mtqdm().update_bar(bar)
         self.video_clips = sorted(get_files(self.video_clips_path))
 
-    def create_custom_scene_clips(self, kept_scenes, global_options, custom_audio_options, custom_ext):
+    def create_custom_scene_clips(self,
+                                  kept_scenes,
+                                  global_options,
+                                  custom_audio_options,
+                                  custom_ext):
         if self.video_details["has_audio"]:
             with Mtqdm().open_bar(total=len(kept_scenes), desc="Remix Clips") as bar:
                 for index, scene_name in enumerate(kept_scenes):
                     scene_video_path = self.video_clips[index]
                     scene_audio_path = self.audio_clips[index]
-                    scene_output_filepath = os.path.join(self.clips_path, f"{scene_name}.{custom_ext}")
+                    scene_output_filepath = os.path.join(self.clips_path,
+                                                         f"{scene_name}.{custom_ext}")
                     combine_video_audio(scene_video_path, scene_audio_path,
                                         scene_output_filepath, global_options=global_options,
                                         output_options=custom_audio_options)
@@ -1253,14 +1270,17 @@ class VideoRemixerState():
             return path, [], messages.report()
 
         if not files and path_files:
-            messages.add(f"{description} path '{path}' has {path_file_count} files unknown to the project. The files are being ignored (safe to delete).")
+            messages.add(f"{description} path '{path}' has {path_file_count} files unknown " +
+                         " to the project. The files are being ignored (safe to delete).")
             return path, [], messages.report()
 
         if path_file_count != file_count:
-            messages.add(f"{description} path '{path}' should have {file_count} files but has {path_file_count}. The files are being ignored (safe to delete).")
+            messages.add(f"{description} path '{path}' should have {file_count} files" +
+                    f" but has {path_file_count}. The files are being ignored (safe to delete).")
             return path, [], messages.report()
 
-        # TODO further possible checks: files have bytes, files are found to be the right binary type, etc
+        # TODO further possible checks: files have bytes,
+        # files are found to be the right binary type, etc
 
         return path, files, messages.report()
 
@@ -1279,23 +1299,28 @@ class VideoRemixerState():
     def post_load_integrity_check(self):
         messages = Jot()
 
-        self.thumbnail_path, self.thumbnails, message = self.ensure_valid_populated_path("Thumbnails", self.thumbnail_path, self.thumbnails)
+        self.thumbnail_path, self.thumbnails, message = self.ensure_valid_populated_path(
+            "Thumbnails", self.thumbnail_path, self.thumbnails)
         if message:
             messages.add(message)
 
-        self.clips_path, self.clips, message = self.ensure_valid_populated_path("Clips", self.clips_path, self.clips)
+        self.clips_path, self.clips, message = self.ensure_valid_populated_path(
+            "Clips", self.clips_path, self.clips)
         if message:
             messages.add(message)
 
-        self.audio_clips_path, self.audio_clips, message = self.ensure_valid_populated_path("Audio Clips", self.audio_clips_path, self.audio_clips)
+        self.audio_clips_path, self.audio_clips, message = self.ensure_valid_populated_path(
+            "Audio Clips", self.audio_clips_path, self.audio_clips)
         if message:
             messages.add(message)
 
-        self.video_clips_path, self.video_clips, message = self.ensure_valid_populated_path("Video Clips", self.video_clips_path, self.video_clips)
+        self.video_clips_path, self.video_clips, message = self.ensure_valid_populated_path(
+            "Video Clips", self.video_clips_path, self.video_clips)
         if message:
             messages.add(message)
 
-        self.dropped_scenes_path, message = self.ensure_valid_path("Dropped Scenes", self.dropped_scenes_path)
+        self.dropped_scenes_path, message = self.ensure_valid_path(
+            "Dropped Scenes", self.dropped_scenes_path)
         if message:
             messages.add(message)
 
@@ -1315,7 +1340,8 @@ class VideoRemixerState():
         if message:
             messages.add(message)
 
-        self.resynthesis_path, message = self.ensure_valid_path("Resynthesis Path", self.resynthesis_path)
+        self.resynthesis_path, message = self.ensure_valid_path(
+            "Resynthesis Path", self.resynthesis_path)
         if message:
             messages.add(message)
 
@@ -1355,7 +1381,8 @@ class VideoRemixerState():
             except YAMLError as error:
                 if hasattr(error, 'problem_mark'):
                     mark = error.problem_mark
-                    message = f"Error loading project file on line {mark.line+1} column {mark.column+1}: {error}"
+                    message = \
+                f"Error loading project file on line {mark.line+1} column {mark.column+1}: {error}"
                 else:
                     message = error
                 raise ValueError(message)

--- a/video_remixer.py
+++ b/video_remixer.py
@@ -245,12 +245,17 @@ class VideoRemixerState():
             self.source_video = project_video_path
             Mtqdm().update_bar(bar)
 
+    def copy_project_file(self, copy_path):
+        project_file = self.determine_project_filepath(self.project_path)
+        saved_project_file = os.path.join(copy_path, self.DEF_FILENAME)
+        shutil.copy(project_file, saved_project_file)
+
     # when advancing forward from the Set Up Project step
     # the user may be redoing the project from this step
     # need to purge anything created based on old settings
     # TODO make purging on backing up smarter
     def reset_at_project_settings(self):
-        remove_directories([
+        purge_path = self.purge_paths([
             self.scenes_path,
             self.dropped_scenes_path,
             self.thumbnail_path,
@@ -259,6 +264,7 @@ class VideoRemixerState():
             self.resynthesis_path,
             self.inflation_path,
             self.upscale_path])
+        self.copy_project_file(purge_path)
         self.scene_names = []
         self.current_scene = 0
         self.thumbnails = []
@@ -648,6 +654,7 @@ class VideoRemixerState():
         for path in path_list:
             if path and os.path.exists(path):
                 shutil.move(path, purged_path)
+        return purged_path
 
     def delete_purged_content(self):
         purged_root_path = os.path.join(self.project_path, self.PURGED_CONTENT)
@@ -672,23 +679,24 @@ class VideoRemixerState():
 
     def purge_processed_content(self, purge_from):
         if purge_from == self.RESIZE_STEP:
-            self.purge_paths([
+            purge_path = self.purge_paths([
                 self.resize_path,
                 self.resynthesis_path,
                 self.inflation_path,
                 self.upscale_path])
         elif purge_from == self.RESYNTH_STEP:
-            self.purge_paths([
+            purge_path = self.purge_paths([
                 self.resynthesis_path,
                 self.inflation_path,
                 self.upscale_path])
         elif purge_from == self.INFLATE_STEP:
-            self.purge_paths([
+            purge_path = self.purge_paths([
                 self.inflation_path,
                 self.upscale_path])
         elif purge_from == self.UPSCALE_STEP:
-            self.purge_paths([
+            purge_path = self.purge_paths([
                 self.upscale_path])
+        self.copy_project_file(purge_path)
         self.clean_remix_content(purge_from="audio_clips")
 
     def clean_remix_content(self, purge_from):


### PR DESCRIPTION
When auto-resetting the project in response to changes being made on the _Remix Settings_ page and then clicking _Setup Project_ on the next tab, the project directories were being removed instead of soft-deleted. Now they are soft-deleted, and the project file is saved to the purge directory too.

also
- return to scene chooser tab after using _Choose Scene Range_
- add warning message to _Set Up Project_ tab about purging of content