### PR TITLE
Video Remixer feature: export kept scenes as a new project

### DIFF
--- a/tabs/video_remixer_ui.py
+++ b/tabs/video_remixer_ui.py
@@ -44,6 +44,7 @@ class VideoRemixer(TabBase):
     TAB_EXTRA_UTIL_DROP_PROCESSED = 0
     TAB_EXTRA_UTIL_CHOOSE_RANGE = 1
     TAB_EXTRA_UTIL_SPLIT_SCENE = 2
+    TAB_EXTRA_UTIL_EXPORT_SCENES = 3
 
     TAB00_DEFAULT_MESSAGE = "Click New Project to: Inspect Video and Count Frames (can take a minute or more)"
     TAB01_DEFAULT_MESSAGE = "Click Open Project to: Resume Editing an Existing Project"
@@ -353,6 +354,7 @@ class VideoRemixer(TabBase):
                 ## REMIX EXTRA
                 with gr.Tab(SimpleIcons.COCKTAIL + " Remix Extra", id=self.TAB_REMIX_EXTRA):
                     with gr.Tabs() as tabs_remix_extra:
+
                         with gr.Tab(SimpleIcons.TOOLBOX + " Utilities", id=self.TAB_EXTRA_UTILITIES):
                             with gr.Tabs() as tabs_remix_extra_utils:
                                 with gr.Tab(SimpleIcons.AXE + " Split Scene", id=self.TAB_EXTRA_UTIL_SPLIT_SCENE):
@@ -389,6 +391,18 @@ class VideoRemixer(TabBase):
                                     with gr.Row():
                                         message_box701 = gr.Markdown(self.format_markdown("Click Choose Scene Range to: Set the Scene Range to the specified state"))
                                     choose_button701 = gr.Button("Choose Scene Range",
+                                                            variant="stop").style(full_width=False)
+
+                                with gr.Tab(SimpleIcons.HEART_EXCLAMATION + " Export Kept Scenes", id=self.TAB_EXTRA_UTIL_EXPORT_SCENES):
+                                    gr.Markdown("**_Save Kept Scenes as a New Project_**")
+                                    with gr.Row():
+                                        export_path_703 = gr.Textbox(label="Exported Project Path", max_lines=1,
+                                                info="Enter a path on this server for the new project")
+                                        project_name_703 = gr.Textbox(label="Exported Project Name", max_lines=1,
+                                                info="Enter a name for the new project")
+                                    with gr.Row():
+                                        message_box703 = gr.Markdown(self.format_markdown("Click Export Project to: Save the kept scenes as a new project"))
+                                    export_project_703 = gr.Button("Export Project",
                                                             variant="stop").style(full_width=False)
 
                         with gr.Tab(SimpleIcons.HERB +" Reduce Footprint", id=self.TAB_EXTRA_REDUCE):
@@ -666,6 +680,9 @@ class VideoRemixer(TabBase):
         split_button702.click(self.split_button702, inputs=[scene_id_702, split_percent_702],
                               outputs=[tabs_video_remixer, message_box702, scene_index, scene_label,
                                        scene_image, scene_state, scene_info])
