### PR TITLE
Video Remixer: Use markdown for message box (user feedback UI)

### DIFF
--- a/tabs/video_remixer_ui.py
+++ b/tabs/video_remixer_ui.py
@@ -335,8 +335,7 @@ class VideoRemixer(TabBase):
                                 "**_Drop a scene after processing has been already been done_**")
                                     scene_id_700 = gr.Number(value=-1, label="Scene Index")
                                     with gr.Row():
-                                        message_box700 = gr.Textbox(show_label=False,
-                                                                    interactive=False)
+                                        message_box700 = gr.Markdown(self.format_markdown("Click Drop Scene to: Remove all Processed Content for the specified scene"))
                                     drop_button700 = gr.Button("Drop Scene", variant="stop").\
                                         style(full_width=False)
 
@@ -352,8 +351,7 @@ class VideoRemixer(TabBase):
                                                                    value=None,
                                                                    choices=["Keep", "Drop"])
                                     with gr.Row():
-                                        message_box701 = gr.Textbox(show_label=False,
-                                                                    interactive=False)
+                                        message_box701 = gr.Markdown(self.format_markdown("Click Choose Scene Range to: Set the Scene Range to the specified state"))
                                     choose_button701 = gr.Button("Choose Scene Range",
                                                             variant="stop").style(full_width=False)
 
@@ -361,8 +359,7 @@ class VideoRemixer(TabBase):
                                     gr.Markdown("**_Split a Scene in two at the 50% point_**")
                                     scene_id_702 = gr.Number(value=-1, label="Scene Index")
                                     with gr.Row():
-                                        message_box702 = gr.Textbox(show_label=False,
-                                                                    interactive=False)
+                                        message_box702 = gr.Markdown(self.format_markdown("Click Split Scene to: Split the scenes into Two Scenes at the Halfway Point"))
                                     split_button702 = gr.Button("Split Scene", variant="stop").\
                                         style(full_width=False)
 
@@ -378,7 +375,7 @@ class VideoRemixer(TabBase):
                                             gr.Markdown(
                                 "Delete the contents of the 'purged_content' project directory.")
                                     with gr.Row():
