### PR TITLE
Video Remixer: 60X speed up in GIF thumbnail rendering

### DIFF
--- a/guide/video_remixer_setup.md
+++ b/guide/video_remixer_setup.md
@@ -6,11 +6,11 @@ The _Project Details_ box shows a summary of the remix project about to be creat
 1. Choose a _Thumbnail Type_:
     - **_GIF_**
         - A 10X sped-up animated GIF of the entire scene
-        - GIF thumbnails provide the best experience, but are _slow to render_
-        - They are best used when selecting certain key clips from a video
+        - GIF thumbnails provide the best experience as they show the whole scene
+        - They take a bit more time to render than _JPG_ thumbnails
     - **_JPG_**
-        - A still image at the center of the scene
-        - JPG thumbnails are _fast to render_ but may not provide enough confidence for _keep_ vs. _drop_ decisions
+        - A still image from the middle moment of the scene
+        - JPG thumbnails are _fast to render_ but may obscure some scene details
         - They are best used with the _Break_ split type to identify and remove commercial scenes
 1. Click _Set Up Project_ to begin the setup process
 - Progress can be tracked in the console

--- a/slice_video.py
+++ b/slice_video.py
@@ -142,6 +142,8 @@ class SliceVideo:
             self.log(message)
             return message
 
+    # TODO this was hacked into this class, but it doesn't slice from a video,
+    #      so perhaps it should be in its own class, despite so much shared functionality
     # slice from a pre-grouped set of PNG frames
     def _slice_png_group(self, group_name, slice_name):
         first_index, last_index, num_width = details_from_group_name(group_name)
@@ -152,6 +154,7 @@ class SliceVideo:
         first_index = 0
 
         first_index += self.edge_trim
+        # TODO confirm why this is necessary
         if first_index < 0:
             first_index = 0
         last_index -= self.edge_trim

--- a/slice_video.py
+++ b/slice_video.py
@@ -234,7 +234,6 @@ class SliceVideo:
             self.log(f"Creating output path {self.output_path}")
             create_directory(self.output_path)
 
-        # self.log("using slice_video (may cause long delay while processing request)")
         pbar_desc = f"Slice {self.type}"
         errors = []
         with Mtqdm().open_bar(total=1, desc=pbar_desc) as bar:

--- a/slice_video.py
+++ b/slice_video.py
@@ -5,7 +5,7 @@ from typing import Callable
 from webui_utils.simple_log import SimpleLog
 from webui_utils.file_utils import create_directory, is_safe_path
 from webui_utils.video_utils import validate_input_path, details_from_group_name, slice_video, \
-    determine_input_pattern
+    determine_input_pattern, slice_png_frames
 from webui_utils.mtqdm import Mtqdm
 from ffmpy import FFRuntimeError
 
@@ -168,7 +168,7 @@ class SliceVideo:
         self.log(f"slicing from frames path {frames_path}")
 
         try:
