### PR TITLE
Video Remixer Minor

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -102,8 +102,15 @@ remixer_settings:
   default_gif_fps: 10
   gif_end_delay: 1.0
   gif_factor: 10
-  marked_ffmpeg_video: -vf "drawtext=text='<SCENE_INFO>':x=(w-text_w)/2:y=(text_h*1):fontsize=(h/22):fontcolor=white@0.9:fontfile='fonts/trim.ttf':box=1:boxcolor=black@0.5:boxborderw=5" -c:v libx264 -crf 28
+  marked_at_top: True
+  marked_border_size: 5
+  marked_box_color: black@0.5
+  marked_draw_box: True
+  marked_ffmpeg_video: -vf "drawtext=<SCENE_INFO>" -c:v libx264 -crf 28
   marked_ffmpeg_audio: -c:a aac
+  marked_font_color: white@0.9
+  marked_font_size: 30
+  marked_font_file: fonts/trim.ttf
   max_project_fps: 60.0
   max_thumb_size: 512
   maximum_crf: 28

--- a/tabs/video_remixer_ui.py
+++ b/tabs/video_remixer_ui.py
@@ -1330,14 +1330,16 @@ class VideoRemixer(TabBase):
                           global_options,
                           kept_scenes,
                           custom_video_options,
-                          custom_audio_options):
+                          custom_audio_options,
+                          draw_text_options=None):
         _, _, output_ext = split_filepath(output_filepath)
         output_ext = output_ext[1:]
 
         self.log(f"about to create custom video clips")
         self.state.create_custom_video_clips(self.log, kept_scenes, global_options,
                                              custom_video_options=custom_video_options,
-                                             custom_ext=output_ext)
+                                             custom_ext=output_ext,
+                                             draw_text_options=draw_text_options)
         self.log("saving project after creating custom video clips")
         self.state.save()
 
@@ -1386,8 +1388,27 @@ class VideoRemixer(TabBase):
     def next_button62(self, marked_video_options, marked_audio_options, output_filepath):
         try:
             global_options, kept_scenes = self.prepare_save_remix(output_filepath)
+            draw_text_options = {}
+            draw_text_options["font_size"] = self.config.remixer_settings["marked_font_size"]
+            draw_text_options["font_color"] = self.config.remixer_settings["marked_font_color"]
+            draw_text_options["font_file"] = self.config.remixer_settings["marked_font_file"]
+            draw_text_options["draw_box"] = self.config.remixer_settings["marked_draw_box"]
+            draw_text_options["box_color"] = self.config.remixer_settings["marked_box_color"]
+            draw_text_options["border_size"] = self.config.remixer_settings["marked_border_size"]
+            draw_text_options["marked_at_top"] = self.config.remixer_settings["marked_at_top"]
+
+            # account for upscaling
+            upscale_factor = 1
+            if self.state.upscale:
+                if self.state.upscale_option == "2X":
+                    upscale_factor = 2
+                elif self.state.upscale_option == "4X":
+                    upscale_factor = 4
+            draw_text_options["crop_width"] = self.state.crop_w * upscale_factor
+            draw_text_options["crop_height"] = self.state.crop_h * upscale_factor
+
             self.save_custom_remix(output_filepath, global_options, kept_scenes,
-                                   marked_video_options, marked_audio_options)
+                                   marked_video_options, marked_audio_options, draw_text_options)
             return gr.update(value=self.format_markdown(f"Remixed marked video {output_filepath} is complete.", "highlight"))
         except ValueError as error:
             return gr.update(value=self.format_markdown(str(error), "error"))

--- a/tabs/video_remixer_ui.py
+++ b/tabs/video_remixer_ui.py
@@ -398,8 +398,8 @@ class VideoRemixer(TabBase):
                                     with gr.Row():
                                         export_path_703 = gr.Textbox(label="Exported Project Root Directory", max_lines=1,
                                                 info="Enter a path on this server for the root directory of the new project")
