### PR TITLE
Simple session handling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -152,3 +152,4 @@ models!/
 ui.bat
 config-local.yaml
 my_video_blender_projects.csv
+session.yaml

--- a/tabs/video_remixer_ui.py
+++ b/tabs/video_remixer_ui.py
@@ -16,6 +16,7 @@ from interpolate_engine import InterpolateEngine
 from tabs.tab_base import TabBase
 from video_remixer import VideoRemixerState
 from webui_utils.mtqdm import Mtqdm
+from webui_utils.session import Session
 
 class VideoRemixer(TabBase):
     """Encapsulates UI elements and events for the Video Remixer Feature"""
@@ -93,7 +94,8 @@ class VideoRemixer(TabBase):
                             gr.Markdown("**Open an existing Video Remixer project**")
                             with gr.Row():
                                 project_load_path = gr.Textbox(label="Project Path",
-                placeholder="Path on this server to the Video Remixer project directory or file")
+                placeholder="Path on this server to the Video Remixer project directory or file",
+                                    value=Session().get("last-video-remixer-project"))
                             with gr.Row():
                                 message_box01 = gr.Markdown(
                                     value=format_markdown(self.TAB01_DEFAULT_MESSAGE))
@@ -889,6 +891,8 @@ class VideoRemixer(TabBase):
             message_text = format_markdown(self.TAB01_DEFAULT_MESSAGE)
         return_to_tab = self.state.get_progress_tab()
         scene_details = self.scene_chooser_details(self.state.tryattr("current_scene"))
+
+        Session().set("last-video-remixer-project", project_path)
 
         return gr.update(selected=return_to_tab), \
             gr.update(value=message_text), \

--- a/tabs/video_remixer_ui.py
+++ b/tabs/video_remixer_ui.py
@@ -967,6 +967,8 @@ class VideoRemixer(TabBase):
             self.log(f"saving new project at {self.state.project_filepath()}")
             self.state.save_progress("setup")
 
+            Session().set("last-video-remixer-project", project_path)
+
             return gr.update(selected=self.TAB_SET_UP_PROJECT), \
                 gr.update(value=format_markdown(self.TAB1_DEFAULT_MESSAGE)), \
                 self.state.project_info2, \

--- a/tabs/video_remixer_ui.py
+++ b/tabs/video_remixer_ui.py
@@ -95,7 +95,7 @@ class VideoRemixer(TabBase):
                             with gr.Row():
                                 project_load_path = gr.Textbox(label="Project Path",
                 placeholder="Path on this server to the Video Remixer project directory or file",
-                                    value=Session().get("last-video-remixer-project"))
+                                    value=lambda : Session().get("last-video-remixer-project"))
                             with gr.Row():
                                 message_box01 = gr.Markdown(
                                     value=format_markdown(self.TAB01_DEFAULT_MESSAGE))

--- a/webui_utils/session.py
+++ b/webui_utils/session.py
@@ -4,7 +4,7 @@ import yaml
 from yaml import Loader, YAMLError
 
 class Session():
-    def __init__(self, path : str):
+    def __init__(self, path : str="session.yaml"):
         self.path = path
         self.data = {}
         self.load()

--- a/webui_utils/session.py
+++ b/webui_utils/session.py
@@ -1,0 +1,28 @@
+"""Application Session Data Handler"""
+import os
+import yaml
+from yaml import Loader, YAMLError
+
+class Session():
+    def __init__(self, path : str):
+        self.path = path
+        self.data = {}
+        self.load()
+
+    def load(self):
+        if os.path.exists(self.path):
+            with open(self.path, "r", encoding="UTF-8") as file:
+                self.data : dict = yaml.load(file, Loader=Loader)
+        else:
+            self.data = {}
+
+    def save(self):
+        with open(self.path, "w", encoding="UTF-8") as file:
+            yaml.dump(self.data, file, width=1024)
+
+    def set(self, key : str, value : str):
+        self.data[key] = value
+        self.save()
+
+    def get(self, key : str, default_value : str | None = None):
+        return self.data.get(key, default_value)


### PR DESCRIPTION
- adds a simple class to save and reload data relevant to usage sessions
- for Video Remixer, it saves the last created or opened project
- when starting the app or refreshing the browser, the last project is preloaded for easy re-entry 