-            ffmpeg_cmd = slice_video(frames_path,
+            ffmpeg_cmd, errors = slice_png_frames(frames_path,
                         self.fps,
                         output_path,
                         num_width,
@@ -184,6 +184,7 @@ class SliceVideo:
                         global_options=self.global_options,
                         output_filename=slice_name)
             self.log(f"FFmpeg command line: '{ffmpeg_cmd}'")
+            self.log(f"FFmpeg stderr output: '{errors}'")
             return None
         except FFRuntimeError as error:
             message = f"FFRuntimeError {error}"

--- a/slice_video.py
+++ b/slice_video.py
@@ -4,7 +4,8 @@ import argparse
 from typing import Callable
 from webui_utils.simple_log import SimpleLog
 from webui_utils.file_utils import create_directory, is_safe_path
-from webui_utils.video_utils import validate_input_path, details_from_group_name, slice_video
+from webui_utils.video_utils import validate_input_path, details_from_group_name, slice_video, \
+    determine_input_pattern
 from webui_utils.mtqdm import Mtqdm
 from ffmpy import FFRuntimeError
 
@@ -141,6 +142,54 @@ class SliceVideo:
             self.log(message)
             return message
 
+    # slice from a pre-grouped set of PNG frames
+    def _slice_png_group(self, group_name, slice_name):
+        first_index, last_index, num_width = details_from_group_name(group_name)
+        output_path = self.output_path or os.path.join(self.group_path, group_name)
+
+        # offset to zero time - the PNG frames should start at the beginning
+        last_index -= first_index
+        first_index = 0
+
+        first_index += self.edge_trim
+        if first_index < 0:
+            first_index = 0
+        last_index -= self.edge_trim
+
+        # With edge trim this can end up with a zero or negative duration
+        # render at least one frame's worth so a valid file is produced.
+        # The combine_video_audio() function will trim to the shortest stream
+        if last_index <= first_index:
+            last_index = first_index + 1
+
+        frames_source = os.path.join(self.group_path, group_name)
+        pattern = determine_input_pattern(frames_source)
+        frames_path = os.path.join(frames_source, pattern)
+        self.log(f"slicing from frames path {frames_path}")
+
+        try:
+            ffmpeg_cmd = slice_video(frames_path,
+                        self.fps,
+                        output_path,
+                        num_width,
+                        first_index,
+                        last_index,
+                        self.type,
+                        self.mp4_quality,
+                        self.gif_factor,
+                        self.output_scale,
+                        self.gif_high_quality,
+                        self.gif_fps,
+                        self.gif_end_delay,
+                        global_options=self.global_options,
+                        output_filename=slice_name)
+            self.log(f"FFmpeg command line: '{ffmpeg_cmd}'")
+            return None
+        except FFRuntimeError as error:
+            message = f"FFRuntimeError {error}"
+            self.log(message)
+            return message
+
     def slice(self, ignore_errors=False):
         group_names = validate_input_path(self.group_path, -1)
         if self.output_path:
@@ -171,6 +220,24 @@ class SliceVideo:
         errors = []
         with Mtqdm().open_bar(total=1, desc=pbar_desc) as bar:
             error = self._slice_group(group_name)
+            if error:
+                errors.append({group_name : error})
+                if not ignore_errors:
+                    raise RuntimeError(error)
+            Mtqdm().update_bar(bar)
+        return errors
+
+    def slice_png_group(self, group_name, ignore_errors=False, slice_name=""):
+        validate_input_path(self.group_path, -1)
+        if self.output_path:
+            self.log(f"Creating output path {self.output_path}")
+            create_directory(self.output_path)
+
+        # self.log("using slice_video (may cause long delay while processing request)")
+        pbar_desc = f"Slice {self.type}"
+        errors = []
+        with Mtqdm().open_bar(total=1, desc=pbar_desc) as bar:
+            error = self._slice_png_group(group_name, slice_name=slice_name)
             if error:
                 errors.append({group_name : error})
                 if not ignore_errors:

--- a/tabs/video_remixer_ui.py
+++ b/tabs/video_remixer_ui.py
@@ -973,7 +973,7 @@ class VideoRemixer(TabBase):
         # user may be redoing project set up
         # settings changes could affect already-processed content
         self.log("resetting project on rendering for project settings")
-        # TODO self.state.reset_at_project_settings()
+        self.state.reset_at_project_settings()
 
         # split video into raw PNG frames, avoid doing again if redoing setup
         self.log("splitting source video into PNG frames")
@@ -999,7 +999,7 @@ class VideoRemixer(TabBase):
 
         # split frames into scenes, must do again if redoing setup since scenes could differ
         self.log(f"about to split scenes by {self.state.split_type}")
-        error = self.state.split_scenes(self.log, prevent_overwrite=True) # TODO
+        error = self.state.split_scenes(self.log, prevent_overwrite=False)
         if error:
             return gr.update(selected=self.TAB_SET_UP_PROJECT), \
                    gr.update(value=self.format_markdown(f"There was an error splitting the source video: {error}", "error")), \

--- a/tabs/video_remixer_ui.py
+++ b/tabs/video_remixer_ui.py
@@ -158,9 +158,9 @@ class VideoRemixer(TabBase):
                     with gr.Box():
                         project_info2 = gr.Markdown("Project Details")
                     with gr.Row():
-                        thumbnail_type = gr.Radio(choices=["GIF", "JPG"], value="JPG",
+                        thumbnail_type = gr.Radio(choices=["GIF", "JPG"], value="GIF",
                                                   label="Thumbnail Type",
-                                    info="Choose 'GIF' for whole-scene animations (slow to render)")
+                                    info="Choose 'GIF' for whole-scene animations")
                         min_frames_per_scene = gr.Number(label="Minimum Frames Per Scene",
                                     precision=0, value=def_min_frames,
                         info="Consolidates very small scenes info the next (0 to disable)")
@@ -593,6 +593,8 @@ class VideoRemixer(TabBase):
                                     scene_image, scene_state, scene_info])
 
         back_button2.click(self.back_button2, outputs=tabs_video_remixer)
