### PR TITLE
Video Remixer - some minor updates

### DIFF
--- a/guide/upscale_frames.md
+++ b/guide/upscale_frames.md
@@ -39,10 +39,8 @@ Real-ESRGAN must be installed locally to use
     - If **Batch Processing**
         - Set _Input Path_ to a directory on this server containing PNG frame groups to be upscaled
         - Set _Output Path_ to a directory on this server for the upscaled PNG frame groups
-
 1. Click _Upscale Frames_ or _Upscale Batch_
-- Progress can be checked in the console
-
+    - Progress can be checked in the console
 1. _Real-ESRGAN_ is used on each frame in the input path
     - Frames are cleaned up, and enlarged if necessary
     - The new frames are copied to the output path

--- a/guide/video_remixer_choose.md
+++ b/guide/video_remixer_choose.md
@@ -14,6 +14,9 @@ The _Keep All Scenes_ and _Drop All Scenes_ buttons (inside the _Danger Zone_ ac
 - **Destructively** _Keep_ or _Drop_ all scenes (there is no undo)
 - Save the project
 
+The _Split Scene_ and _Drop Processed Scene_ buttons (inside the _Danger Zone_ accordion)
+- Shortcuts that take you to the corresponding _Remix Extra_ tabs with pre-filled scene IDs
+
 The remaining buttons are navigation-related, except for:
 
 Click the _Done Choosing Scenes_ button when all _Keep_ or _Drop_ selections have been made
@@ -23,7 +26,7 @@ Other Buttons
 - _< Prev Scene_ and _Next Scene >_ - step through all scenes
 - _< Prev Keep_ and _Next Keep >_ - step through only kept scenes
 - _<< First Scene_ and _Last Scene >>_ - jump to the first or last scene
-- _Danger Zone_ - expands the accordion to reveal _Keep All Scenes_ and _Drop All Scenes_ buttons
+- _Danger Zone_ - expands the accordion to reveal various rare-use buttons
 
 ## Important
 - `ffmpeg.exe` must be available on the system path

--- a/guide/video_remixer_compile.md
+++ b/guide/video_remixer_compile.md
@@ -9,7 +9,7 @@ The _Chosen Scenes Details_ box shows a summary of the remix project about to be
 1. Click _Compile Scenes_
     - Dropped scenes (directories of PNG files) are moved to a _dropped frame_ directory
         - Note: this takes only a moment
-    - You will be taken to the _Processing Options_ tab
+    - You will be taken to the _Process Remix_ tab
 
 ## Important
 - `ffmpeg.exe` must be available on the system path

--- a/guide/video_remixer_extra.md
+++ b/guide/video_remixer_extra.md
@@ -1,0 +1,47 @@
+**Video Remixer Extra** - Special Features and Project Clean Up
+
+### _Utilities_
+
+#### Drop Processed Scene
+Drop a scene after processing has been already been done
+- **Used For:** Removing a scene and resaving the remix video without reprocessing content
+- _Enter the scene ID to drop_
+- _Sets the scene to_ Dropped _in the project and deletes all related processed content_
+
+#### Choose Scene Range
+Keep or Drop a range of scenes
+- **Used For:** Quickly Keeping or Dropping a series of scenes
+- _Enter the starting and ending scene IDs, and whether to Keep or Drop_
+- _All scenes from starting to ending scene ID are set to the chosen state_
+
+#### Split Scene
+Split a Scene in two at the 50% point
+- **Used For:** Splitting up a scene without redoing project setup
+- _Enter the scene ID to split_
+- _Splits the scene into two scenes at the 50% point, and creates replacement thumbnails_
+
+### _Reduce Footprint_
+
+#### Remove Soft-Deleted Content
+Delete content set aside when remix processing selections are changed
+- **When Useful:** Any time - frees disk space used for purged stale processed content
+- _Check the box for the content to delete and click Delete Purged Content_
+- _Content in the "purged_content" project directory is permanently deleted_
+
+#### Remove Scene Chooser Content
+Delete source PNG frame files, thumbnails and dropped scenes
+- **When Useful:** After scene choices are final - frees disk space used for source frames, thumbnails and dropped scenes
+- _Check the box for the content to delete and click Delete Selected Content_
+- _Source frames, thumbnails and dropped scenes are permanently deleted_
+
+#### Remove Remix Video Source Content
+Clear space after final Remix Videos have been saved
+- **When Useful:** After remix video has been created - frees disk space used for kept scenes, processed content, and remix clips
+- _Check the box for the content to delete and click Delete Selected Content_
+- _Kept scenes, processed content, and remix clips are permanently deleted_
+
+#### Remove All Processed Content
+Delete all processed project content (except videos)
+- **When Useful:** Once the project is no longer needed - frees all disk space used by project-created content, except for source and remix videos
+- _Check the box for the content to delete and click Delete Selected Content_
+- _All project content except videos are permanently deleted_

--- a/guide/video_remixer_processing.md
+++ b/guide/video_remixer_processing.md
@@ -1,4 +1,4 @@
-**Video Remixer Processing Options** - Choose processing options for the remixed video
+**Video Remixer Process Remix** - Choose processing options and process remix content
 
 ## How To Use
 1. Check _Fix Aspect Ratio_ to apply the _Resize_ and _Crop_ settings from the _Remix Settings_ tab

--- a/split_frames.py
+++ b/split_frames.py
@@ -92,8 +92,8 @@ class SplitFrames:
             self.num_groups = needed_groups
             self.log(f"overriding 'num_groups' with computed value {needed_groups}")
         else:
-            if self.num_groups < 2:
-                raise ValueError("'num_groups' must be >= 2")
+            if self.num_groups < 1:
+                raise ValueError("'num_groups' must be >= 1")
             files_per_group = int(math.ceil(num_files / self.num_groups))
         self.log(f"Splitting files to {self.num_groups} groups of {files_per_group} files")
 

--- a/tabs/video_remixer_ui.py
+++ b/tabs/video_remixer_ui.py
@@ -520,8 +520,8 @@ class VideoRemixer(TabBase):
                                             value="Delete Processed Content " +\
                                                 SimpleIcons.SLOW_SYMBOL, variant="stop")
 
