### PR TITLE
Video Remixer: Auto fill framerate on project setup

### DIFF
--- a/tabs/video_remixer_ui.py
+++ b/tabs/video_remixer_ui.py
@@ -567,7 +567,7 @@ class VideoRemixer(TabBase):
         next_button00.click(self.next_button00,
                            inputs=video_path,
                            outputs=[tabs_video_remixer, message_box00, video_info1, project_path,
-                                    resize_w, resize_h, crop_w, crop_h])
+                                    resize_w, resize_h, crop_w, crop_h, project_fps])
 
         next_button01.click(self.next_button01,
                            inputs=project_load_path,
@@ -779,15 +779,16 @@ class VideoRemixer(TabBase):
 
     # User has clicked New Project > from Remix Home
     def next_button00(self, video_path):
+        empty_args = self.empty_args(7)
         if not video_path:
             return gr.update(selected=self.TAB_REMIX_HOME), \
                    gr.update(value=self.format_markdown("Enter a path to a video on this server to get started", "warning")), \
-                   *self.empty_args(6)
+                   *empty_args
 
         if not os.path.exists(video_path):
             return gr.update(selected=self.TAB_REMIX_HOME), \
                    gr.update(value=self.format_markdown(f"File '{video_path}' was not found", "error")), \
-                   *self.empty_args(6)
+                   *empty_args
 
         self.new_project()
         try:
@@ -796,7 +797,7 @@ class VideoRemixer(TabBase):
         except ValueError as error:
             return gr.update(selected=self.TAB_REMIX_HOME), \
                    gr.update(value=self.format_markdown(str(error), "error")), \
-                   *self.empty_args(6)
+                   *empty_args
 
         # don't save yet, user may change project path next
         self.state.save_progress("settings", save_project=False)
@@ -808,7 +809,8 @@ class VideoRemixer(TabBase):
             self.state.resize_w, \
             self.state.resize_h, \
             self.state.crop_w, \
-            self.state.crop_h
+            self.state.crop_h, \
+            self.state.project_fps
 
     # User has clicked Open Project > from Remix Home
     def next_button01(self, project_path):

--- a/tabs/video_remixer_ui.py
+++ b/tabs/video_remixer_ui.py
@@ -1012,7 +1012,13 @@ class VideoRemixer(TabBase):
             self.state.save()
 
         self.state.scene_names = sorted(get_directories(self.state.scenes_path))
-        self.state.drop_all_scenes()
+
+        # if there's only one scene, assume it should be kept to save some time
+        if len(self.state.scene_names) < 2:
+            self.state.keep_all_scenes()
+        else:
+            self.state.drop_all_scenes()
+
         self.state.current_scene = 0
         self.log("saving project after establishing scene names")
         self.state.save()

--- a/video_remixer.py
+++ b/video_remixer.py
@@ -191,8 +191,8 @@ class VideoRemixerState():
 
         filtered_filename = clean_filename(filename, self.FILENAME_FILTER)
         project_path = os.path.join(path, f"{self.PROJECT_PATH_PREFIX}{filtered_filename}")
-        resize_w = video_details['display_width']
-        resize_h = video_details['display_height']
+        resize_w = int(video_details['display_width'])
+        resize_h = int(video_details['display_height'])
         crop_w, crop_h = resize_w, resize_h
 
         self.project_path = project_path
@@ -200,7 +200,7 @@ class VideoRemixerState():
         self.resize_h = resize_h
         self.crop_w = crop_w
         self.crop_h = crop_h
-        self.project_fps = video_details['frame_rate']
+        self.project_fps = float(video_details['frame_rate'])
 
     @staticmethod
     def determine_project_filepath(project_path):

--- a/video_remixer.py
+++ b/video_remixer.py
@@ -200,6 +200,7 @@ class VideoRemixerState():
         self.resize_h = resize_h
         self.crop_w = crop_w
         self.crop_h = crop_h
+        self.project_fps = video_details['frame_rate']
 
     @staticmethod
     def determine_project_filepath(project_path):


### PR DESCRIPTION
Proper slicing of thumbnails and audio files requires that the scene frames match the original video FPS
- Set the project FPS to match the incoming video's FPS to ensure proper slicing (and not require manual changing)

Also, when a new project has only one scene, automatically set it to "Keep".