+
+        thumbnail_type.change(self.thumb_change, inputs=thumbnail_type, show_progress=False)
 
         scene_state.change(self.scene_state_button, show_progress=False,
                             inputs=[scene_index, scene_label, scene_state],
@@ -1052,6 +1054,12 @@ class VideoRemixer(TabBase):
 
     def back_button2(self):
         return gr.update(selected=self.TAB_REMIX_SETTINGS)
+
+    def thumb_change(self, thumbnail_type):
+        self.state.thumbnail_type = thumbnail_type
+        if self.state.project_path:
+            self.log(f"Saving project after hot-setting thumbnail type to {thumbnail_type}")
+            self.state.save()
 
     ### SCENE CHOOSER EVENT HANDLERS
 

--- a/tabs/video_remixer_ui.py
+++ b/tabs/video_remixer_ui.py
@@ -973,12 +973,13 @@ class VideoRemixer(TabBase):
         # user may be redoing project set up
         # settings changes could affect already-processed content
         self.log("resetting project on rendering for project settings")
-        self.state.reset_at_project_settings()
+        # TODO self.state.reset_at_project_settings()
 
-        # split video into raw PNG frames
+        # split video into raw PNG frames, avoid doing again if redoing setup
         self.log("splitting source video into PNG frames")
         global_options = self.config.ffmpeg_settings["global_options"]
-        ffcmd = self.state.render_source_frames(global_options=global_options)
+        ffcmd = self.state.render_source_frames(global_options=global_options,
+                                                prevent_overwrite=True)
         if not ffcmd:
             self.log("rendering source frames skipped")
         else:
@@ -996,8 +997,9 @@ class VideoRemixer(TabBase):
         self.log("saving project after establishing scene paths")
         self.state.save()
 
+        # split frames into scenes, must do again if redoing setup since scenes could differ
         self.log(f"about to split scenes by {self.state.split_type}")
-        error = self.state.split_scenes(self.log)
+        error = self.state.split_scenes(self.log, prevent_overwrite=True) # TODO
         if error:
             return gr.update(selected=self.TAB_SET_UP_PROJECT), \
                    gr.update(value=self.format_markdown(f"There was an error splitting the source video: {error}", "error")), \

--- a/video_remixer.py
+++ b/video_remixer.py
@@ -538,62 +538,6 @@ class VideoRemixerState():
                 self.create_thumbnail(scene_name, log_fn, global_options, remixer_settings)
                 Mtqdm().update_bar(bar)
 
-        # if self.thumbnail_type == "JPG":
-        #     thumb_scale = remixer_settings["thumb_scale"]
-        #     max_thumb_size = remixer_settings["max_thumb_size"]
-        #     video_w = self.video_details['display_width']
-        #     video_h = self.video_details['display_height']
-        #     max_frame_dimension = video_w if video_w > video_h else video_h
-        #     thumb_size = max_frame_dimension * thumb_scale
-        #     if thumb_size > max_thumb_size:
-        #         thumb_scale = max_thumb_size / max_frame_dimension
-
-        #     SliceVideo(self.source_video,
-        #                 self.project_fps,
-        #                 self.scenes_path,
-        #                 self.thumbnail_path,
-        #                 thumb_scale,
-        #                 "jpg",
-        #                 0,
-        #                 1,
-        #                 0,
-        #                 False,
-        #                 0.0,
-        #                 0.0,
-        #                 log_fn,
-        #                 global_options=global_options).slice()
-
-        # elif self.thumbnail_type == "GIF":
-        #     gif_fps = remixer_settings["default_gif_fps"]
-        #     gif_factor = remixer_settings["gif_factor"]
-        #     gif_end_delay = remixer_settings["gif_end_delay"]
-        #     thumb_scale = remixer_settings["thumb_scale"]
-        #     max_thumb_size = remixer_settings["max_thumb_size"]
-        #     video_w = self.video_details['display_width']
-        #     video_h = self.video_details['display_height']
-
-        #     max_frame_dimension = video_w if video_w > video_h else video_h
-        #     thumb_size = max_frame_dimension * thumb_scale
-        #     if thumb_size > max_thumb_size:
-        #         thumb_scale = max_thumb_size / max_frame_dimension
-        #     self.thumbnail_path = os.path.join(self.project_path, "THUMBNAILS")
-        #     SliceVideo(self.source_video,
-        #                 self.project_fps,
-        #                 self.scenes_path,
-        #                 self.thumbnail_path,
-        #                 thumb_scale,
-        #                 "gif",
-        #                 0,
-        #                 gif_factor,
-        #                 0,
-        #                 False,
-        #                 gif_fps,
-        #                 gif_end_delay,
-        #                 log_fn,
-        #                 global_options=global_options).slice(ignore_errors=True)
-        # else:
-        #     raise ValueError(f"thumbnail type '{self.thumbnail_type}' is not implemented")
-
     def keep_all_scenes(self):
         self.scene_states = {scene_name : "Keep" for scene_name in self.scene_names}
 

--- a/webui_utils/video_utils.py
+++ b/webui_utils/video_utils.py
@@ -588,15 +588,20 @@ def slice_video(input_path : str,
                 gif_high_quality : bool=False,
                 gif_fps : float=0.0,
                 gif_end_delay : float=0.0,
-                global_options : str=""):
+                global_options : str="",
+                output_filename : str=""):
     # 153=5.1
     # 203+1=6.8
     # ffmpeg -y -i WINDCHIME.mp4 -ss 0:00:05.100000 -to 0:00:06.800000 -copyts 153-203-WINDCHIME.mp4
     # ffmpeg -y -i WINDCHIME.mp4 -ss 0:00:05.100000 -to 0:00:06.800000 -copyts 153-203-WINDCHIME.wav
