### PR TITLE
New Tool: Video Assembler

### DIFF
--- a/create_ui.py
+++ b/create_ui.py
@@ -35,7 +35,7 @@ from tabs.split_scenes_ui import SplitScenes
 from tabs.slice_video_ui import SliceVideo
 from tabs.strip_scenes_ui import StripScenes
 from tabs.video_remixer_ui import VideoRemixer
-from tabs.assemble_video_ui import AssembleVideo
+from tabs.video_assembler_ui import VideoAssembler
 
 def create_ui(config : SimpleConfig,
               engine : InterpolateEngine,
@@ -104,7 +104,7 @@ def create_ui(config : SimpleConfig,
                 GIFtoPNG(config, engine, log.log).render_tab()
                 PNGtoGIF(config, engine, log.log).render_tab()
                 SimplifyPngFiles(config, engine, log.log).render_tab()
-                AssembleVideo(config, engine, log.log).render_tab()
+                VideoAssembler(config, engine, log.log).render_tab()
             ChangeFPS(config, engine, log.log).render_tab()
             GIFtoMP4(config, engine, log.log).render_tab()
             with gr.Tab(SimpleIcons.GEAR + "Application"):

--- a/create_ui.py
+++ b/create_ui.py
@@ -35,6 +35,7 @@ from tabs.split_scenes_ui import SplitScenes
 from tabs.slice_video_ui import SliceVideo
 from tabs.strip_scenes_ui import StripScenes
 from tabs.video_remixer_ui import VideoRemixer
+from tabs.assemble_video_ui import AssembleVideo
 
 def create_ui(config : SimpleConfig,
               engine : InterpolateEngine,
@@ -77,6 +78,7 @@ def create_ui(config : SimpleConfig,
                 DuplicateTuning(config, engine, log.log).render_tab()
                 DedupeFrames(config, engine, log.log).render_tab()
                 AutofillFrames(config, engine, log.log).render_tab()
+
             with gr.Tab("Split & Merge"):
                 gr.HTML(SimpleIcons.SPLIT_MERGE_SYMBOL +
                         "Split, Merge & Process PNG Frame Groups",
@@ -88,6 +90,7 @@ def create_ui(config : SimpleConfig,
                 StripScenes(config, engine, log.log).render_tab()
         VideoBlender(config, engine, log.log).render_tab()
         VideoRemixer(config, engine, log.log).render_tab()
+
         with gr.Tab(SimpleIcons.LABCOAT + "Tools"):
             VideoDetails(config, engine, log.log).render_tab()
             ResequenceFiles(config, engine, log.log).render_tab()
@@ -101,6 +104,7 @@ def create_ui(config : SimpleConfig,
                 GIFtoPNG(config, engine, log.log).render_tab()
                 PNGtoGIF(config, engine, log.log).render_tab()
                 SimplifyPngFiles(config, engine, log.log).render_tab()
+                AssembleVideo(config, engine, log.log).render_tab()
             ChangeFPS(config, engine, log.log).render_tab()
             GIFtoMP4(config, engine, log.log).render_tab()
             with gr.Tab(SimpleIcons.GEAR + "Application"):
@@ -111,6 +115,3 @@ def create_ui(config : SimpleConfig,
         if config.user_interface["show_header"]:
             app_footer.render()
     return app
-
-
-

--- a/guide/video_assembler.md
+++ b/guide/video_assembler.md
@@ -1,0 +1,21 @@
+**Video Assembler** - Create video from a set of video clips with audio
+
+## How It Works
+1. Choose _Individual Path_ or _Batch Processing_
+    - If **Individual Path**
+        - Set _Video Clips Path_ to a path on this server to the video clips to be combined
+        - Set _Combined Video Path_to a path and filename on this server for the combined video
+            - _Tip: Leave this field blank to use the_ Video Clips Path _name for the video_
+    - If **Batch Processing**
+        - Set _Video Clip Directories Path_ to a directory on this server containing directories of video clips to be combined
+            - Note: the containing directory name will be used as the output filename
+1. Click _Assemble Video_ or _Assemble Batch_
+1. The clips will be assembled into one or more videos
+
+## Important
+- The video clips files in a directory should be all of the same type
+
+## Notes
+- Uses the FFmpeg _concat demuxer_ to assemble the video from the provided clips in **filename order**
+- The first found clip specifies the video output format
+- Combining clips of different dimensions and frame rates seems to work

--- a/guide/video_assembler.md
+++ b/guide/video_assembler.md
@@ -4,18 +4,19 @@
 1. Choose _Individual Path_ or _Batch Processing_
     - If **Individual Path**
         - Set _Video Clips Path_ to a path on this server to the video clips to be combined
-        - Set _Combined Video Path_to a path and filename on this server for the combined video
+        - Set _Combined Video Path_ to a path and filename on this server for the combined video
             - _Tip: Leave this field blank to use the_ Video Clips Path _name for the video_
     - If **Batch Processing**
         - Set _Video Clip Directories Path_ to a directory on this server containing directories of video clips to be combined
-            - Note: the containing directory name will be used as the output filename
+            - Note: The containing directory name will be used as the output filename
 1. Click _Assemble Video_ or _Assemble Batch_
 1. The clips will be assembled into one or more videos
 
 ## Important
-- The video clips files in a directory should be all of the same type
+- The video clip files in a directory should be all of the same type
 
 ## Notes
 - Uses the FFmpeg _concat demuxer_ to assemble the video from the provided clips in **filename order**
 - The first found clip specifies the video output format
 - Combining clips of different dimensions and frame rates seems to work
+    - _Tip: Combining clips of different types appears to not work_

--- a/tabs/assemble_video_ui.py
+++ b/tabs/assemble_video_ui.py
@@ -1,0 +1,143 @@
+"""Assemble Video feature UI and event handlers"""
+import os
+from typing import Callable
+import gradio as gr
+from webui_utils.simple_config import SimpleConfig
+from webui_utils.simple_icons import SimpleIcons
+from webui_utils.video_utils import combine_videos
+from webui_utils.file_utils import get_files, get_directories, split_filepath
+from webui_utils.simple_utils import format_markdown
+from webui_utils.mtqdm import Mtqdm
+# from webui_tips import WebuiTips
+from interpolate_engine import InterpolateEngine
+from tabs.tab_base import TabBase
+# from simplify_png_files import SimplifyPngFiles as _SimplifyPngFiles
+
+class AssembleVideo(TabBase):
+    """Encapsulates UI elements and events for the Assemble Video feature"""
+    def __init__(self,
+                    config : SimpleConfig,
+                    engine : InterpolateEngine,
+                    log_fn : Callable):
+        TabBase.__init__(self, config, engine, log_fn)
+
+    DEFAULT_MESSAGE_SINGLE = "Click Assemble Clips to: Combine video clips into a single video file (can take from seconds to minutes)"
+    DEFAULT_MESSAGE_BATCH = "Click Assemble Batch to: Combine video clips in batch directories (can take from minutes to hours)"
+
+    def render_tab(self):
+        """Render tab into UI"""
+        with gr.Tab("Video Assembler"):
+            gr.Markdown(
+                SimpleIcons.CINEMA + "Combine video clips of the same dimensions and rate",
+                elem_id="tabheading")
+            with gr.Tabs():
+                with gr.Tab(label="Individual Path"):
+                    input_path = gr.Text(max_lines=1, label="Video Clips Path",
+                        info="Path on this server to the video clips to be combined")
+                    output_path = gr.Text(max_lines=1, label="Combined Video Path",
+                        info="Path and fileame on this server for the combined video",
+                        placeholder="Leave blank to use input path name as default")
+                    message_box = gr.Markdown(format_markdown(self.DEFAULT_MESSAGE_SINGLE))
+                    gr.Markdown("*Progress can be tracked in the console*")
+                    assemble_button = gr.Button("Assemble Clips " + SimpleIcons.SLOW_SYMBOL, variant="primary")
+
+                with gr.Tab(label="Batch Processing"):
+                    input_path_batch = gr.Text(max_lines=1, label="Video Clip Directories Path",
+                placeholder="Path on this server to the directories of video clips to be combined")
+                    message_batch = gr.Markdown(format_markdown(self.DEFAULT_MESSAGE_BATCH))
+                    gr.Markdown("*Progress can be tracked in the console*")
+                    assemble_batch = gr.Button("Assemble Batch " + SimpleIcons.SLOW_SYMBOL, variant="primary")
+            # with gr.Accordion(SimpleIcons.TIPS_SYMBOL + " Guide", open=False):
+            #     WebuiTips.simplify_png_files.render()
+        assemble_button.click(self.assemble_clips, inputs=[input_path, output_path], outputs=message_box)
+        assemble_batch.click(self.assemble_batch, inputs=input_path_batch, outputs=message_batch)
+
+    def assemble_batch(self, input_path : str):
+        """Clean Batch button handler"""
+        if not input_path:
+            return gr.update(value=format_markdown("Enter a path to directories of video clips on this server to get started", "warning"))
+
+        if not os.path.exists(input_path):
+            return gr.update(value=format_markdown(f"Input path {input_path} was not found", "error"))
+
+        path_names = sorted(get_directories(input_path))
+        if not path_names:
+            return gr.update(value=format_markdown(f"Input path {input_path} does not contain video clip directories", "error"))
+
+        self.log(f"beginning batch combine video clips processing with input_path={input_path}")
+        self.log(f"found {len(path_names)} groups to process")
+
+        warnings = []
+        with Mtqdm().open_bar(total=len(path_names), desc="Assembling Batch") as bar:
+            for path_name in path_names:
+                clips_input_path = os.path.join(input_path, path_name)
+                clips = get_files(clips_input_path)
+
+                if not clips:
+                    message = f"Directory {clips_input_path} is empty - skipping"
+                    self.log(message)
+                    warnings.append(message)
+                    Mtqdm().update_bar(bar)
+                    continue
+
+                default_path = input_path
+                default_filename = path_name
+                first_clip = clips[0]
+                _, _, default_ext = split_filepath(first_clip)
+                output_filepath = os.path.join(default_path, default_filename + default_ext)
+
+                try:
+                    self.assemble_clips(clips_input_path, output_filepath, interactive=False)
+                except ValueError as error:
+                    return gr.update(value=format_markdown(f"Error: {str(error)}", "error"))
+
+                Mtqdm().update_bar(bar)
+        if warnings:
+            warnings = "\r\n".join(warnings)
+            return gr.update(value=format_markdown(warnings, "warning"))
+        else:
+            return gr.update(value=format_markdown(self.DEFAULT_MESSAGE_BATCH))
+
+    def assemble_clips(self, input_path : str, output_filepath : str="", interactive=True):
+        """Assemble Clips button handler"""
+        if not input_path:
+            if interactive:
+                return gr.update(value=format_markdown("Enter a path to video clips on this server to get started", "warning"))
+            else:
+                raise ValueError("'input_path' must be provided")
+
+        if not os.path.exists(input_path):
+            if interactive:
+                return gr.update(value=format_markdown(f"Input path {input_path} was not found", "error"))
+            else:
+                raise ValueError(f"input_path {input_path} not found")
+
+        paths = sorted(get_files(input_path))
+        if not paths:
+            if interactive:
+                return gr.update(value=format_markdown(f"Input path {input_path} does not contain video clips", "error"))
+            else:
+                raise ValueError(f"input_path {input_path} is empty")
+
+        global_options = self.config.ffmpeg_settings["global_options"]
+        if not output_filepath:
+            _, default_filename, _ = split_filepath(input_path)
+            _, _, default_ext = split_filepath(paths[0])
+            output_filepath = os.path.join(input_path, default_filename + default_ext)
+
+        with Mtqdm().open_bar(total=1, desc="Assembling Clips") as bar:
+            try:
+                ffcmd = combine_videos(paths,
+                                    output_filepath,
+                                    global_options=global_options)
+            except ValueError as error:
+                if interactive:
+                    return gr.update(value=format_markdown(f"Error: {str(error)}", "error"))
+                else:
+                    raise error
+
+            self.log(f"assemble_clips ffcmd={ffcmd}")
+            Mtqdm().update_bar(bar)
+
+        if interactive:
+            return gr.update(value=format_markdown(self.DEFAULT_MESSAGE_SINGLE))

--- a/tabs/change_fps_ui.py
+++ b/tabs/change_fps_ui.py
@@ -80,7 +80,7 @@ class ChangeFPS(TabBase):
                             placeholder="Where to place the converted frame groups",
                             label="Output Path")
                     gr.Markdown("*Progress can be tracked in the console*")
-                    convert_batch = gr.Button("Convert Batch" + SimpleIcons.SLOW_SYMBOL,
+                    convert_batch = gr.Button("Convert Batch " + SimpleIcons.SLOW_SYMBOL,
                                                 variant="primary")
             with gr.Accordion(SimpleIcons.TIPS_SYMBOL + " Guide", open=False):
                 WebuiTips.change_fps.render()

--- a/tabs/video_assembler_ui.py
+++ b/tabs/video_assembler_ui.py
@@ -8,12 +8,11 @@ from webui_utils.video_utils import combine_videos
 from webui_utils.file_utils import get_files, get_directories, split_filepath
 from webui_utils.simple_utils import format_markdown
 from webui_utils.mtqdm import Mtqdm
-# from webui_tips import WebuiTips
+from webui_tips import WebuiTips
 from interpolate_engine import InterpolateEngine
 from tabs.tab_base import TabBase
-# from simplify_png_files import SimplifyPngFiles as _SimplifyPngFiles
 
-class AssembleVideo(TabBase):
+class VideoAssembler(TabBase):
     """Encapsulates UI elements and events for the Assemble Video feature"""
     def __init__(self,
                     config : SimpleConfig,
@@ -21,14 +20,14 @@ class AssembleVideo(TabBase):
                     log_fn : Callable):
         TabBase.__init__(self, config, engine, log_fn)
 
-    DEFAULT_MESSAGE_SINGLE = "Click Assemble Clips to: Combine video clips into a single video file (can take from seconds to minutes)"
+    DEFAULT_MESSAGE_SINGLE = "Click Assemble Video to: Combine video clips into a single video file (can take from seconds to minutes)"
     DEFAULT_MESSAGE_BATCH = "Click Assemble Batch to: Combine video clips in batch directories (can take from minutes to hours)"
 
     def render_tab(self):
         """Render tab into UI"""
         with gr.Tab("Video Assembler"):
             gr.Markdown(
-                SimpleIcons.CINEMA + "Combine video clips of the same dimensions and rate",
+                SimpleIcons.CINEMA + "Combine multiple video clips into a single video",
                 elem_id="tabheading")
             with gr.Tabs():
                 with gr.Tab(label="Individual Path"):
@@ -39,7 +38,7 @@ class AssembleVideo(TabBase):
                         placeholder="Leave blank to use input path name as default")
                     message_box = gr.Markdown(format_markdown(self.DEFAULT_MESSAGE_SINGLE))
                     gr.Markdown("*Progress can be tracked in the console*")
-                    assemble_button = gr.Button("Assemble Clips " + SimpleIcons.SLOW_SYMBOL, variant="primary")
+                    assemble_button = gr.Button("Assemble Video " + SimpleIcons.SLOW_SYMBOL, variant="primary")
 
                 with gr.Tab(label="Batch Processing"):
                     input_path_batch = gr.Text(max_lines=1, label="Video Clip Directories Path",
@@ -47,8 +46,8 @@ class AssembleVideo(TabBase):
                     message_batch = gr.Markdown(format_markdown(self.DEFAULT_MESSAGE_BATCH))
                     gr.Markdown("*Progress can be tracked in the console*")
                     assemble_batch = gr.Button("Assemble Batch " + SimpleIcons.SLOW_SYMBOL, variant="primary")
-            # with gr.Accordion(SimpleIcons.TIPS_SYMBOL + " Guide", open=False):
-            #     WebuiTips.simplify_png_files.render()
+            with gr.Accordion(SimpleIcons.TIPS_SYMBOL + " Guide", open=False):
+                WebuiTips.video_assembler.render()
         assemble_button.click(self.assemble_clips, inputs=[input_path, output_path], outputs=message_box)
         assemble_batch.click(self.assemble_batch, inputs=input_path_batch, outputs=message_batch)
 
@@ -99,7 +98,7 @@ class AssembleVideo(TabBase):
             return gr.update(value=format_markdown(self.DEFAULT_MESSAGE_BATCH))
 
     def assemble_clips(self, input_path : str, output_filepath : str="", interactive=True):
-        """Assemble Clips button handler"""
+        """Assemble Video button handler"""
         if not input_path:
             if interactive:
                 return gr.update(value=format_markdown("Enter a path to video clips on this server to get started", "warning"))

--- a/tabs/video_remixer_ui.py
+++ b/tabs/video_remixer_ui.py
@@ -369,7 +369,7 @@ class VideoRemixer(TabBase):
                                     label="Split Position", minimum=1.0, maximum=99.0, step=1.0, info="A lower value splits earlier in the scene")
                                     with gr.Row():
                                         message_box702 = gr.Markdown(self.format_markdown("Click Split Scene to: Split the scenes into Two Scenes at a set percentage"))
-                                    split_button702 = gr.Button("Split Scene" + SimpleIcons.SLOW_SYMBOL, variant="stop").\
+                                    split_button702 = gr.Button("Split Scene " + SimpleIcons.SLOW_SYMBOL, variant="stop").\
                                         style(full_width=False)
 
                                 with gr.Tab(SimpleIcons.BROKEN_HEART + " Drop Processed Scene", id=self.TAB_EXTRA_UTIL_DROP_PROCESSED):
@@ -378,7 +378,7 @@ class VideoRemixer(TabBase):
                                     scene_id_700 = gr.Number(value=-1, label="Scene Index")
                                     with gr.Row():
                                         message_box700 = gr.Markdown(self.format_markdown("Click Drop Scene to: Remove all Processed Content for the specified scene"))
-                                    drop_button700 = gr.Button("Drop Processed Scene" + SimpleIcons.SLOW_SYMBOL, variant="stop").\
+                                    drop_button700 = gr.Button("Drop Processed Scene " + SimpleIcons.SLOW_SYMBOL, variant="stop").\
                                         style(full_width=False)
 
                                 with gr.Tab(SimpleIcons.HEART_HANDS + " Choose Scene Range", id=self.TAB_EXTRA_UTIL_CHOOSE_RANGE):
@@ -406,7 +406,7 @@ class VideoRemixer(TabBase):
                                                 info="Enter a name for the new project")
                                     with gr.Row():
                                         message_box703 = gr.Markdown(self.format_markdown("Click Export Project to: Save the kept scenes as a new project"))
-                                    export_project_703 = gr.Button("Export Project" + SimpleIcons.SLOW_SYMBOL,
+                                    export_project_703 = gr.Button("Export Project " + SimpleIcons.SLOW_SYMBOL,
                                                             variant="stop").style(full_width=False)
                                     with gr.Row():
                                         result_box703 = gr.Textbox(label="New Project Path", max_lines=1, visible=False)

--- a/webui_tips.py
+++ b/webui_tips.py
@@ -72,3 +72,4 @@ class WebuiTips:
     video_remixer_home = gr.Markdown(load_markdown(tips_path, "video_remixer_home"))
     video_remixer_save = gr.Markdown(load_markdown(tips_path, "video_remixer_save"))
     video_remixer_extra = gr.Markdown(load_markdown(tips_path, "video_remixer_extra"))
+    video_assembler = gr.Markdown(load_markdown(tips_path, "video_assembler"))

--- a/webui_utils/simple_icons.py
+++ b/webui_utils/simple_icons.py
@@ -49,6 +49,7 @@ class SimpleIcons:
 
     CAMERA = "📷"
     CASSETTE = "📼"
+    CINEMA = "🎦"
     CLAPPER = "🎬"
     FILM = "🎞️"
     MICROPHONE = "🎤"
@@ -142,6 +143,7 @@ class SimpleIcons:
         BANDAGE,
         BAR_CHART,
         BROKEN_HEART,
+        CINEMA,
         CLAPPER,
         COCKTAIL,
         COLLISION,

--- a/webui_utils/simple_utils.py
+++ b/webui_utils/simple_utils.py
@@ -239,3 +239,21 @@ def shrink(container_data, minimum, move_fn, remove_fn, rename_fn, state):
             container_data, _ = \
                 _shrink_merge(container_data, prev_key, key, move_fn, remove_fn, rename_fn, state)
     return container_data
+
+def _format_markdown_line(text, style):
+    return f"<p style=\"{style}\">{text}</p>"
+
+def format_markdown(text, color="info", bold=True):
+    font_style = "font-weight:bold" if bold else ""
+    color_style = {
+        "info" : "color:hsl(120 100% 65%)",
+        "warning" : "color:hsl(60 100% 65%)",
+        "error" : "color:hsl(0 100% 65%)",
+        "highlight" : "color:hsl(284 100% 65%)",
+    }.get(color, "")
+    style = ";".join([color_style, font_style])
+
+    result = []
+    for line in text.splitlines():
+        result.append(_format_markdown_line(line, style))
+    return "\r\n".join(result)

--- a/webui_utils/test_simple_icons.py
+++ b/webui_utils/test_simple_icons.py
@@ -5,7 +5,7 @@ from .simple_icons import *
 
 GOOD_EXAMPLES = [
     (SimpleIcons.SYMBOLS, 8, 10),
-    (SimpleIcons.APP_ICONS, 54, 77)]
+    (SimpleIcons.APP_ICONS, 55, 78)]
 
 def test_SimpleIcons():
     for example, expected_items, expected_len in GOOD_EXAMPLES:

--- a/webui_utils/video_utils.py
+++ b/webui_utils/video_utils.py
@@ -7,7 +7,7 @@ from fractions import Fraction
 from ffmpy import FFmpeg, FFprobe, FFRuntimeError
 from .image_utils import gif_frame_count
 from .file_utils import split_filepath, get_directories
-from .simple_utils import seconds_to_hms, clean_dict, get_frac_str_as_float
+from .simple_utils import seconds_to_hms, get_frac_str_as_float
 from .jot import Jot
 
 QUALITY_NEAR_LOSSLESS = 17
@@ -725,7 +725,10 @@ def combine_videos(input_paths : list,
         outputs={output_filepath : "-c: copy"},
         global_options="-y " + global_options)
     cmd = ffcmd.cmd
-    ffcmd.run()
-    if not keep_concat_file:
-        os.remove(concat_file)
-    return cmd
+    try:
+        ffcmd.run()
+        if not keep_concat_file:
+            os.remove(concat_file)
+        return cmd
+    except FFRuntimeError as error:
+        raise ValueError(f"combine_video() received an error using FFmpeg: {str(error)}")


### PR DESCRIPTION
Under Tool, File Conversion
- Give path to a set of video clips, uses FFmpeg concat demuxer to create a combined video (including audio)
- Supports batch conversion of a set of directories of clips also
- Easy-of-use default output filenames
    - In single mode, uses the input path name as the video filename, with the first clip's extension as the file type
    - In batch mode, places the videos in the outer input path directory for ease of finding/idempotency