### PR TITLE
Video Remixer: Bug fix - fix yaml file broken lines

### DIFF
--- a/video_remixer.py
+++ b/video_remixer.py
@@ -159,7 +159,7 @@ class VideoRemixerState():
     def save(self, filepath : str=None):
         filepath = filepath or self.project_filepath()
         with open(filepath, "w", encoding="UTF-8") as file:
-            yaml.dump(self, file)
+            yaml.dump(self, file, width=1024)
 
     def project_filepath(self, filename : str=DEF_FILENAME):
         return os.path.join(self.project_path, filename)


### PR DESCRIPTION
When creating an exported project from a previously exported project, and moving between storage locations in the process, the `dropped_scenes_path` wasn't getting properly ported to the new path because the YAML emitter was using the default line length of 100, causing the path to get split onto two lines because it was too long. When this happened, the _porting_ code failed to fix the path because the full string didn't match. This forces the emitter line length to 1024.