-                                        message_box710 = gr.Textbox(show_label=False)
+                                        message_box710 = gr.Markdown(self.format_markdown("Click Delete Purged Content to: Permanently Remove soft-deleted content"))
                                     gr.Markdown("*Progress can be tracked in the console*")
                                     with gr.Row():
                                         delete_button710 = gr.Button(value="Delete Purged Content "\
@@ -409,7 +406,7 @@ class VideoRemixer(TabBase):
                                             gr.Markdown(
                                     "Delete Thumbnails used to display scenes in Scene Chooser.")
                                     with gr.Row():
-                                        message_box711 = gr.Textbox(show_label=False)
+                                        message_box711 = gr.Markdown(self.format_markdown("Click Delete Selected Content to: Permanently Remove the selected content"))
                                     gr.Markdown("*Progress can be tracked in the console*")
                                     with gr.Row():
                                         delete_button711 = gr.Button(
@@ -470,7 +467,7 @@ class VideoRemixer(TabBase):
                                             gr.Markdown(
         "Delete Video+Audio MP4 files used as inputs to concatentate into the final Remix Video.")
                                     with gr.Row():
-                                        message_box712 = gr.Textbox(show_label=False)
+                                        message_box712 = gr.Markdown(self.format_markdown("Click Delete Selected Content to: Permanently Remove the selected content"))
                                     gr.Markdown("*Progress can be tracked in the console*")
                                     with gr.Row():
                                         delete_button712 = gr.Button(
@@ -491,7 +488,7 @@ class VideoRemixer(TabBase):
                                             gr.Markdown(
             "Deletes all created project content. **Does not delete original and remixed videos.**")
                                     with gr.Row():
-                                        message_box713 = gr.Textbox(show_label=False)
+                                        message_box713 = gr.Markdown(self.format_markdown("Click Delete Processed Content to: Permanently Remove all processed content"))
                                     gr.Markdown("*Progress can be tracked in the console*")
                                     with gr.Row():
                                         delete_button713 = gr.Button(
@@ -679,6 +676,9 @@ class VideoRemixer(TabBase):
     def empty_args(self, num):
         return [None for _ in range(num)]
 
+    def noop_args(self, num):
+        return [gr.update(visible=True) for _ in range(num)]
+
     def format_markdown(self, text, format="info"):
         style = "font-weight:bold;"
         if format == "plain":
@@ -847,7 +847,7 @@ class VideoRemixer(TabBase):
         except ValueError as error:
             return gr.update(selected=self.TAB_REMIX_SETTINGS), \
                 gr.update(value=self.format_markdown(str(error), "error")), \
-                *self.empty_args(3)
+                *self.noop_args(3)
 
     def back_button1(self):
         return gr.update(selected=self.TAB_REMIX_HOME)
@@ -857,6 +857,11 @@ class VideoRemixer(TabBase):
     # User has clicked Set Up Project from Set Up Project
     def next_button2(self, thumbnail_type, min_frames_per_scene):
         global_options = self.config.ffmpeg_settings["global_options"]
+
+        if not self.state.project_path:
+            return gr.update(selected=self.TAB_SET_UP_PROJECT), \
+                   gr.update(value=self.format_markdown(f"Project settings have not yet been saved on the previous tab", "error")), \
+                   *self.empty_args(5)
 
         self.state.thumbnail_type = thumbnail_type
         self.state.min_frames_per_scene = min_frames_per_scene
@@ -1061,6 +1066,11 @@ class VideoRemixer(TabBase):
 
     # User has clicked Compile Scenes from Compile Scenes
     def next_button4(self):
+        if not self.state.project_path:
+            return gr.update(selected=self.TAB_COMPILE_SCENES), \
+                   gr.update(value=self.format_markdown(f"The project has not yet been set up from the Set Up Project tab.", "error")), \
+                   *self.empty_args(5)
+
         self.log("moving previously dropped scenes back to scenes directory")
         self.state.uncompile_scenes()
 
@@ -1194,7 +1204,7 @@ class VideoRemixer(TabBase):
         else:
             return gr.update(selected=self.TAB_PROC_OPTIONS), \
                    gr.update(value=self.format_markdown("At least one scene must be set to 'Keep' before processing can proceed", "error")), \
-                   *self.empty_args(7)
+                   *self.noop_args(7)
 
     def back_button5(self):
         return gr.update(selected=self.TAB_COMPILE_SCENES)
@@ -1330,13 +1340,11 @@ class VideoRemixer(TabBase):
         last_scene = num_scenes - 1
 
         if not isinstance(scene_index, (int, float)):
-            message = f"Please enter a Scene Index to get started"
-            return gr.update(visible=True, value=message)
+            return gr.update(value=self.format_markdown(f"Please enter a Scene Index to get started", "warning"))
 
         scene_index = int(scene_index)
         if scene_index < 0 or scene_index > last_scene:
-            message = f"Please enter a Scene Index from 0 to {last_scene}"
-            return gr.update(visible=True, value=message)
+            return gr.update(value=self.format_markdown(f"Please enter a Scene Index from 0 to {last_scene}", "warning"))
 
         removed = self.state.force_drop_processed_scene(scene_index)
         self.log(f"removed files: {removed}")
@@ -1344,8 +1352,7 @@ class VideoRemixer(TabBase):
             f"saving project after using force_drop_processed_scene for scene index {scene_index}")
         self.state.save()
         removed = "\r\n".join(removed)
-        message = f"Removed:\r\n{removed}"
-        return gr.update(visible=True, value=message)
+        return gr.update(value=self.format_markdown(f"Removed:\r\n{removed}"))
 
     def choose_button701(self, first_scene_index, last_scene_index, scene_state):
         num_scenes = len(self.state.scene_names)
@@ -1353,8 +1360,9 @@ class VideoRemixer(TabBase):
 
         if not isinstance(first_scene_index, (int, float)) \
                 or not isinstance(last_scene_index, (int, float)):
-            message = "Please enter Scene Indexes to get started"
-            return gr.update(visible=True, value=message)
+            return gr.update(selected=self.TAB_REMIX_EXTRA), \
+    gr.update(value=self.format_markdown("Please enter Scene Indexes to get started", "warning")), \
+                *self.empty_args(5)
 
         first_scene_index = int(first_scene_index)
         last_scene_index = int(last_scene_index)
@@ -1362,16 +1370,19 @@ class VideoRemixer(TabBase):
                 or first_scene_index > last_scene \
                 or last_scene_index < 0 \
                 or last_scene_index > last_scene:
-            message = f"Please enter valid Scene Indexes between 0 and {last_scene} to get started"
-            return gr.update(visible=True, value=message)
+            return gr.update(selected=self.TAB_REMIX_EXTRA), \
+                gr.update(value=self.format_markdown(f"Please enter valid Scene Indexes between 0 and {last_scene} to get started", "warning")), \
+                *self.empty_args(5)
 
         if first_scene_index >= last_scene_index:
-            message = f"'Ending Scene Index' must be higher than 'Starting Scene Index''"
-            return gr.update(visible=True, value=message)
+            return gr.update(selected=self.TAB_REMIX_EXTRA), \
+                gr.update(value=self.format_markdown(f"'Ending Scene Index' must be higher than 'Starting Scene Index'", "warning")), \
+                *self.empty_args(5)
 
         if scene_state not in ["Keep", "Drop"]:
-            message = "Please make a Scenes Choice to get started"
-            return gr.update(visible=True, value=message)
+            return gr.update(selected=self.TAB_REMIX_EXTRA), \
+    gr.update(value=self.format_markdown("Please make a Scenes Choice to get started", "warning")), \
+                *self.empty_args(5)
 
         for scene_index in range(first_scene_index, last_scene_index + 1):
             scene_name = self.state.scene_names[scene_index]
@@ -1386,7 +1397,7 @@ class VideoRemixer(TabBase):
         self.state.save()
 
         return gr.update(selected=self.TAB_CHOOSE_SCENES), \
-            gr.update(visible=True, value=message), \
+            gr.update(value=self.format_markdown(message)), \
             *self.scene_chooser_details(self.state.current_scene)
 
     def split_button702(self, scene_index):
@@ -1394,27 +1405,24 @@ class VideoRemixer(TabBase):
         split_point = 0.5 # make variable later
 
         if not isinstance(scene_index, (int, float)):
-            message = f"Please enter a Scene Index to get started"
             return gr.update(selected=self.TAB_REMIX_EXTRA), \
-                gr.update(visible=True, value=message), \
+                gr.update(value=self.format_markdown("Please enter a Scene Index to get started", "warning")), \
                 *self.empty_args(5)
 
         num_scenes = len(self.state.scene_names)
         last_scene = num_scenes - 1
         scene_index = int(scene_index)
         if scene_index < 0 or scene_index > last_scene:
-            message = f"Please enter a Scene Index from 0 to {last_scene}"
             return gr.update(selected=self.TAB_REMIX_EXTRA), \
-                gr.update(visible=True, value=message), \
+                gr.update(value=self.format_markdown(f"Please enter a Scene Index from 0 to {last_scene}", "warning")), \
                 *self.empty_args(5)
 
         scene_name = self.state.scene_names[scene_index]
         first_frame, last_frame, num_width = details_from_group_name(scene_name)
         num_frames = (last_frame - first_frame) + 1
         if num_frames < 2:
-            message = f"Scene must have at least two frames to be split"
             return gr.update(selected=self.TAB_REMIX_EXTRA), \
-                gr.update(visible=True, value=message), \
+                gr.update(value=self.format_markdown("Scene must have at least two frames to be split", "error")), \
                 *self.empty_args(5)
 
         # ensure the split is at least at the 50% point
@@ -1447,7 +1455,7 @@ class VideoRemixer(TabBase):
             message = f"Mismatch between expected frames ({num_frames}) and found frames " + \
                 f"({num_frame_files}) in scene path '{original_scene_path}'"
             return gr.update(selected=self.TAB_REMIX_EXTRA), \
-                gr.update(visible=True, value=message), \
+                gr.update(value=self.format_markdown(message, "error")), \
                     *self.empty_args(5)
 
         messages = Jot()
@@ -1510,15 +1518,16 @@ class VideoRemixer(TabBase):
 
         message = messages.report()
         return gr.update(selected=self.TAB_CHOOSE_SCENES), \
-            gr.update(visible=True, value=message), \
+            gr.update(value=self.format_markdown(message)), \
             *self.scene_chooser_details(self.state.current_scene)
 
     def delete_button710(self, delete_purged):
         if delete_purged:
             self.log("about to remove content from 'purged_content' directory")
             removed = self.state.delete_purged_content()
-            message = f"Removed: {removed}"
-            return gr.update(visible=True, value=message)
+            return gr.update(value=self.format_markdown(f"Removed: {removed}"))
+        else:
+            return gr.update(value=self.format_markdown(f"Removed: None"))
 
     def select_all_button710(self):
         return gr.update(value=True)
@@ -1540,7 +1549,7 @@ class VideoRemixer(TabBase):
             message = f"Removed:\r\n{removed_str}"
         else:
             message = f"Removed: None"
-        return gr.update(visible=True, value=message)
+        return gr.update(value=self.format_markdown(message))
 
     def select_all_button711(self):
         return gr.update(value=True), \
@@ -1584,7 +1593,7 @@ class VideoRemixer(TabBase):
             message = f"Removed:\r\n{removed_str}"
         else:
             message = f"Removed: None"
-        return gr.update(visible=True, value=message)
+        return gr.update(value=self.format_markdown(message))
 
     def select_all_button712(self):
         return gr.update(value=True), \
@@ -1627,4 +1636,4 @@ class VideoRemixer(TabBase):
             message = f"Removed:\r\n{removed_str}"
         else:
             message = f"Removed: None"
-        return gr.update(visible=True, value=message)
+        return gr.update(value=self.format_markdown(message))

--- a/tabs/video_remixer_ui.py
+++ b/tabs/video_remixer_ui.py
@@ -689,20 +689,23 @@ class VideoRemixer(TabBase):
     def noop_args(self, num):
         return [gr.update(visible=True) for _ in range(num)]
 
-    def format_markdown(self, text, format="info"):
-        style = "font-weight:bold;"
-        if format == "plain":
-            return f"<p style=\"{style}\">{text}</p>"
-        elif format == "info":
-            return f"<p style=\"color:hsl(120 100% 65%);{style}\">{text}</p>"
-        elif format == "warning":
-            return f"<p style=\"color:hsl(60 100% 65%);{style}\">{text}</p>"
-        elif format == "error":
-            return f"<p style=\"color:hsl(0 100% 65%);{style}\">{text}</p>"
-        elif format == "highlight":
-            return f"<p style=\"color:hsl(284 100% 65%);{style}\">{text}</p>"
-        else:
-            return text
+    def _format_markdown_line(self, text, style):
+        return f"<p style=\"{style}\">{text}</p>"
+
+    def format_markdown(self, text, color="info", bold=True):
+        font_style = "font-weight:bold" if bold else ""
+        color_style = {
+            "info" : "color:hsl(120 100% 65%)",
+            "warning" : "color:hsl(60 100% 65%)",
+            "error" : "color:hsl(0 100% 65%)",
+            "highlight" : "color:hsl(284 100% 65%)",
+        }.get(color, "")
+        style = ";".join([color_style, font_style])
+
+        result = []
+        for line in text.splitlines():
+            result.append(self._format_markdown_line(line, style))
+        return "\r\n".join(result)
 
     ### REMIX HOME EVENT HANDLERS
 

--- a/tabs/video_remixer_ui.py
+++ b/tabs/video_remixer_ui.py
@@ -29,6 +29,22 @@ class VideoRemixer(TabBase):
         self.state = VideoRemixerState()
         self.state.set_project_ui_defaults(self.config.remixer_settings["def_project_fps"])
 
+    TAB_REMIX_HOME = 0
+    TAB_REMIX_SETTINGS = 1
+    TAB_SET_UP_PROJECT = 2
+    TAB_CHOOSE_SCENES = 3
+    TAB_COMPILE_SCENES = 4
+    TAB_PROC_OPTIONS = 5
+    TAB_SAVE_REMIX = 6
+    TAB_REMIX_EXTRA = 7
+
+    TAB_EXTRA_UTILITIES = 0
+    TAB_EXTRA_REDUCE = 1
+
+    TAB_EXTRA_UTIL_DROP_PROCESSED = 0
+    TAB_EXTRA_UTIL_CHOOSE_RANGE = 1
+    TAB_EXTRA_UTIL_SPLIT_SCENE = 2
+
     def render_tab(self):
         """Render tab into UI"""
         def_project_fps = self.config.remixer_settings["def_project_fps"]
@@ -46,7 +62,7 @@ class VideoRemixer(TabBase):
             with gr.Tabs() as tabs_video_remixer:
 
                 ### NEW PROJECT
-                with gr.Tab("Remix Home", id=0):
+                with gr.Tab("Remix Home", id=self.TAB_REMIX_HOME):
                     with gr.Row():
                         with gr.Column():
                             gr.Markdown("**Input a video to get started remixing**")
@@ -72,7 +88,7 @@ class VideoRemixer(TabBase):
                         WebuiTips.video_remixer_home.render()
 
                 ### REMIX SETTINGS
-                with gr.Tab("Remix Settings", id=1):
+                with gr.Tab("Remix Settings", id=self.TAB_REMIX_SETTINGS):
                     gr.Markdown("**Confirm Remixer Settings**")
                     with gr.Box():
                         video_info1 = gr.Markdown("Video Details")
@@ -111,7 +127,7 @@ class VideoRemixer(TabBase):
                         WebuiTips.video_remixer_settings.render()
 
                 ## SET UP PROJECT
-                with gr.Tab("Set Up Project", id=2):
+                with gr.Tab("Set Up Project", id=self.TAB_SET_UP_PROJECT):
                     gr.Markdown("**Ready to Set Up Video Remixer Project**")
                     with gr.Box():
                         project_info2 = gr.Markdown("Project Details")
@@ -137,7 +153,7 @@ class VideoRemixer(TabBase):
                         WebuiTips.video_remixer_setup.render()
 
                 ## CHOOSE SCENES
-                with gr.Tab("Choose Scenes", id=3):
+                with gr.Tab("Choose Scenes", id=self.TAB_CHOOSE_SCENES):
                     with gr.Row():
                         with gr.Column():
                             with gr.Row():
@@ -188,7 +204,7 @@ class VideoRemixer(TabBase):
                         WebuiTips.video_remixer_choose.render()
 
                 ## COMPILE SCENES
-                with gr.Tab("Compile Scenes", id=4):
+                with gr.Tab("Compile Scenes", id=self.TAB_COMPILE_SCENES):
                     with gr.Box():
                         project_info4 = gr.Markdown("Chosen Scene Details")
                     with gr.Row():
@@ -203,7 +219,7 @@ class VideoRemixer(TabBase):
                         WebuiTips.video_remixer_compile.render()
 
                 ## PROCESSING OPTIONS
-                with gr.Tab("Processing Options", id=5):
+                with gr.Tab("Processing Options", id=self.TAB_PROC_OPTIONS):
                     gr.Markdown("**Ready to Process Content for Remix Video**")
                     with gr.Row():
                         resize = gr.Checkbox(label="Fix Aspect Ratio", value=True)
@@ -244,14 +260,12 @@ class VideoRemixer(TabBase):
                         WebuiTips.video_remixer_processing.render()
 
                 ## SAVE REMIX
-                with gr.Tab("Save Remix", id=6):
+                with gr.Tab("Save Remix", id=self.TAB_SAVE_REMIX):
                     gr.Markdown("**Ready to Finalize Scenes and Save Remixed Video**")
                     with gr.Row():
                         summary_info6 = gr.Textbox(label="Processed Content", lines=6,
                                                 interactive=False)
-
                     with gr.Tabs():
-
                         ### CREATE MP4 REMIX
                         with gr.Tab(label="Create MP4 Remix"):
                             quality_slider = gr.Slider(minimum=minimum_crf, maximum=maximum_crf,
@@ -317,12 +331,12 @@ class VideoRemixer(TabBase):
                     with gr.Accordion(SimpleIcons.TIPS_SYMBOL + " Guide", open=False):
                         WebuiTips.video_remixer_save.render()
 
-                ## Remix Extra
-                with gr.Tab("Remix Extra", id=7):
+                ## REMIX EXTRA
+                with gr.Tab("Remix Extra", id=self.TAB_REMIX_EXTRA):
                     with gr.Tabs() as tabs_remix_extra:
-                        with gr.Tab(label="Utilities", id=0):
+                        with gr.Tab(label="Utilities", id=self.TAB_EXTRA_UTILITIES):
                             with gr.Tabs() as tabs_remix_extra_utils:
-                                with gr.Tab("Drop Processed Scene", id=0):
+                                with gr.Tab("Drop Processed Scene", id=self.TAB_EXTRA_UTIL_DROP_PROCESSED):
                                     gr.Markdown(
                                 "**_Drop a scene after processing has been already been done_**")
                                     scene_id_700 = gr.Number(value=-1, label="Scene Index")
@@ -332,7 +346,7 @@ class VideoRemixer(TabBase):
                                     drop_button700 = gr.Button("Drop Scene", variant="stop").\
                                         style(full_width=False)
 
-                                with gr.Tab("Choose Scene Range", id=1):
+                                with gr.Tab("Choose Scene Range", id=self.TAB_EXTRA_UTIL_CHOOSE_RANGE):
                                     gr.Markdown("**_Keep or Drop a range of scenes_**")
                                     with gr.Row():
                                         first_scene_id_701 = gr.Number(value=-1,
@@ -349,7 +363,7 @@ class VideoRemixer(TabBase):
                                     choose_button701 = gr.Button("Choose Scene Range",
                                                             variant="stop").style(full_width=False)
 
-                                with gr.Tab("Split Scene", id=2):
+                                with gr.Tab("Split Scene", id=self.TAB_EXTRA_UTIL_SPLIT_SCENE):
                                     gr.Markdown("**_Split a Scene in two at the 50% point_**")
                                     scene_id_702 = gr.Number(value=-1, label="Scene Index")
                                     with gr.Row():
@@ -358,7 +372,7 @@ class VideoRemixer(TabBase):
                                     split_button702 = gr.Button("Split Scene", variant="stop").\
                                         style(full_width=False)
 
-                        with gr.Tab(label="Reduce Footprint", id=1):
+                        with gr.Tab(label="Reduce Footprint", id=self.TAB_EXTRA_REDUCE):
                             with gr.Tabs():
                                 with gr.Tab(label="Remove Soft-Deleted Content"):
                                     gr.Markdown(
@@ -689,12 +703,12 @@ class VideoRemixer(TabBase):
     # User has clicked New Project > from Remix Home
     def next_button00(self, video_path):
         if not video_path:
-            return gr.update(selected=0), \
+            return gr.update(selected=self.TAB_REMIX_HOME), \
                    gr.update(value=self.format_markdown("Enter a path to a video on this server to get started", "warning")), \
                    *self.empty_args(6)
 
         if not os.path.exists(video_path):
-            return gr.update(selected=0), \
+            return gr.update(selected=self.TAB_REMIX_HOME), \
                    gr.update(value=self.format_markdown(f"File '{video_path}' was not found", "error")), \
                    *self.empty_args(6)
 
@@ -703,14 +717,14 @@ class VideoRemixer(TabBase):
             self.state.ingest_video(video_path)
             self.state.video_info1 = self.state.ingested_video_report()
         except ValueError as error:
-            return gr.update(selected=0), \
+            return gr.update(selected=self.TAB_REMIX_HOME), \
                    gr.update(value=self.format_markdown(str(error), "error")), \
                    *self.empty_args(6)
 
         # don't save yet, user may change project path next
         self.state.save_progress("settings", save_project=False)
 
-        return gr.update(selected=1), \
+        return gr.update(selected=self.TAB_REMIX_SETTINGS), \
             gr.update(value=self.format_markdown("Click New Project to: Inspect Video and Count Frames (can take a minute or more)")), \
             gr.update(value=self.state.video_info1), \
             self.state.project_path, \
@@ -722,19 +736,19 @@ class VideoRemixer(TabBase):
     # User has clicked Open Project > from Remix Home
     def next_button01(self, project_path):
         if not project_path:
-            return gr.update(selected=0), \
+            return gr.update(selected=self.TAB_REMIX_HOME), \
                    gr.update(value=self.format_markdown("Enter a path to a Video Remixer project directory on this server to get started", "warning")), \
                    *self.empty_args(28)
 
         if not os.path.exists(project_path):
-            return gr.update(selected=0), \
+            return gr.update(selected=self.TAB_REMIX_HOME), \
                    gr.update(value=self.format_markdown(f"Directory '{project_path}' was not found", "error")), \
                    *self.empty_args(28)
 
         try:
             project_file = self.state.determine_project_filepath(project_path)
         except ValueError as error:
-            return gr.update(selected=0), \
+            return gr.update(selected=self.TAB_REMIX_HOME), \
                    gr.update(value=self.format_markdown(str(error), "error")), \
                    *self.empty_args(28)
 
@@ -742,7 +756,7 @@ class VideoRemixer(TabBase):
             self.state = VideoRemixerState.load(project_file)
         except ValueError as error:
             self.log(f"error opening project: {error}")
-            return gr.update(selected=0), \
+            return gr.update(selected=self.TAB_REMIX_HOME), \
                    gr.update(value=self.format_markdown(str(error), "error")), \
                    *self.empty_args(28)
 
@@ -751,7 +765,7 @@ class VideoRemixer(TabBase):
                 self.state = VideoRemixerState.load_ported(self.state.project_path, project_file)
             except ValueError as error:
                 self.log(f"error opening ported project at {project_file}: {error}")
-                return gr.update(selected=0), \
+                return gr.update(selected=self.TAB_REMIX_HOME), \
                     gr.update(value=self.format_markdown(str(error), "error")), \
                     *self.empty_args(28)
 
@@ -800,7 +814,7 @@ class VideoRemixer(TabBase):
         self.state.project_path = project_path
 
         if not is_safe_path(project_path):
-            return gr.update(selected=1), \
+            return gr.update(selected=self.TAB_REMIX_SETTINGS), \
                 gr.update(value=self.format_markdown(f"The project path is not valid", "warning")),\
                 *self.empty_args(3)
 
@@ -828,19 +842,19 @@ class VideoRemixer(TabBase):
 
             tab1_restore_message = self.format_markdown("Click Next to: Confirm Project Settings and Choose Thumbnail Type")
             tab2_restore_message = self.format_markdown("Click Set Up Project to: Create Scenes and Thumbnails (can take from minutes to hours)")
-            return gr.update(selected=2), \
+            return gr.update(selected=self.TAB_SET_UP_PROJECT), \
                 gr.update(value=tab1_restore_message), \
                 self.state.project_info2, \
                 gr.update(value=tab2_restore_message), \
                 project_path
 
         except ValueError as error:
-            return gr.update(selected=1), \
+            return gr.update(selected=self.TAB_REMIX_SETTINGS), \
                 gr.update(value=self.format_markdown(str(error), "error")), \
                 *self.empty_args(3)
 
     def back_button1(self):
-        return gr.update(selected=0)
+        return gr.update(selected=self.TAB_REMIX_HOME)
 
     ### REMIX SETUP EVENT HANDLERS
 
@@ -892,7 +906,7 @@ class VideoRemixer(TabBase):
         self.log(f"about to split scenes by {self.state.split_type}")
         error = self.state.split_scenes(self.log)
         if error:
-            return gr.update(selected=2), \
+            return gr.update(selected=self.TAB_SET_UP_PROJECT), \
                    gr.update(value=self.format_markdown(f"There was an error splitting the source video: {error}", "error")), \
                    *self.empty_args(5)
         self.log("saving project after splitting into scenes")
@@ -914,7 +928,7 @@ class VideoRemixer(TabBase):
         try:
             self.state.create_thumbnails(self.log, global_options, self.config.remixer_settings)
         except ValueError as error:
-            return gr.update(selected=2), \
+            return gr.update(selected=self.TAB_SET_UP_PROJECT), \
                    gr.update(value=self.format_markdown(f"There was an error creating thumbnails from the source video: {error}", "error")), \
                    *self.empty_args(5)
 
@@ -932,12 +946,12 @@ class VideoRemixer(TabBase):
         self.state.save_progress("choose")
 
         tab2_restore_message = self.format_markdown("Click Set Up Project to: Create Scenes and Thumbnails (can take from minutes to hours)")
-        return gr.update(selected=3), \
+        return gr.update(selected=self.TAB_CHOOSE_SCENES), \
                gr.update(value=tab2_restore_message), \
                *self.scene_chooser_details(self.state.current_scene)
 
     def back_button2(self):
-        return gr.update(selected=1)
+        return gr.update(selected=self.TAB_REMIX_SETTINGS)
 
     ### SCENE CHOOSER EVENT HANDLERS
 
@@ -1016,10 +1030,10 @@ class VideoRemixer(TabBase):
         return self.scene_chooser_details(self.state.current_scene)
 
     def drop_processed_shortcut(self, scene_index):
-        return gr.update(selected=7), gr.update(selected=0), gr.update(selected=0), scene_index
+        return gr.update(selected=7), gr.update(selected=self.TAB_EXTRA_UTILITIES), gr.update(selected=self.TAB_EXTRA_UTIL_DROP_PROCESSED), scene_index
 
     def split_scene_shortcut(self, scene_index):
-        return gr.update(selected=7), gr.update(selected=0), gr.update(selected=2), scene_index
+        return gr.update(selected=7), gr.update(selected=self.TAB_EXTRA_UTILITIES), gr.update(selected=self.TAB_EXTRA_UTIL_SPLIT_SCENE), scene_index
 
     # given scene name such as [042-420] compute details to display in Scene Chooser
     def scene_chooser_details(self, scene_index):
@@ -1042,10 +1056,10 @@ class VideoRemixer(TabBase):
         self.log("saving project after displaying scene choices")
         self.state.save_progress("compile")
 
-        return gr.update(selected=4), self.state.project_info4
+        return gr.update(selected=self.TAB_COMPILE_SCENES), self.state.project_info4
 
     def back_button3(self):
-        return gr.update(selected=2)
+        return gr.update(selected=self.TAB_SET_UP_PROJECT)
 
     ### COMPILE SCENES EVENT HANDLERS
 
@@ -1066,12 +1080,12 @@ class VideoRemixer(TabBase):
         self.log("saving project after compiling scenes")
         self.state.save_progress("process")
 
-        return gr.update(selected=5),  \
+        return gr.update(selected=self.TAB_PROC_OPTIONS),  \
                gr.update(visible=True), \
                "Next: Perform all Processing Steps (takes from hours to days)"
 
     def back_button4(self):
-        return gr.update(selected=3)
+        return gr.update(selected=self.TAB_CHOOSE_SCENES)
 
     ### PROCESSING OPTIONS EVENT HANDLERS
 
@@ -1164,7 +1178,7 @@ class VideoRemixer(TabBase):
             self.log("saving project after completing processing steps")
             self.state.save_progress("save")
 
-            return gr.update(selected=6), \
+            return gr.update(selected=self.TAB_SAVE_REMIX), \
                    gr.update(visible=True), \
                    jot.grab(), \
                    self.state.output_filepath, \
@@ -1172,13 +1186,13 @@ class VideoRemixer(TabBase):
                    output_filepath_marked, \
                    None, None, None
         else:
-            return gr.update(selected=5), \
+            return gr.update(selected=self.TAB_PROC_OPTIONS), \
                    gr.update(
                 value="At least one scene must be set to 'Keep' before processing can proceed"), \
                    None, None, None, None, None, None, None
 
     def back_button5(self):
-        return gr.update(selected=4)
+        return gr.update(selected=self.TAB_COMPILE_SCENES)
 
     ### SAVE REMIX EVENT HANDLERS
 
@@ -1307,7 +1321,7 @@ class VideoRemixer(TabBase):
             return gr.update(value=error, visible=True)
 
     def back_button6(self):
-        return gr.update(selected=5)
+        return gr.update(selected=self.TAB_PROC_OPTIONS)
 
     def drop_button700(self, scene_index):
         num_scenes = len(self.state.scene_names)
@@ -1369,7 +1383,7 @@ class VideoRemixer(TabBase):
         self.log(f"saving project after {message}")
         self.state.save()
 
-        return gr.update(selected=3), \
+        return gr.update(selected=self.TAB_CHOOSE_SCENES), \
             gr.update(visible=True, value=message), \
             *self.scene_chooser_details(self.state.current_scene)
 
@@ -1379,7 +1393,7 @@ class VideoRemixer(TabBase):
 
         if not isinstance(scene_index, (int, float)):
             message = f"Please enter a Scene Index to get started"
-            return gr.update(selected=7), \
+            return gr.update(selected=self.TAB_REMIX_EXTRA), \
                 gr.update(visible=True, value=message), \
                 *self.empty_args(5)
 
@@ -1388,7 +1402,7 @@ class VideoRemixer(TabBase):
         scene_index = int(scene_index)
         if scene_index < 0 or scene_index > last_scene:
             message = f"Please enter a Scene Index from 0 to {last_scene}"
-            return gr.update(selected=7), \
+            return gr.update(selected=self.TAB_REMIX_EXTRA), \
                 gr.update(visible=True, value=message), \
                 *self.empty_args(5)
 
@@ -1397,7 +1411,7 @@ class VideoRemixer(TabBase):
         num_frames = (last_frame - first_frame) + 1
         if num_frames < 2:
             message = f"Scene must have at least two frames to be split"
-            return gr.update(selected=7), \
+            return gr.update(selected=self.TAB_REMIX_EXTRA), \
                 gr.update(visible=True, value=message), \
                 *self.empty_args(5)
 
@@ -1430,7 +1444,7 @@ class VideoRemixer(TabBase):
         if num_frame_files != num_frames:
             message = f"Mismatch between expected frames ({num_frames}) and found frames " + \
                 f"({num_frame_files}) in scene path '{original_scene_path}'"
-            return gr.update(selected=7), \
+            return gr.update(selected=self.TAB_REMIX_EXTRA), \
                 gr.update(visible=True, value=message), \
                     *self.empty_args(5)
 
@@ -1493,7 +1507,7 @@ class VideoRemixer(TabBase):
         self.state.save()
 
         message = messages.report()
-        return gr.update(selected=3), \
+        return gr.update(selected=self.TAB_CHOOSE_SCENES), \
             gr.update(visible=True, value=message), \
             *self.scene_chooser_details(self.state.current_scene)
 

--- a/tabs/video_remixer_ui.py
+++ b/tabs/video_remixer_ui.py
@@ -45,6 +45,16 @@ class VideoRemixer(TabBase):
     TAB_EXTRA_UTIL_CHOOSE_RANGE = 1
     TAB_EXTRA_UTIL_SPLIT_SCENE = 2
 
+    TAB00_DEFAULT_MESSAGE = "Click New Project to: Inspect Video and Count Frames (can take a minute or more)"
+    TAB01_DEFAULT_MESSAGE = "Click Open Project to: Resume Editing an Existing Project"
+    TAB1_DEFAULT_MESSAGE = "Click Next to: Confirm Project Settings and Choose Thumbnail Type"
+    TAB2_DEFAULT_MESSAGE = "Click Set Up Project to: Create Scenes and Thumbnails (can take from minutes to hours)"
+    TAB4_DEFAULT_MESSAGE = "Click Compile Scenes to: Assemble Kept Scenes for Processing (can take a few seconds)"
+    TAB5_DEFAULT_MESSAGE = "Click Process Remix to: Perform all Processing Steps (can take from hours to days)"
+    TAB60_DEFAULT_MESSAGE = "Click Save Remix to: Combine Processed Content with Audio Clips and Save Remix Video"
+    TAB61_DEFAULT_MESSAGE = "Click Save Custom Remix to: Apply Custom Options and save Custom Remix Video"
+    TAB62_DEFAULT_MESSAGE = "Click Save Marked Remix to: Apply Marking Options and save Marked Remix Video"
+
     def render_tab(self):
         """Render tab into UI"""
         def_project_fps = self.config.remixer_settings["def_project_fps"]
@@ -70,7 +80,7 @@ class VideoRemixer(TabBase):
                                 video_path = gr.Textbox(label="Video Path",
                                     placeholder="Path on this server to the video to be remixed")
                             with gr.Row():
-                                message_box00 = gr.Markdown(self.format_markdown("Click New Project to: Inspect Video and Count Frames (can take a minute or more)"))
+                                message_box00 = gr.Markdown(self.format_markdown(self.TAB00_DEFAULT_MESSAGE))
                             gr.Markdown("*Progress can be tracked in the console*")
                             next_button00 = gr.Button(value="New Project > " +
                                 SimpleIcons.SLOW_SYMBOL, variant="primary", elem_id="actionbutton")
@@ -80,7 +90,7 @@ class VideoRemixer(TabBase):
                                 project_load_path = gr.Textbox(label="Project Path",
                 placeholder="Path on this server to the Video Remixer project directory or file")
                             with gr.Row():
-                                message_box01 = gr.Markdown(value=self.format_markdown("Click Open Project to: Resume Editing an Existing Project"))
+                                message_box01 = gr.Markdown(value=self.format_markdown(self.TAB01_DEFAULT_MESSAGE))
                             gr.Markdown("*The last used tab will be shown after loading project*")
                             next_button01 = gr.Button(value="Open Project >",
                                                     variant="primary")
@@ -117,7 +127,7 @@ class VideoRemixer(TabBase):
                         crop_w = gr.Number(label="Crop Width")
                         crop_h = gr.Number(label="Crop Height")
 
-                    message_box1 = gr.Markdown(value=self.format_markdown("Click Next to: Confirm Project Settings and Choose Thumbnail Type"))
+                    message_box1 = gr.Markdown(value=self.format_markdown(self.TAB1_DEFAULT_MESSAGE))
                     with gr.Row():
                         back_button1 = gr.Button(value="< Back", variant="secondary").\
                             style(full_width=False)
@@ -139,7 +149,7 @@ class VideoRemixer(TabBase):
                                     precision=0, value=def_min_frames,
                         info="Consolidates very small scenes info the next (0 to disable)")
                     with gr.Row():
-                        message_box2 = gr.Markdown(value=self.format_markdown("Click Set Up Project to: Create Scenes and Thumbnails (can take from minutes to hours)"))
+                        message_box2 = gr.Markdown(value=self.format_markdown(self.TAB2_DEFAULT_MESSAGE))
 
                     gr.Markdown(
                         SimpleIcons.WARNING + "**Important: Redoing this step will purge and recreate content!**" +
@@ -208,7 +218,7 @@ class VideoRemixer(TabBase):
                     with gr.Box():
                         project_info4 = gr.Markdown("Chosen Scene Details")
                     with gr.Row():
-                        message_box4 = gr.Markdown(value=self.format_markdown("Click Compile Scenes to: Assemble Kept Scenes for Processing (can take a few seconds)"))
+                        message_box4 = gr.Markdown(value=self.format_markdown(self.TAB4_DEFAULT_MESSAGE))
                     with gr.Row():
                         back_button4 = gr.Button(value="< Back", variant="secondary").\
                             style(full_width=False)
@@ -246,7 +256,7 @@ class VideoRemixer(TabBase):
                         with gr.Box():
                             gr.Markdown(
                                 "Frames are cleansed and enlarged using AI - Real-ESRGAN 4x+\r\n")
-                    message_box5 = gr.Markdown(value=self.format_markdown("Click Process Remix to: Perform all Processing Steps (can take from hours to days)"))
+                    message_box5 = gr.Markdown(value=self.format_markdown(self.TAB5_DEFAULT_MESSAGE))
                     with gr.Row():
                         back_button5 = gr.Button(value="< Back", variant="secondary").\
                             style(full_width=False)
@@ -271,7 +281,7 @@ class VideoRemixer(TabBase):
                             output_filepath = gr.Textbox(label="Output Filepath", max_lines=1,
                                     info="Enter a path and filename for the remixed video")
                             with gr.Row():
-                                message_box60 = gr.Markdown(value=self.format_markdown("Click Save Remix to: Combine Processed Content with Audio Clips and Save Remix Video"))
+                                message_box60 = gr.Markdown(value=self.format_markdown(self.TAB60_DEFAULT_MESSAGE))
                             gr.Markdown("*Progress can be tracked in the console*")
                             with gr.Row():
                                 back_button60 = gr.Button(value="< Back", variant="secondary").\
@@ -292,7 +302,7 @@ class VideoRemixer(TabBase):
                                                                 max_lines=1,
                                             info="Enter a path and filename for the remixed video")
                             with gr.Row():
-                                message_box61 = gr.Markdown(value=self.format_markdown("Click Save Custom Remix to: Apply Custom Options and save Custom Remix Video"))
+                                message_box61 = gr.Markdown(value=self.format_markdown(self.TAB61_DEFAULT_MESSAGE))
                             gr.Markdown("*Progress can be tracked in the console*")
                             with gr.Row():
                                 back_button61 = gr.Button(value="< Back", variant="secondary").\
@@ -313,7 +323,7 @@ class VideoRemixer(TabBase):
                                                                 max_lines=1,
                                             info="Enter a path and filename for the remixed video")
                             with gr.Row():
-                                message_box62 = gr.Markdown(value=self.format_markdown("Click Save Marked Remix to: Apply Marking Options and save Marked Remix Video"))
+                                message_box62 = gr.Markdown(value=self.format_markdown(self.TAB62_DEFAULT_MESSAGE))
                             gr.Markdown("*Progress can be tracked in the console*")
                             with gr.Row():
                                 back_button62 = gr.Button(value="< Back", variant="secondary").\
@@ -721,7 +731,7 @@ class VideoRemixer(TabBase):
         self.state.save_progress("settings", save_project=False)
 
         return gr.update(selected=self.TAB_REMIX_SETTINGS), \
-            gr.update(value=self.format_markdown("Click New Project to: Inspect Video and Count Frames (can take a minute or more)")), \
+            gr.update(value=self.format_markdown(self.TAB00_DEFAULT_MESSAGE)), \
             gr.update(value=self.state.video_info1), \
             self.state.project_path, \
             self.state.resize_w, \
@@ -769,7 +779,7 @@ class VideoRemixer(TabBase):
         if messages:
             message_text = self.format_markdown(messages, "warning")
         else:
-            message_text = self.format_markdown("Click Open Project to: Resume Editing an Existing Project")
+            message_text = self.format_markdown(self.TAB01_DEFAULT_MESSAGE)
         return_to_tab = self.state.get_progress_tab()
         scene_details = self.scene_chooser_details(self.state.tryattr("current_scene"))
 
@@ -836,12 +846,10 @@ class VideoRemixer(TabBase):
             self.log(f"saving new project at {self.state.project_filepath()}")
             self.state.save_progress("setup")
 
-            tab1_restore_message = self.format_markdown("Click Next to: Confirm Project Settings and Choose Thumbnail Type")
-            tab2_restore_message = self.format_markdown("Click Set Up Project to: Create Scenes and Thumbnails (can take from minutes to hours)")
             return gr.update(selected=self.TAB_SET_UP_PROJECT), \
-                gr.update(value=tab1_restore_message), \
+                gr.update(value=self.format_markdown(self.TAB1_DEFAULT_MESSAGE)), \
                 self.state.project_info2, \
-                gr.update(value=tab2_restore_message), \
+                gr.update(value=self.format_markdown(self.TAB2_DEFAULT_MESSAGE)), \
                 project_path
 
         except ValueError as error:
@@ -946,9 +954,8 @@ class VideoRemixer(TabBase):
         self.log("saving project after setting up scene selection states")
         self.state.save_progress("choose")
 
-        tab2_restore_message = self.format_markdown("Click Set Up Project to: Create Scenes and Thumbnails (can take from minutes to hours)")
         return gr.update(selected=self.TAB_CHOOSE_SCENES), \
-               gr.update(value=tab2_restore_message), \
+               gr.update(value=self.format_markdown(self.TAB2_DEFAULT_MESSAGE)), \
                *self.scene_chooser_details(self.state.current_scene)
 
     def back_button2(self):
@@ -1086,12 +1093,9 @@ class VideoRemixer(TabBase):
         self.log("saving project after compiling scenes")
         self.state.save_progress("process")
 
-        tab4_restore_message = self.format_markdown("Click Compile Scenes to: Assemble Kept Scenes for Processing (can take a few seconds)")
-        tab5_restore_message = self.format_markdown("Click Process Remix to: Perform all Processing Steps (can take from hours to days)")
-
         return gr.update(selected=self.TAB_PROC_OPTIONS),  \
-               gr.update(value=tab4_restore_message), \
-               gr.update(value=tab5_restore_message)
+               gr.update(value=self.format_markdown(self.TAB4_DEFAULT_MESSAGE)), \
+               gr.update(value=self.format_markdown(self.TAB5_DEFAULT_MESSAGE))
 
     def back_button4(self):
         return gr.update(selected=self.TAB_CHOOSE_SCENES)
@@ -1187,20 +1191,15 @@ class VideoRemixer(TabBase):
             self.log("saving project after completing processing steps")
             self.state.save_progress("save")
 
-            tab5_restore_message = self.format_markdown("Click Process Remix to: Perform all Processing Steps (can take from hours to days)")
-            tab60_restore_message = self.format_markdown("Click Save Remix to: Combine Processed Content with Audio Clips and Save Remix Video")
-            tab61_restore_message = self.format_markdown("Click Save Custom Remix to: Apply Custom Options and save Custom Remix Video")
-            tab62_restore_message = self.format_markdown("Click Save Marked Remix to: Apply Marking Options and save Marked Remix Video")
-
             return gr.update(selected=self.TAB_SAVE_REMIX), \
-                   gr.update(value=tab5_restore_message), \
+                   gr.update(value=self.format_markdown(self.TAB5_DEFAULT_MESSAGE)), \
                    jot.grab(), \
                    self.state.output_filepath, \
                    output_filepath_custom, \
                    output_filepath_marked, \
-                   gr.update(value=tab60_restore_message), \
-                   gr.update(value=tab61_restore_message), \
-                   gr.update(value=tab62_restore_message)
+                   gr.update(value=self.format_markdown(self.TAB60_DEFAULT_MESSAGE)), \
+                   gr.update(value=self.format_markdown(self.TAB61_DEFAULT_MESSAGE)), \
+                   gr.update(value=self.format_markdown(self.TAB62_DEFAULT_MESSAGE))
         else:
             return gr.update(selected=self.TAB_PROC_OPTIONS), \
                    gr.update(value=self.format_markdown("At least one scene must be set to 'Keep' before processing can proceed", "error")), \

--- a/tabs/video_remixer_ui.py
+++ b/tabs/video_remixer_ui.py
@@ -208,8 +208,7 @@ class VideoRemixer(TabBase):
                     with gr.Box():
                         project_info4 = gr.Markdown("Chosen Scene Details")
                     with gr.Row():
-                        message_box4 = gr.Textbox(show_label=False, interactive=False,
-                                        value="Next: Compile 'Keep' and 'Drop' scenes")
+                        message_box4 = gr.Markdown(value=self.format_markdown("Click Compile Scenes to: Assemble Kept Scenes for Processing"))
                     with gr.Row():
                         back_button4 = gr.Button(value="< Back", variant="secondary").\
                             style(full_width=False)
@@ -247,9 +246,7 @@ class VideoRemixer(TabBase):
                         with gr.Box():
                             gr.Markdown(
                                 "Frames are cleansed and enlarged using AI - Real-ESRGAN 4x+\r\n")
-                    message_box5 = gr.Textbox(
-                        value="Next: Perform all Processing Steps (takes from hours to days)",
-                                              show_label=False, interactive=False)
+                    message_box5 = gr.Markdown(value=self.format_markdown("Click Process Remix to: Perform all Processing Steps (can take from hours to days)"))
                     with gr.Row():
                         back_button5 = gr.Button(value="< Back", variant="secondary").\
                             style(full_width=False)
@@ -274,8 +271,7 @@ class VideoRemixer(TabBase):
                             output_filepath = gr.Textbox(label="Output Filepath", max_lines=1,
                                     info="Enter a path and filename for the remixed video")
                             with gr.Row():
-                                message_box60 = gr.Textbox(value=None, show_label=False,
-                                                          interactive=False)
+                                message_box60 = gr.Markdown(value=self.format_markdown("Click Save Remix to: Combine Processed Content with Audio Clips and Save Remix Video"))
                             gr.Markdown("*Progress can be tracked in the console*")
                             with gr.Row():
                                 back_button60 = gr.Button(value="< Back", variant="secondary").\
@@ -296,8 +292,7 @@ class VideoRemixer(TabBase):
                                                                 max_lines=1,
                                             info="Enter a path and filename for the remixed video")
                             with gr.Row():
-                                message_box61 = gr.Textbox(value=None, show_label=False,
-                                                          interactive=False)
+                                message_box61 = gr.Markdown(value=self.format_markdown("Click Save Custom Remix to: Apply Custom Options and save Custom Remix Video"))
                             gr.Markdown("*Progress can be tracked in the console*")
                             with gr.Row():
                                 back_button61 = gr.Button(value="< Back", variant="secondary").\
@@ -318,8 +313,7 @@ class VideoRemixer(TabBase):
                                                                 max_lines=1,
                                             info="Enter a path and filename for the remixed video")
                             with gr.Row():
-                                message_box62 = gr.Textbox(value=None, show_label=False,
-                                                          interactive=False)
+                                message_box62 = gr.Markdown(value=self.format_markdown("Click Save Marked Remix to: Apply Marking Options and save Marked Remix Video"))
                             gr.Markdown("*Progress can be tracked in the console*")
                             with gr.Row():
                                 back_button62 = gr.Button(value="< Back", variant="secondary").\
@@ -695,6 +689,8 @@ class VideoRemixer(TabBase):
             return f"<p style=\"color:hsl(60 100% 65%);{style}\">{text}</p>"
         elif format == "error":
             return f"<p style=\"color:hsl(0 100% 65%);{style}\">{text}</p>"
+        elif format == "highlight":
+            return f"<p style=\"color:hsl(284 100% 65%);{style}\">{text}</p>"
         else:
             return text
 
@@ -1080,9 +1076,12 @@ class VideoRemixer(TabBase):
         self.log("saving project after compiling scenes")
         self.state.save_progress("process")
 
+        tab4_restore_message = self.format_markdown("Click Compile Scenes to: Assemble Kept Scenes for Processing")
+        tab5_restore_message = self.format_markdown("Click Process Remix to: Perform all Processing Steps (can take from hours to days)")
+
         return gr.update(selected=self.TAB_PROC_OPTIONS),  \
-               gr.update(visible=True), \
-               "Next: Perform all Processing Steps (takes from hours to days)"
+               gr.update(value=tab4_restore_message), \
+               gr.update(value=tab5_restore_message)
 
     def back_button4(self):
         return gr.update(selected=self.TAB_CHOOSE_SCENES)
@@ -1178,18 +1177,24 @@ class VideoRemixer(TabBase):
             self.log("saving project after completing processing steps")
             self.state.save_progress("save")
 
+            tab5_restore_message = self.format_markdown("Click Process Remix to: Perform all Processing Steps (can take from hours to days)")
+            tab60_restore_message = self.format_markdown("Click Save Remix to: Combine Processed Content with Audio Clips and Save Remix Video")
+            tab61_restore_message = self.format_markdown("Click Save Custom Remix to: Apply Custom Options and save Custom Remix Video")
+            tab62_restore_message = self.format_markdown("Click Save Marked Remix to: Apply Marking Options and save Marked Remix Video")
+
             return gr.update(selected=self.TAB_SAVE_REMIX), \
-                   gr.update(visible=True), \
+                   gr.update(value=tab5_restore_message), \
                    jot.grab(), \
                    self.state.output_filepath, \
                    output_filepath_custom, \
                    output_filepath_marked, \
-                   None, None, None
+                   gr.update(value=tab60_restore_message), \
+                   gr.update(value=tab61_restore_message), \
+                   gr.update(value=tab62_restore_message)
         else:
             return gr.update(selected=self.TAB_PROC_OPTIONS), \
-                   gr.update(
-                value="At least one scene must be set to 'Keep' before processing can proceed"), \
-                   None, None, None, None, None, None, None
+                   gr.update(value=self.format_markdown("At least one scene must be set to 'Keep' before processing can proceed", "error")), \
+                   *self.empty_args(7)
 
     def back_button5(self):
         return gr.update(selected=self.TAB_COMPILE_SCENES)
@@ -1292,11 +1297,10 @@ class VideoRemixer(TabBase):
         try:
             global_options, kept_scenes = self.prepare_save_remix(output_filepath)
             self.save_remix(global_options, kept_scenes)
-            return gr.update(value=f"Remixed video {output_filepath} is complete.",
-                            visible=True)
+            return gr.update(value=self.format_markdown(f"Remixed video {output_filepath} is complete.", "highlight"))
 
         except ValueError as error:
-            return gr.update(value=error, visible=True)
+            return gr.update(value=self.format_markdown(str(error), "error"))
 
     # User has clicked Save Custom Remix from Save Remix
     def next_button61(self, custom_video_options, custom_audio_options, output_filepath):
@@ -1304,10 +1308,9 @@ class VideoRemixer(TabBase):
             global_options, kept_scenes = self.prepare_save_remix(output_filepath)
             self.save_custom_remix(output_filepath, global_options, kept_scenes,
                                    custom_video_options, custom_audio_options)
-            return gr.update(value=f"Remixed custom video {output_filepath} is complete.",
-                            visible=True)
+            return gr.update(value=self.format_markdown(f"Remixed custom video {output_filepath} is complete.", "highlight"))
         except ValueError as error:
-            return gr.update(value=error, visible=True)
+            return gr.update(value=self.format_markdown(str(error), "error"))
 
     # User has clicked Save Marked Remix from Save Remix
     def next_button62(self, marked_video_options, marked_audio_options, output_filepath):
@@ -1315,10 +1318,9 @@ class VideoRemixer(TabBase):
             global_options, kept_scenes = self.prepare_save_remix(output_filepath)
             self.save_custom_remix(output_filepath, global_options, kept_scenes,
                                    marked_video_options, marked_audio_options)
-            return gr.update(value=f"Remixed marked video {output_filepath} is complete.",
-                            visible=True)
+            return gr.update(value=self.format_markdown(f"Remixed marked video {output_filepath} is complete.", "highlight"))
         except ValueError as error:
-            return gr.update(value=error, visible=True)
+            return gr.update(value=self.format_markdown(str(error), "error"))
 
     def back_button6(self):
         return gr.update(selected=self.TAB_PROC_OPTIONS)

--- a/tabs/video_remixer_ui.py
+++ b/tabs/video_remixer_ui.py
@@ -208,7 +208,7 @@ class VideoRemixer(TabBase):
                     with gr.Box():
                         project_info4 = gr.Markdown("Chosen Scene Details")
                     with gr.Row():
-                        message_box4 = gr.Markdown(value=self.format_markdown("Click Compile Scenes to: Assemble Kept Scenes for Processing"))
+                        message_box4 = gr.Markdown(value=self.format_markdown("Click Compile Scenes to: Assemble Kept Scenes for Processing (can take a few seconds)"))
                     with gr.Row():
                         back_button4 = gr.Button(value="< Back", variant="secondary").\
                             style(full_width=False)
@@ -1086,7 +1086,7 @@ class VideoRemixer(TabBase):
         self.log("saving project after compiling scenes")
         self.state.save_progress("process")
 
-        tab4_restore_message = self.format_markdown("Click Compile Scenes to: Assemble Kept Scenes for Processing")
+        tab4_restore_message = self.format_markdown("Click Compile Scenes to: Assemble Kept Scenes for Processing (can take a few seconds)")
         tab5_restore_message = self.format_markdown("Click Process Remix to: Perform all Processing Steps (can take from hours to days)")
 
         return gr.update(selected=self.TAB_PROC_OPTIONS),  \

--- a/webui.css
+++ b/webui.css
@@ -11,12 +11,13 @@
 :root {
     --frame-chooser-action: #008542;
     --main-output-highlight: #ee7400;
-    --feature-output-highlight: #72308A;
+    --feature-output-highlight: #72308a;
     --frame-chooser-action-dim: #004d26;
     --main-output-highlight-dim: hsl(29, 100%, 30%);
-    --message-box-text-info: #0aff85;
-    --message-box-text-warn: #ffff0a;
-    --message-box-text-error: #ff0a0a;
+    --message-box-text-info: hsl(120, 100%, 65%);
+    --message-box-text-warn: hsl(60, 100%, 65%);
+    --message-box-text-error: hsl(0, 100%, 65%);
+    --message-box-text-highlight: hsl(284, 100%, 65%);
 }
 
 #sideimage {

--- a/webui.css
+++ b/webui.css
@@ -14,6 +14,9 @@
     --feature-output-highlight: #72308A;
     --frame-chooser-action-dim: #004d26;
     --main-output-highlight-dim: hsl(29, 100%, 30%);
+    --message-box-text-info: #0aff85;
+    --message-box-text-warn: #ffff0a;
+    --message-box-text-error: #ff0a0a;
 }
 
 #sideimage {


### PR DESCRIPTION
Currently there are text boxes being used to display feedback messages to the user. This makes the UI more cluttered and confusing since these appear to also be text input fields.

- Use Gradio Markdown controls instead of Textbox controls for feedback messages
- Use text of different colors to convey message importance

Also
- Constantize tab integer IDs to make the code more self-explanatory
- Clean up some error messaging