-                    # with gr.Accordion(SimpleIcons.TIPS_SYMBOL + " Guide", open=False):
-                    #     WebuiTips.video_remixer_save.render()
+                    with gr.Accordion(SimpleIcons.TIPS_SYMBOL + " Guide", open=False):
+                        WebuiTips.video_remixer_extra.render()
 
         next_button00.click(self.next_button00,
                            inputs=video_path,

--- a/tabs/video_remixer_ui.py
+++ b/tabs/video_remixer_ui.py
@@ -47,7 +47,7 @@ class VideoRemixer(TabBase):
 
     TAB00_DEFAULT_MESSAGE = "Click New Project to: Inspect Video and Count Frames (can take a minute or more)"
     TAB01_DEFAULT_MESSAGE = "Click Open Project to: Resume Editing an Existing Project"
-    TAB1_DEFAULT_MESSAGE = "Click Next to: Confirm Project Settings and Choose Thumbnail Type"
+    TAB1_DEFAULT_MESSAGE = "Click Next to: Save Project Settings and Choose Thumbnail Type"
     TAB2_DEFAULT_MESSAGE = "Click Set Up Project to: Create Scenes and Thumbnails (can take from minutes to hours)"
     TAB4_DEFAULT_MESSAGE = "Click Compile Scenes to: Assemble Kept Scenes for Processing (can take a few seconds)"
     TAB5_DEFAULT_MESSAGE = "Click Process Remix to: Perform all Processing Steps (can take from hours to days)"
@@ -72,7 +72,7 @@ class VideoRemixer(TabBase):
             with gr.Tabs() as tabs_video_remixer:
 
                 ### NEW PROJECT
-                with gr.Tab("Remix Home", id=self.TAB_REMIX_HOME):
+                with gr.Tab(SimpleIcons.ONE + " Remix Home", id=self.TAB_REMIX_HOME):
                     with gr.Row():
                         with gr.Column():
                             gr.Markdown("**Input a video to get started remixing**")
@@ -98,7 +98,7 @@ class VideoRemixer(TabBase):
                         WebuiTips.video_remixer_home.render()
 
                 ### REMIX SETTINGS
-                with gr.Tab("Remix Settings", id=self.TAB_REMIX_SETTINGS):
+                with gr.Tab(SimpleIcons.TWO + " Remix Settings", id=self.TAB_REMIX_SETTINGS):
                     gr.Markdown("**Confirm Remixer Settings**")
                     with gr.Box():
                         video_info1 = gr.Markdown("Video Details")
@@ -137,7 +137,7 @@ class VideoRemixer(TabBase):
                         WebuiTips.video_remixer_settings.render()
 
                 ## SET UP PROJECT
-                with gr.Tab("Set Up Project", id=self.TAB_SET_UP_PROJECT):
+                with gr.Tab(SimpleIcons.THREE + " Set Up Project", id=self.TAB_SET_UP_PROJECT):
                     gr.Markdown("**Ready to Set Up Video Remixer Project**")
                     with gr.Box():
                         project_info2 = gr.Markdown("Project Details")
@@ -163,7 +163,7 @@ class VideoRemixer(TabBase):
                         WebuiTips.video_remixer_setup.render()
 
                 ## CHOOSE SCENES
-                with gr.Tab("Choose Scenes", id=self.TAB_CHOOSE_SCENES):
+                with gr.Tab(SimpleIcons.FOUR + " Choose Scenes", id=self.TAB_CHOOSE_SCENES):
                     with gr.Row():
                         with gr.Column():
                             with gr.Row():
@@ -214,7 +214,7 @@ class VideoRemixer(TabBase):
                         WebuiTips.video_remixer_choose.render()
 
                 ## COMPILE SCENES
-                with gr.Tab("Compile Scenes", id=self.TAB_COMPILE_SCENES):
+                with gr.Tab(SimpleIcons.FIVE + " Compile Scenes", id=self.TAB_COMPILE_SCENES):
                     with gr.Box():
                         project_info4 = gr.Markdown("Chosen Scene Details")
                     with gr.Row():
@@ -228,7 +228,7 @@ class VideoRemixer(TabBase):
                         WebuiTips.video_remixer_compile.render()
 
                 ## PROCESSING OPTIONS
-                with gr.Tab("Processing Options", id=self.TAB_PROC_OPTIONS):
+                with gr.Tab(SimpleIcons.SIX + " Processing Options", id=self.TAB_PROC_OPTIONS):
                     gr.Markdown("**Ready to Process Content for Remix Video**")
                     with gr.Row():
                         resize = gr.Checkbox(label="Fix Aspect Ratio", value=True)
@@ -267,7 +267,7 @@ class VideoRemixer(TabBase):
                         WebuiTips.video_remixer_processing.render()
 
                 ## SAVE REMIX
-                with gr.Tab("Save Remix", id=self.TAB_SAVE_REMIX):
+                with gr.Tab(SimpleIcons.FINISH_FLAG + " Save Remix", id=self.TAB_SAVE_REMIX):
                     gr.Markdown("**Ready to Finalize Scenes and Save Remixed Video**")
                     with gr.Row():
                         summary_info6 = gr.Textbox(label="Processed Content", lines=6,
@@ -336,11 +336,11 @@ class VideoRemixer(TabBase):
                         WebuiTips.video_remixer_save.render()
 
                 ## REMIX EXTRA
-                with gr.Tab("Remix Extra", id=self.TAB_REMIX_EXTRA):
+                with gr.Tab(SimpleIcons.COCKTAIL + " Remix Extra", id=self.TAB_REMIX_EXTRA):
                     with gr.Tabs() as tabs_remix_extra:
-                        with gr.Tab(label="Utilities", id=self.TAB_EXTRA_UTILITIES):
+                        with gr.Tab(SimpleIcons.TOOLBOX + " Utilities", id=self.TAB_EXTRA_UTILITIES):
                             with gr.Tabs() as tabs_remix_extra_utils:
-                                with gr.Tab("Drop Processed Scene", id=self.TAB_EXTRA_UTIL_DROP_PROCESSED):
+                                with gr.Tab(SimpleIcons.BROKEN_HEART + " Drop Processed Scene", id=self.TAB_EXTRA_UTIL_DROP_PROCESSED):
                                     gr.Markdown(
                                 "**_Drop a scene after processing has been already been done_**")
                                     scene_id_700 = gr.Number(value=-1, label="Scene Index")
@@ -349,7 +349,7 @@ class VideoRemixer(TabBase):
                                     drop_button700 = gr.Button("Drop Scene", variant="stop").\
                                         style(full_width=False)
 
-                                with gr.Tab("Choose Scene Range", id=self.TAB_EXTRA_UTIL_CHOOSE_RANGE):
+                                with gr.Tab(SimpleIcons.HEART_HANDS + " Choose Scene Range", id=self.TAB_EXTRA_UTIL_CHOOSE_RANGE):
                                     gr.Markdown("**_Keep or Drop a range of scenes_**")
                                     with gr.Row():
                                         first_scene_id_701 = gr.Number(value=-1,
@@ -365,7 +365,7 @@ class VideoRemixer(TabBase):
                                     choose_button701 = gr.Button("Choose Scene Range",
                                                             variant="stop").style(full_width=False)
 
-                                with gr.Tab("Split Scene", id=self.TAB_EXTRA_UTIL_SPLIT_SCENE):
+                                with gr.Tab(SimpleIcons.AXE + " Split Scene", id=self.TAB_EXTRA_UTIL_SPLIT_SCENE):
                                     gr.Markdown("**_Split a Scene in two at the 50% point_**")
                                     scene_id_702 = gr.Number(value=-1, label="Scene Index")
                                     with gr.Row():
@@ -373,9 +373,9 @@ class VideoRemixer(TabBase):
                                     split_button702 = gr.Button("Split Scene", variant="stop").\
                                         style(full_width=False)
 
-                        with gr.Tab(label="Reduce Footprint", id=self.TAB_EXTRA_REDUCE):
+                        with gr.Tab(SimpleIcons.WASTE_BASKET +" Reduce Footprint", id=self.TAB_EXTRA_REDUCE):
                             with gr.Tabs():
-                                with gr.Tab(label="Remove Soft-Deleted Content"):
+                                with gr.Tab(SimpleIcons.CROSSMARK + " Remove Soft-Deleted Content"):
                                     gr.Markdown(
                     "**_Delete content set aside when remix processing selections are changed_**")
                                     with gr.Row():
@@ -395,7 +395,7 @@ class VideoRemixer(TabBase):
                                         select_none_button710 = gr.Button(value="Select None").\
                                             style(full_width=False)
 
-                                with gr.Tab(label="Remove Scene Chooser Content"):
+                                with gr.Tab(SimpleIcons.CROSSMARK + " Remove Scene Chooser Content"):
                                     gr.Markdown(
                             "**_Delete source PNG frame files, thumbnails and dropped scenes_**")
                                     with gr.Row():
@@ -427,7 +427,7 @@ class VideoRemixer(TabBase):
                                         select_none_button711 = gr.Button(value="Select None").\
                                             style(full_width=False)
 
-                                with gr.Tab(label="Remove Remix Video Source Content"):
+                                with gr.Tab(SimpleIcons.CROSSMARK + " Remove Remix Video Source Content"):
                                     gr.Markdown(
                                     "**_Clear space after final Remix Videos have been saved_**")
                                     with gr.Row():
@@ -488,7 +488,7 @@ class VideoRemixer(TabBase):
                                         select_none_button712 = gr.Button(value="Select None").\
                                             style(full_width=False)
 
-                                with gr.Tab(label="Remove All Processed Content"):
+                                with gr.Tab(SimpleIcons.BOMB + " Remove All Processed Content"):
                                     gr.Markdown(
                                     "**_Delete all processed project content (except videos)_**")
                                     with gr.Row():

--- a/tabs/video_remixer_ui.py
+++ b/tabs/video_remixer_ui.py
@@ -868,6 +868,7 @@ class VideoRemixer(TabBase):
             self.state.deinterlace = deinterlace
             self.state.split_time = split_time
             self.state.project_info2 = self.state.project_settings_report()
+            self.state.processed_content_invalid = True
 
             # this is the first time project progress advances
             # user will expect to return to the setup tab on reopening
@@ -1147,10 +1148,15 @@ class VideoRemixer(TabBase):
         jot = Jot()
         kept_scenes = self.state.kept_scenes()
         if kept_scenes:
-            self.log("purging stale content")
-            self.state.purge_stale_processed_content(upscale_option_changed)
-            self.log("purging incomplete content")
-            self.state.purge_incomplete_processed_content()
+            if self.state.processed_content_invalid:
+                self.log("setup options changed, purging all processed content")
+                self.state.purge_processed_content(self.state.RESIZE_STEP)
+                self.state.processed_content_invalid = False
+            else:
+                self.log("purging stale content")
+                self.state.purge_stale_processed_content(upscale_option_changed)
+                self.log("purging incomplete content")
+                self.state.purge_incomplete_processed_content()
             self.log("saving project after purging stale and incomplete content")
             self.state.save()
 

--- a/tabs/video_remixer_ui.py
+++ b/tabs/video_remixer_ui.py
@@ -242,8 +242,8 @@ class VideoRemixer(TabBase):
                     with gr.Accordion(SimpleIcons.TIPS_SYMBOL + " Guide", open=False):
                         WebuiTips.video_remixer_compile.render()
 
-                ## PROCESSING OPTIONS
-                with gr.Tab(SimpleIcons.SIX + " Processing Options", id=self.TAB_PROC_OPTIONS):
+                ## PROCESS REMIX
+                with gr.Tab(SimpleIcons.SIX + " Process Remix", id=self.TAB_PROC_OPTIONS):
                     gr.Markdown("**Ready to Process Content for Remix Video**")
                     with gr.Row():
                         resize = gr.Checkbox(label="Fix Aspect Ratio", value=True)
@@ -849,6 +849,8 @@ class VideoRemixer(TabBase):
                 gr.update(value=self.format_markdown(f"Scene Split Seconds should be >= 1", "warning")),\
                 *self.empty_args(3)
 
+        # TODO validate the other entries
+
         try:
             # this is first project write
             self.log(f"creating project path {project_path}")
@@ -1126,9 +1128,9 @@ class VideoRemixer(TabBase):
     def back_button4(self):
         return gr.update(selected=self.TAB_CHOOSE_SCENES)
 
-    ### PROCESSING OPTIONS EVENT HANDLERS
+    ### PROCESS REMIX EVENT HANDLERS
 
-    # User has clicked Process Remix from Processing Options
+    # User has clicked Process Remix from Process Remix
     def next_button5(self, resynthesize, inflate, resize, upscale, upscale_option):
         self.state.resynthesize = resynthesize
         self.state.inflate = inflate

--- a/tabs/video_remixer_ui.py
+++ b/tabs/video_remixer_ui.py
@@ -111,7 +111,7 @@ class VideoRemixer(TabBase):
                         deinterlace = gr.Checkbox(label="Deinterlace Soure Video")
                     with gr.Row():
                         split_type = gr.Radio(label="Split Type", value="Scene",
-                                                    choices=["Scene", "Break", "Minute"])
+                                                    choices=["Scene", "Break", "Minute", "None"])
                         scene_threshold = gr.Slider(value=0.6, minimum=0.0, maximum=1.0,
                                                     step=0.01, label="Scene Detection Threshold",
                                 info="Value between 0.0 and 1.0 (higher = fewer scenes detected)")
@@ -863,7 +863,7 @@ class VideoRemixer(TabBase):
     def back_button1(self):
         return gr.update(selected=self.TAB_REMIX_HOME)
 
-    ### REMIX SETUP EVENT HANDLERS
+    ### SET UP PROJECT EVENT HANDLERS
 
     # User has clicked Set Up Project from Set Up Project
     def next_button2(self, thumbnail_type, min_frames_per_scene):

--- a/video_remixer.py
+++ b/video_remixer.py
@@ -229,7 +229,7 @@ class VideoRemixerState():
                 self.split_frames = self.calc_split_frames(self.project_fps, self.split_time)
                 jot.down(f"| Frame Rate | Deinterlace | Resize To | Crop To | Split Type | Split Time | Split Frames |")
                 jot.down(f"| :-: | :-: | :-: | :-: | :-: | :-: | :-: |")
-                jot.down(f"| {float(self.project_fps):.2f} | {self.deinterlace} | {self.resize_w} x {self.resize_h} | {self.crop_w} x {self.crop_h} | {self.split_type} | {self.split_time} | {self.split_frames} |")
+                jot.down(f"| {float(self.project_fps):.2f} | {self.deinterlace} | {self.resize_w} x {self.resize_h} | {self.crop_w} x {self.crop_h} | {self.split_type} | {self.split_time}s | {self.split_frames} |")
             else: # "None"
                 jot.down(f"| Frame Rate | Deinterlace | Resize To | Crop To | Split Type |")
                 jot.down(f"| :-: | :-: | :-: | :-: | :-: |")

--- a/video_remixer.py
+++ b/video_remixer.py
@@ -4,8 +4,8 @@ import shutil
 import yaml
 from yaml import Loader, YAMLError
 from webui_utils.auto_increment import AutoIncrementBackupFilename, AutoIncrementDirectory
-from webui_utils.file_utils import split_filepath, remove_directories, create_directory, \
-    get_directories, get_files, clean_directories, clean_filename, get_matching_files
+from webui_utils.file_utils import split_filepath, create_directory, get_directories, get_files,\
+    clean_directories, clean_filename
 from webui_utils.simple_icons import SimpleIcons
 from webui_utils.simple_utils import seconds_to_hmsf, shrink
 from webui_utils.video_utils import details_from_group_name, get_essential_video_details, \
@@ -322,8 +322,8 @@ class VideoRemixerState():
                                 float(self.break_ratio),
                                 log_fn).split()
                     Mtqdm().update_bar(bar)
-
-            else: # split by minute
+            elif self.split_type == "Minute":
+                # split by minute
                 SplitFrames(
                     self.frames_path,
                     self.scenes_path,
@@ -331,6 +331,18 @@ class VideoRemixerState():
                     "precise",
                     0,
                     self.frames_per_minute,
+                    "copy",
+                    False,
+                    log_fn).split()
+            else:
+                # single split
+                SplitFrames(
+                    self.frames_path,
+                    self.scenes_path,
+                    "png",
+                    "precise",
+                    1,
+                    0,
                     "copy",
                     False,
                     log_fn).split()

--- a/video_remixer.py
+++ b/video_remixer.py
@@ -51,6 +51,7 @@ class VideoRemixerState():
         # set on confirming set up options
         self.split_frames = None
         self.project_info2 = None # re-set on re-opening project
+        self.processed_content_invalid = False # ensure processed content is purged on redo
 
         # set on confirming project setup
         self.thumbnail_type = None

--- a/webui_tips.py
+++ b/webui_tips.py
@@ -71,3 +71,4 @@ class WebuiTips:
     video_remixer_processing = gr.Markdown(load_markdown(tips_path, "video_remixer_processing"))
     video_remixer_home = gr.Markdown(load_markdown(tips_path, "video_remixer_home"))
     video_remixer_save = gr.Markdown(load_markdown(tips_path, "video_remixer_save"))
+    video_remixer_extra = gr.Markdown(load_markdown(tips_path, "video_remixer_extra"))

--- a/webui_utils/simple_icons.py
+++ b/webui_utils/simple_icons.py
@@ -11,6 +11,8 @@ class SimpleIcons:
     OPEN_FOLDER = "📂"
 
     DIVIDE = "➗"
+    FAST_DOWN = "⏬"
+    FIVE = "5️⃣"
     FOUR = "4️⃣"
     GEAR = "⚙️"
     INFO = "ℹ️"
@@ -22,10 +24,12 @@ class SimpleIcons:
     RECYCLE = "♻️"
     RIGHT_ARROW = "➡️"
     SCISSORS = "✂️"
+    SIX = "6️⃣"
     THREE = "3️⃣"
     TOOLBOX = "🧰"
     TWO = "2️⃣"
     UP_DOWN_ARROW = "↕️"
+    WASTE_BASKET = "🗑️"
     WHITE_QUESTION = "❔"
     WRENCH = "🔧"
 
@@ -64,18 +68,23 @@ class SimpleIcons:
     VULCAN_HAND = "🖖"
 
     COPYRIGHT = "©️"
+    CROSSMARK = "❌"
     NO_ENTRY = "⛔"
     PROHIBITED = "🚫"
     WARNING = "⚠️"
 
+    AXE = "🪓"
     BALLOON = "🎈"
     BABY = "👶"
     BANDAGE = "🩹"
     BOMB = "💣"
+    BROKEN_HEART = "💔"
     CHERRY_BLOSSOM = "🌸"
+    COCKTAIL = "🍸"
     COOL = "🆒"
     EGGPLANT = "🍆"
     EYES = "👀"
+    FINISH_FLAG = "🏁"
     FLASHLIGHT ="🔦"
     GEMSTONE = "💎"
     GHOST = "👻"
@@ -84,6 +93,7 @@ class SimpleIcons:
     HAMMER = "🔨"
     HAMMER_WRENCH = "🛠️"
     HEART = "❤️"
+    HEART_HANDS = "🫶"
     INCREASING = "📈"
     LABCOAT = "🥼"
     MAGIC_WAND = "🪄"
@@ -91,6 +101,7 @@ class SimpleIcons:
     PACKAGE = "📦"
     ROBOT = "🤖"
     ROCKET = "🚀"
+
     SCROLL = "📜"
     SEEDLING = "🌱"
     SOAP = "🧼"
@@ -122,21 +133,29 @@ class SimpleIcons:
     ]
 
     APP_ICONS = [
+        AXE,
         BALLOON,
         BANDAGE,
         BAR_CHART,
+        BOMB,
+        BROKEN_HEART,
         CLAPPER,
+        COCKTAIL,
         CONTROLS,
         COPYRIGHT,
+        CROSSMARK,
         DIVIDE,
         DOCUMENT,
         FILM,
+        FINISH_FLAG,
+        FIVE,
         FOUR,
         GEAR,
         GEMSTONE,
         GLOBE,
         HAMMER,
         HAMMER_WRENCH,
+        HEART_HANDS,
         INCREASING,
         INFO,
         LABCOAT,
@@ -153,14 +172,17 @@ class SimpleIcons:
         ROCKET,
         SCROLL,
         SEEDLING,
+        SIX,
         SPONGE,
         STETHOSCOPE,
         STILL,
         TELEVISION,
         THREE,
+        TOOLBOX,
         TWO,
         TWO_HEARTS,
         VULCAN_HAND,
         WARNING,
+        WASTE_BASKET,
         WATCH,
 ]

--- a/webui_utils/test_simple_icons.py
+++ b/webui_utils/test_simple_icons.py
@@ -5,7 +5,7 @@ from .simple_icons import *
 
 GOOD_EXAMPLES = [
     (SimpleIcons.SYMBOLS, 8, 10),
-    (SimpleIcons.APP_ICONS, 41, 58)]
+    (SimpleIcons.APP_ICONS, 52, 74)]
 
 def test_SimpleIcons():
     for example, expected_items, expected_len in GOOD_EXAMPLES:


### PR DESCRIPTION
- Add icons to Video Remixer tabs to help with the confusion of a sea of tabs
- Add a new "None" split type
- Change the "Minute" split type to "Time" and add a control for the number of seconds, default 60
- Rename "Processing Options" tab to "Process Remix" to better represent its purpose
- Ensure processed content is purged if project settings (e.g. crop size) is changed
- Add Guide pages for the _Remix Extra_ tab
- etc