+
+        export_project_703.click(self.export_project_703,
+                                 inputs=[export_path_703, project_name_703], outputs=message_box703)
 
         delete_button710.click(self.delete_button710,
                                inputs=delete_purged_710,
@@ -1563,6 +1580,35 @@ class VideoRemixer(TabBase):
         return gr.update(selected=self.TAB_CHOOSE_SCENES), \
             gr.update(value=self.format_markdown(message)), \
             *self.scene_chooser_details(self.state.current_scene)
+
+    def export_project_703(self, new_project_path, new_project_name):
+        if not new_project_path:
+            return gr.update(value=self.format_markdown("Please enter a Project Path for the new project", "warning"))
+        if not is_safe_path(new_project_path):
+            return gr.update(value=self.format_markdown("The entered Project Path is not valid", "warning"))
+        if not new_project_name:
+            return gr.update(value=self.format_markdown("Please enter a Project Name for the new project", "warning"))
+
+        # uncompile the original project scenes
+
+        # duplicate the original project state to a new one
+        # update the project path and related to the new path and name (project_path, source_video)
+        # recompute all the project paths (audio_clips_path, clips_path, dropped_scenes_path,
+        # frames_path, inflation_path, resize_path, resynthesis_path, scenes_path, thumbnail_path,
+        # upscale_path, video_clips_path,  )
+        # clear some paths (ouput_filepath)
+        # remove processed content from the state (rc, re, in, up)
+        # remove dropped scenes from the scene names
+        # remove droped scenes from the scene states
+        # remove dropped thumbnails
+        # reset the project reentry point to scene chooser (progress)
+        # clear certain message box entries post-scene chooser (summary_info6)
+        # remove audio clips, video clips, remix clips
+        # reset current scene to the first (kept) scene
+        # reset processed_content_invalid
+
+        # re-compile the original project scenes
+
 
     def delete_button710(self, delete_purged):
         if delete_purged:

--- a/video_remixer.py
+++ b/video_remixer.py
@@ -201,7 +201,8 @@ class VideoRemixerState():
         self.crop_w = crop_w
         self.crop_h = crop_h
 
-    def determine_project_filepath(self, project_path):
+    @staticmethod
+    def determine_project_filepath(project_path):
         if os.path.isdir(project_path):
             project_file = os.path.join(project_path, VideoRemixerState.DEF_FILENAME)
         else:
@@ -257,9 +258,10 @@ class VideoRemixerState():
             Mtqdm().update_bar(bar)
 
     def copy_project_file(self, copy_path):
-        project_file = self.determine_project_filepath(self.project_path)
+        project_file = VideoRemixerState.determine_project_filepath(self.project_path)
         saved_project_file = os.path.join(copy_path, self.DEF_FILENAME)
         shutil.copy(project_file, saved_project_file)
+        return saved_project_file
 
     # when advancing forward from the Set Up Project step
     # the user may be redoing the project from this step
@@ -1418,15 +1420,15 @@ class VideoRemixerState():
                 raise ValueError(message)
 
     @staticmethod
-    def load_ported(original_project_path, ported_project_file : str):
+    def load_ported(original_project_path, ported_project_file : str, save_original = True):
         new_path, _, _ = split_filepath(ported_project_file)
 
-        # save the original YAML file
-        backup_path = os.path.join(new_path, "ported_project_files")
-        create_directory(backup_path)
-        backup_filepath = \
-            AutoIncrementBackupFilename(ported_project_file, backup_path).next_filepath()
-        shutil.copy(ported_project_file, backup_filepath)
+        if save_original:
+            backup_path = os.path.join(new_path, "ported_project_files")
+            create_directory(backup_path)
+            backup_filepath = \
+                AutoIncrementBackupFilename(ported_project_file, backup_path).next_filepath()
+            shutil.copy(ported_project_file, backup_filepath)
 
         if new_path[-1] != "\\":
             new_path += "\\"

--- a/webui_utils/simple_icons.py
+++ b/webui_utils/simple_icons.py
@@ -94,11 +94,13 @@ class SimpleIcons:
     HAMMER = "🔨"
     HAMMER_WRENCH = "🛠️"
     HEART = "❤️"
+    HEART_EXCLAMATION = "❣️"
     HEART_HANDS = "🫶"
     HERB = "🌿"
     INCREASING = "📈"
     LABCOAT = "🥼"
     MAGIC_WAND = "🪄"
+    MEAT = "🥩"
     MICROSCOPE = "🔬"
     PACKAGE = "📦"
     ROBOT = "🤖"
@@ -157,6 +159,7 @@ class SimpleIcons:
         GLOBE,
         HAMMER,
         HAMMER_WRENCH,
+        HEART_EXCLAMATION,
         HEART_HANDS,
         HERB,
         INCREASING,

--- a/webui_utils/test_simple_icons.py
+++ b/webui_utils/test_simple_icons.py
@@ -5,7 +5,7 @@ from .simple_icons import *
 
 GOOD_EXAMPLES = [
     (SimpleIcons.SYMBOLS, 8, 10),
-    (SimpleIcons.APP_ICONS, 52, 74)]
+    (SimpleIcons.APP_ICONS, 54, 77)]
 
 def test_SimpleIcons():
     for example, expected_items, expected_len in GOOD_EXAMPLES:


### PR DESCRIPTION
A new tab on the Remix Extra/Utilities tab: _Export Kept Scenes_

Creates a new project at the specified location copying only:
- the original video
- the kept scenes
- the kept scene thumbnails