### PR TITLE
Video Remixer: speed up scene split tool with cache

### DIFF
--- a/guide/video_remixer_save.md
+++ b/guide/video_remixer_save.md
@@ -1,4 +1,4 @@
-**Video Remixer Save Remix** - Marge audio with processed content and create remixed video
+**Video Remixer Save Remix** - Merge audio with processed content and create remixed video
 
 The _Processed Content_ box shows a summary of the completed processing.
 

--- a/tabs/video_remixer_ui.py
+++ b/tabs/video_remixer_ui.py
@@ -625,9 +625,6 @@ class VideoRemixer(TabBase):
 
         back_button1.click(self.back_button1, outputs=tabs_video_remixer)
 
-        # deinterlace.change(self.deinterlace_change, inputs=deinterlace, outputs=project_fps,
-        #                    show_progress=False)
-
         next_button2.click(self.next_button2, inputs=[thumbnail_type, min_frames_per_scene],
                            outputs=[tabs_video_remixer, message_box2, scene_index, scene_label,
                                     scene_image, scene_state, scene_info])
@@ -756,6 +753,9 @@ class VideoRemixer(TabBase):
                                 outputs=preview_image702, show_progress=False)
 
         scene_id_702.change(self.preview_button702, inputs=[scene_id_702, split_percent_702],
+                                outputs=preview_image702, show_progress=False)
+
+        split_percent_702.change(self.preview_button702, inputs=[scene_id_702, split_percent_702],
                                 outputs=preview_image702, show_progress=False)
 
         split_percent_702.change(self.preview_button702, inputs=[scene_id_702, split_percent_702],
@@ -1605,6 +1605,7 @@ class VideoRemixer(TabBase):
 
     def compute_scene_split(self, scene_index : int, split_percent : float):
         scene_name = self.state.scene_names[scene_index]
+        split_percent = 0.0 if isinstance(split_percent, type(None)) else split_percent
         split_point = split_percent / 100.0
         first_frame, last_frame, num_width = details_from_group_name(scene_name)
         num_frames = (last_frame - first_frame) + 1

--- a/tabs/video_remixer_ui.py
+++ b/tabs/video_remixer_ui.py
@@ -29,8 +29,6 @@ class VideoRemixer(TabBase):
     def new_project(self):
         self.state = VideoRemixerState()
         self.state.set_project_ui_defaults(self.config.remixer_settings["def_project_fps"])
-        # self.split_scene_cache = []
-        # self.split_scene_cached_index = -1
         self.invalidate_split_scene_cache()
 
     TAB_REMIX_HOME = 0
@@ -1621,7 +1619,6 @@ class VideoRemixer(TabBase):
 
     def split_button702(self, scene_index, split_percent):
         global_options = self.config.ffmpeg_settings["global_options"]
-        # split_point = split_percent / 100.0
 
         if not isinstance(scene_index, (int, float)):
             return gr.update(selected=self.TAB_REMIX_EXTRA), \
@@ -1753,25 +1750,16 @@ class VideoRemixer(TabBase):
 
         scene_name, _, num_frames, _, _, split_frame = self.compute_scene_split(scene_index, split_percent)
         original_scene_path = os.path.join(self.state.scenes_path, scene_name)
-        # self.state.uncompile_scenes()
 
         frame_files = self.valid_split_scene_cache(scene_index)
-
-        # if self.split_scene_cache and self.split_scene_cached_index == scene_index:
-        #     frame_files = self.split_scene_cache
-        # else:
-
         if not frame_files:
             # optimize to uncompile only the first time it's needed
             # TODO this will need to be handled differently if changing code
-            #      to enter scene split with the preview pre-filled
+            #      to enter into scene split with the preview pre-filled
             self.state.uncompile_scenes()
 
             frame_files = sorted(get_files(original_scene_path))
             self.fill_split_scene_cache(scene_index, frame_files)
-
-            # self.split_scene_cache = frame_files
-            # self.split_scene_cached_index = scene_index
 
         num_frame_files = len(frame_files)
         if num_frame_files != num_frames:


### PR DESCRIPTION
The _Split Scene_ tool in Remix Extra was slow when splitting a huge scene. This was due to retrieving the whole set of PNG frame files on disk for the scene on every preview image refresh.

- The frames files are now cached on the first need
- The cache is invalidated if the scene index changes, or when the split is actually done
- The necessary _uncompiling_ of scenes to view the PNG frames is now only done when the cache needs populating
