### PR TITLE
Video Remixer: tighten audio gaps on concatenating remixed video clips

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -107,7 +107,7 @@ remixer_settings:
   marked_box_color: black@0.5
   marked_draw_box: True
   marked_ffmpeg_video: -vf "drawtext=<SCENE_INFO>" -c:v libx264 -crf 28
-  marked_ffmpeg_audio: -c:a aac
+  marked_ffmpeg_audio: -c:a aac -shortest
   marked_font_color: white@0.9
   marked_font_size: 30
   marked_font_file: fonts/trim.ttf

--- a/guide/video_remixer_processing.md
+++ b/guide/video_remixer_processing.md
@@ -7,7 +7,7 @@
     - When resynthesis is used, the WAV audio clips are shortened to match
 1. Check _Inflate New Frames_ to insert AI-interpolated _likely_ frames between all real frames
     - This causes the effective frame rate of the remix video to double
-    - When inflation used, this is taken into aacount for creating the final video clips
+    - When inflation used, this is taken into account for creating the final video clips
 1. Check _Upscale Frames_ to use AI to clean and enlarge frames
     - Choose whether to upscale by _1X_, _2X_ or _4X_
     - Upscaling at 1X will cleanse the frames without enlarging

--- a/webui_utils/video_utils.py
+++ b/webui_utils/video_utils.py
@@ -777,7 +777,7 @@ def combine_video_audio(video_path : str,
                         audio_path : str,
                         output_filepath : str,
                         global_options : str = "",
-                        output_options : str = "-c:a aac"):
+                        output_options : str = "-c:a aac -shortest"):
 # ffmpeg -y -i "MALE Me-TV-03192023-0335PM[000001-001245].wav" -i "MALE Me-TV-03192023-0335PM[000001-001245].mp4" -c:v copy -c:a aac output1.mp4
     ffcmd = FFmpeg(
         inputs= {video_path : None,


### PR DESCRIPTION
Use the FFmpeg _-shortest_ option to ensure audio doesn't run out before the end of a clip, which could increased the unpleasant silence between clips