### PR TITLE
Video Remixer: mute error if loading scene chooser info w purged thumbnails

### DIFF
--- a/video_remixer.py
+++ b/video_remixer.py
@@ -578,9 +578,14 @@ class VideoRemixerState():
     GAP = " " * 5
 
     def scene_chooser_data(self, scene_index):
+        # prevent an error if the thumbnails have been purged
+        try:
+            thumbnail_path = self.thumbnails[scene_index]
+        except IndexError:
+            thumbnail_path = None
+
         try:
             scene_name = self.scene_names[scene_index]
-            thumbnail_path = self.thumbnails[scene_index]
             scene_state = self.scene_states[scene_name]
             scene_position = f"{scene_index+1} of {len(self.scene_names)}"
 


### PR DESCRIPTION
If the scene chooser details have been purged, the lack of thumbnails could cause an error when scene chooser details were calculated for display in marked videos. This mutes this specific error case, allowing the marked video to be created.