### PR TITLE
Video Remixer: Create mp4 audio source for non-mp4 source videos

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -118,6 +118,7 @@ remixer_settings:
   minimum_crf: 17
   scale_type_up: "lanczos"
   scale_type_down: "area"
+source_audio_crf: 28
   thumb_scale: 0.5
   use_tiling: False
 restoration_settings:

--- a/guide/video_remixer_extra.md
+++ b/guide/video_remixer_extra.md
@@ -7,8 +7,7 @@
 - **Used For:** Breaking up a scene without redoing project setup
 - _Enter the scene ID for the scene to split and choose a percentage for the split point_
 - _Splits the scene into two new scenes, and creates replacement thumbnails_
-- _**Tips:**_
-    - Click _Refresh Preview_ to see the chosen split frame
+- _**Tip:**_
     - Use the _Split Scene_ button in the _Danger Zone_ from the Scene Chooser
 
 #### Drop Processed Scene - Drop a scene after processing has been already been done

--- a/webui_utils/video_utils.py
+++ b/webui_utils/video_utils.py
@@ -819,3 +819,18 @@ def combine_videos(input_paths : list,
         return cmd
     except FFRuntimeError as error:
         raise ValueError(f"combine_video() received an error using FFmpeg: {str(error)}")
+
+def SourceToMP4(input_path : str, # pylint: disable=invalid-name
+            output_filepath : str,
+            crf : int=QUALITY_DEFAULT,
+            global_options : str=""):
+    """Encapsulate logic for the Source to MP4 feature"""
+    path, filename, ext = split_filepath(output_filepath)
+    output_filepath = os.path.join(path, filename + ".mp4")
+    ffcmd = FFmpeg(
+        inputs= {input_path : None},
+        outputs={output_filepath : f"-c:a aac -c:v libx264 -crf {crf}"},
+        global_options="-y " + global_options)
+    cmd = ffcmd.cmd
+    ffcmd.run()
+    return cmd


### PR DESCRIPTION
### Note: New `config.yaml` setting under `remixer_settings`

    source_audio_crf: 28

For non-MP4 sources, transcode a .MP4 version of the source to use for audio extraction. This improves syncing of audio clips with remixed video clips. In the case of some sources, it enables the ability to extract audio.

I had been manually editing the `project.yaml` file after setting up the project, setting the source video to point at a MP4 version of any non-MP4 videos to ensure frame-exact audio clip extraction. This PR builds this capability in directly.

- In the case of MP4 sources, the source audio is set to the original source video and no separate MP4 file is created
- The transcoding process might introduce some generation loss when converting audio to AAC encoding
- The `project.yaml` file variable "source_audio" can be edited to point to the original source video instead if needed

Reasoning
- I've had audio sync problems with some MPG sources where the sliced WAV audio clips don't sync up exactly to the remixed video clips. I first noticed it in this posted video https://youtu.be/8Ce98WZM4ws
- I've also had issues with MPG sources that don't seem to allow audio to be sliced at specific times
