### PR TITLE
Video Remixer minor

### DIFF
--- a/tabs/video_remixer_ui.py
+++ b/tabs/video_remixer_ui.py
@@ -1177,7 +1177,7 @@ class VideoRemixer(TabBase):
         if kept_scenes:
             if self.state.processed_content_invalid:
                 self.log("setup options changed, purging all processed content")
-                self.state.purge_processed_content(self.state.RESIZE_STEP)
+                self.state.purge_processed_content(purge_from=self.state.RESIZE_STEP)
                 self.state.processed_content_invalid = False
             else:
                 self.log("purging stale content")
@@ -1194,7 +1194,7 @@ class VideoRemixer(TabBase):
                 jot.down(f"Using original source content in {self.state.scenes_path}")
 
             if self.state.resize:
-                if self.state.processed_content_present(self.state.RESIZE_STEP):
+                if self.state.processed_content_complete(self.state.RESIZE_STEP):
                     jot.down(f"Using processed resized scenes in {self.state.resize_path}")
                 else:
                     self.log("about to resize scenes")
@@ -1206,7 +1206,7 @@ class VideoRemixer(TabBase):
                     jot.down(f"Resized scenes created in {self.state.resize_path}")
 
             if self.state.resynthesize:
-                if self.state.processed_content_present(self.state.RESYNTH_STEP):
+                if self.state.processed_content_complete(self.state.RESYNTH_STEP):
                     jot.down(
                         f"Using processed resynthesized scenes in {self.state.resynthesis_path}")
                 else:
@@ -1219,7 +1219,7 @@ class VideoRemixer(TabBase):
                     jot.down(f"Resynthesized scenes created in {self.state.resynthesis_path}")
 
             if self.state.inflate:
-                if self.state.processed_content_present(self.state.INFLATE_STEP):
+                if self.state.processed_content_complete(self.state.INFLATE_STEP):
                     jot.down(f"Using processed inflated scenes in {self.state.inflation_path}")
                 else:
                     self.state.inflate_scenes(self.log,
@@ -1231,7 +1231,7 @@ class VideoRemixer(TabBase):
                     jot.down(f"Inflated scenes created in {self.state.inflation_path}")
 
             if self.state.upscale:
-                if self.state.processed_content_present(self.state.UPSCALE_STEP):
+                if self.state.processed_content_complete(self.state.UPSCALE_STEP):
                     jot.down(f"Using processed upscaled scenes in {self.state.upscale_path}")
                 else:
                     self.state.upscale_scenes(self.log,
@@ -1294,7 +1294,7 @@ class VideoRemixer(TabBase):
         # create audio clips only if they do not already exist
         # this depends on the audio clips being purged at the time the scene selection are compiled
         if self.state.video_details["has_audio"] and not \
-                self.state.processed_content_present("audio"):
+                self.state.processed_content_complete(self.state.AUDIO_STEP):
             self.log("about to create audio clips")
             audio_format = self.config.remixer_settings["audio_format"]
             self.state.create_audio_clips(self.log, global_options, audio_format=audio_format)

--- a/tabs/video_remixer_ui.py
+++ b/tabs/video_remixer_ui.py
@@ -1407,6 +1407,11 @@ class VideoRemixer(TabBase):
             return gr.update(value=self.format_markdown(f"Please enter a Scene Index from 0 to {last_scene}", "warning"))
 
         removed = self.state.force_drop_processed_scene(scene_index)
+
+        # audio clips aren't cleaned each time a remix is saved
+        # clean now to ensure the dropped scene audio clip is removed
+        self.state.clean_remix_content(purge_from="audio_clips")
+
         self.log(f"removed files: {removed}")
         self.log(
             f"saving project after using force_drop_processed_scene for scene index {scene_index}")

--- a/webui_utils/video_utils.py
+++ b/webui_utils/video_utils.py
@@ -702,7 +702,10 @@ def combine_video_audio(video_path : str,
     return cmd
 
 # combine videos that have the same code,dimensions,etc
-def combine_videos(input_paths : list, output_filepath : str, global_options : str=""):
+def combine_videos(input_paths : list,
+                   output_filepath : str,
+                   global_options : str="",
+                   keep_concat_file : bool=False):
 # ffmpeg -y -f concat -i file.txt -c copy final.mp4
 # file 'output1.mp4'
 # file 'output2.mp4'
@@ -723,4 +726,6 @@ def combine_videos(input_paths : list, output_filepath : str, global_options : s
         global_options="-y " + global_options)
     cmd = ffcmd.cmd
     ffcmd.run()
+    if not keep_concat_file:
+        os.remove(concat_file)
     return cmd


### PR DESCRIPTION
- fix: stale audio clip can be leftover using drop processed scene
- delete the .txt file created for use with the ffmpeg concat muxer as not needed
- clean up the processed content integrity checking logic
- only create a purge sub directory if there's something to purge