-    _, filename, ext = split_filepath(input_path)
-    output_filename =\
-f"{filename}[{str(first_frame).zfill(num_width)}-{str(last_frame).zfill(num_width)}].{type}"
-    output_filepath = os.path.join(output_path, output_filename)
+    if output_filename:
+        filename = f"{output_filename}.{type}"
+    else:
+        _, default_filename, _ = split_filepath(input_path)
+        filename =\
+f"{default_filename}[{str(first_frame).zfill(num_width)}-{str(last_frame).zfill(num_width)}].{type}"
+    output_filepath = os.path.join(output_path, filename)
+
     start_second = first_frame / fps
     end_second = (last_frame + 1) / fps
     start_time = seconds_to_hms(start_second)

--- a/webui_utils/video_utils.py
+++ b/webui_utils/video_utils.py
@@ -673,6 +673,88 @@ f"{default_filename}[{str(first_frame).zfill(num_width)}-{str(last_frame).zfill(
     ffcmd.run()
     return cmd
 
+def slice_png_frames(input_path : str,
+                fps : float,
+                output_path : str,
+                num_width : int,
+                first_frame : int,
+                last_frame : int,
+                type : str="mp4",
+                mp4_quality : int=28,
+                gif_speed : int=1,
+                scale_factor : float=0.5,
+                gif_high_quality : bool=False,
+                gif_fps : float=0.0,
+                gif_end_delay : float=0.0,
+                global_options : str="",
+                output_filename : str=""):
+
+    if output_filename:
+        filename = f"{output_filename}.{type}"
+    else:
+        _, default_filename, _ = split_filepath(input_path)
+        filename =\
+f"{default_filename}[{str(first_frame).zfill(num_width)}-{str(last_frame).zfill(num_width)}].{type}"
+    output_filepath = os.path.join(output_path, filename)
+
+    if type == "gif":
+        gif_fps = fps if gif_fps == 0.0 else gif_fps
+
+        # expressed in 1/100th seconds
+        final_delay = f"-final_delay {int(gif_end_delay * 100)}" if gif_end_delay else ""
+
+        if gif_high_quality: # extremely slow
+            ffcmd = FFmpeg(inputs= {input_path : None},
+                                    outputs={output_filepath :
+                    f"-vf 'setpts=PTS/{gif_speed},fps={gif_fps},scale=iw*{scale_factor}:-2,split[s0][s1];[s0]palettegen[p];[s1][p]paletteuse' -loop 0 {final_delay}"},
+                global_options="-y " + global_options)
+        else:
+            ffcmd = FFmpeg(inputs= {input_path : None},
+                                    outputs={output_filepath :
+                    f"-vf 'setpts=PTS/{gif_speed},fps={gif_fps},scale=iw*{scale_factor}:-2' -loop 0 {final_delay}"},
+                global_options="-y " + global_options)
+
+        try:
+            cmd = ffcmd.cmd
+            # errors are common, don't mess up the console output
+            result = ffcmd.run(stderr=subprocess.PIPE)
+            stderr = result[1].decode("UTF-8")
+            return cmd, stderr
+
+        except FFRuntimeError:
+            # TODO could be smarter to locate the middle PNG frame file
+
+            # try again as a static gif at the mid frame
+            mid_frame = int((last_frame + first_frame) / 2)
+            start_second = mid_frame / (fps * 1.0)
+            start_time = seconds_to_hms(start_second)
+
+            if gif_high_quality:
+                ffcmd = FFmpeg(inputs= {input_path : None},
+                                        outputs={output_filepath :
+                        f"-ss {start_time} -vf 'scale=iw*{scale_factor}:-2,split[s0][s1];[s0]palettegen[p];[s1][p]paletteuse' -vframes 1"},
+                    global_options="-y " + global_options)
+            else:
+                ffcmd = FFmpeg(inputs= {input_path : None},
+                                        outputs={output_filepath :
+                        f"-ss {start_time} -vf 'scale=iw*{scale_factor}:-2' -vframes 1"},
+                    global_options="-y " + global_options)
+
+    elif type == "jpg":
+        # TODO could be smarter to locate the middle PNG frame file
+
+        mid_frame = int((last_frame + first_frame) / 2)
+        start_second = mid_frame / (fps * 1.0)
+        start_time = seconds_to_hms(start_second)
+        ffcmd = FFmpeg(inputs= {input_path : f"-ss {start_time}"},
+                                outputs={output_filepath :
+                f"-vf scale=iw*{scale_factor}:-2 -qscale:v 2 -vframes 1"},
+            global_options="-y " + global_options)
+
+    cmd = ffcmd.cmd
+    ffcmd.run()
+    return cmd, None
+
 # input: "40:30"
 # output: 1.2121212121...
 def decode_aspect(aspect):


### PR DESCRIPTION
Switching from slicing thumbnails from the source video to using the already-extracted source PNG frames results in a huge speed-up. Example: A two-hour TV recording with 820 detected scenes was taking 2.5 hours to render all the animated GIF thumbnails. After this change, the time went down to 2.5 minutes.

Also, the thumbnails look better when made from the PNG source frames!

Note: **GIF** is now the default thumbnail type for new projects, and wording has been altered that formerly discouraged their use due to being slow to render.

Bonus:
- The thumbnail type can be changed for the project on the Set Up Project tab without clicking _Set Up Project_ and recreating all the source content.
- Example use: JPG thumbnails were created but animated GIF ones are desired when the _Split Scene_ feature is used.
- Formerly this required hand-editing the `project.yaml` file and reloading the project.