-                                        project_name_703 = gr.Textbox(label="Exported Project Directory Name", max_lines=1,
-                                                info="Enter a directory name for the new project")
+                                        project_name_703 = gr.Textbox(label="Exported Project Name", max_lines=1,
+                                                info="Enter a name for the new project")
                                     with gr.Row():
                                         message_box703 = gr.Markdown(self.format_markdown("Click Export Project to: Save the kept scenes as a new project"))
                                     export_project_703 = gr.Button("Export Project" + SimpleIcons.SLOW_SYMBOL,

--- a/tabs/video_remixer_ui.py
+++ b/tabs/video_remixer_ui.py
@@ -1657,22 +1657,24 @@ class VideoRemixer(TabBase):
             new_state.scene_names = []
             new_state.thumbnails = []
 
-            for index, scene_name in enumerate(self.state.scene_names):
-                state = self.state.scene_states[scene_name]
-                if state == "Keep":
-                    scene_name = self.state.scene_names[index]
-                    new_state.scene_states[scene_name] = "Keep"
+            with Mtqdm().open_bar(total=len(self.state.scene_names), desc="Duplicating") as bar:
+                for index, scene_name in enumerate(self.state.scene_names):
+                    state = self.state.scene_states[scene_name]
+                    if state == "Keep":
+                        scene_name = self.state.scene_names[index]
+                        new_state.scene_states[scene_name] = "Keep"
 
-                    new_state.scene_names.append(scene_name)
-                    scene_dir = os.path.join(self.state.scenes_path, scene_name)
-                    new_scene_dir = os.path.join(new_state.scenes_path, scene_name)
-                    duplicate_directory(scene_dir, new_scene_dir)
+                        new_state.scene_names.append(scene_name)
+                        scene_dir = os.path.join(self.state.scenes_path, scene_name)
+                        new_scene_dir = os.path.join(new_state.scenes_path, scene_name)
+                        duplicate_directory(scene_dir, new_scene_dir)
 
-                    scene_thumbnail = self.state.thumbnails[index]
-                    _, filename, ext = split_filepath(scene_thumbnail)
-                    new_thumbnail = os.path.join(new_state.thumbnail_path, filename + ext)
-                    new_state.thumbnails.append(new_thumbnail)
-                    shutil.copy(scene_thumbnail, new_thumbnail)
+                        scene_thumbnail = self.state.thumbnails[index]
+                        _, filename, ext = split_filepath(scene_thumbnail)
+                        new_thumbnail = os.path.join(new_state.thumbnail_path, filename + ext)
+                        new_state.thumbnails.append(new_thumbnail)
+                        shutil.copy(scene_thumbnail, new_thumbnail)
+                    Mtqdm().update_bar(bar)
 
             # reset some things
             new_state.current_scene = 0

--- a/tabs/video_remixer_ui.py
+++ b/tabs/video_remixer_ui.py
@@ -398,7 +398,7 @@ class VideoRemixer(TabBase):
                                     with gr.Row():
                                         export_path_703 = gr.Textbox(label="Exported Project Root Directory", max_lines=1,
                                                 info="Enter a path on this server for the root directory of the new project")
-                                        project_name_703 = gr.Textbox(label="Exported Project Direcotry Name", max_lines=1,
+                                        project_name_703 = gr.Textbox(label="Exported Project Directory Name", max_lines=1,
                                                 info="Enter a directory name for the new project")
                                     with gr.Row():
                                         message_box703 = gr.Markdown(self.format_markdown("Click Export Project to: Save the kept scenes as a new project"))


### PR DESCRIPTION
⚠️ **New and modified `config.yaml` settings**

```yaml
remixer_settings:
  marked_at_top: True
  marked_border_size: 5
  marked_box_color: black@0.5
  marked_draw_box: True
  marked_ffmpeg_video: -vf "drawtext=<SCENE_INFO>" -c:v libx264 -crf 28
  marked_ffmpeg_audio: -c:a aac
  marked_font_color: white@0.9
  marked_font_size: 30
  marked_font_file: fonts/trim.ttf
```

**Code Changes**
- fix marking of vertical orientation videos
- move FFmpeg `drawtext` marking settings to `config.yaml`
- add a new setting to place the marker at the bottom instead of the top
- change font and border size to be based on frame width and scale with size
- clarify some wording
