### PR TITLE
Video Remixer: support "area" scaling type when only reducing content

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -116,7 +116,8 @@ remixer_settings:
   maximum_crf: 28
   min_frames_per_scene: 10
   minimum_crf: 17
-  scale_type: "lanczos"
+  scale_type_up: "lanczos"
+  scale_type_down: "area"
   thumb_scale: 0.5
   use_tiling: False
 restoration_settings:

--- a/video_remixer.py
+++ b/video_remixer.py
@@ -877,12 +877,20 @@ class VideoRemixerState():
             for scene_name in kept_scenes:
                 scene_input_path = os.path.join(scenes_base_path, scene_name)
                 scene_output_path = os.path.join(self.resize_path, scene_name)
+                content_width = self.video_details["content_width"]
+                content_height = self.video_details["content_height"]
 
-                if self.resize_w == self.video_details["content_width"] and \
-                        self.resize_h == self.video_details["content_height"]:
+                if self.resize_w == content_width and self.resize_h == content_height:
                     scale_type = "none"
                 else:
-                    scale_type = remixer_settings["scale_type"]
+                    if self.resize_w <= content_width and self.resize_h <= content_height:
+                        # use the down scaling type if there are only reductions
+                        # the default "area" type preserves details better on reducing
+                        scale_type = remixer_settings["scale_type_down"]
+                    else:
+                        # otherwise use the upscaling type
+                        # the default "lanczos" type preserves details better on enlarging
+                        scale_type = remixer_settings["scale_type_up"]
 
                 if self.crop_w == self.resize_w and \
                         self.crop_h == self.resize_h:


### PR DESCRIPTION
The "area" scaling type preserves better details when reducing content than does "lanczos", which is currently used for all resizing.

- change the `remixer_settings:scale_type` to  2 settings

```yaml
remixer_settings:
  scale_type_up: "lanczos"
  scale_type_down: "area"
```

- If only reducing, use the `scale_type_down` setting
- Otherwise use the `scale_type_up` setting

Notes: 
- The `lanczos` scaling type is best for enlarging and does a decent job reducing content
- When there is no size change, the scale type `none` is used
