### PR TITLE
Video Remixer: Add Recover Project feature

### DIFF
--- a/guide/video_remixer_extra.md
+++ b/guide/video_remixer_extra.md
@@ -55,3 +55,9 @@
 - **When Useful:** After the project is complete and no longer needed - frees all disk space used by project-created content, except for source and remix videos
 - _Check the box for the content to delete and click Delete Selected Content_
 - _All project content except videos are permanently deleted_
+
+#### Recover Project - Recreate a purged or corrupt project using the source video and project file
+
+- **When Useful:** After a project's content has been purged, or if it has become corrupt - restores the project to an editable state
+- _Click Recover Project_
+- _The project's source frames, scenes and thumbnails are restored_

--- a/tabs/video_remixer_ui.py
+++ b/tabs/video_remixer_ui.py
@@ -1041,7 +1041,8 @@ class VideoRemixer(TabBase):
 
             try:
                 self.log(f"creating source audio from {self.state.source_video}")
-                self.state.create_source_audio(source_audio_crf, global_options, prevent_overwrite=True)
+                self.state.create_source_audio(
+                    source_audio_crf, global_options, prevent_overwrite=True)
             except ValueError as error:
                 # ignore, don't create the file a second time if the user is restarting here
                 self.log(f"ignoring: {error}")
@@ -1282,11 +1283,8 @@ class VideoRemixer(TabBase):
                    gr.update(value=format_markdown(f"The project has not yet been set up from the Set Up Project tab.", "error")), \
                    *self.empty_args(5)
 
-        self.log("moving previously dropped scenes back to scenes directory")
-        self.state.uncompile_scenes()
-
         self.log("moving dropped scenes to dropped scenes directory")
-        self.state.compile_scenes()
+        self.state.recompile_scenes()
 
         # scene choice changes are what invalidate previously made audio clips,
         # so clear them now along with dependent remix content
@@ -1325,6 +1323,9 @@ class VideoRemixer(TabBase):
         self.state.setup_processing_paths()
         self.log("saving project after storing processing choices")
         self.state.save()
+
+        # user may have changed scene choices and skipped compiling scenes
+        self.state.recompile_scenes()
 
         jot = Jot()
         kept_scenes = self.state.kept_scenes()
@@ -1920,8 +1921,7 @@ class VideoRemixer(TabBase):
                     Mtqdm().update_bar(bar)
 
             # ensure scenes path contains all / only kept scenes
-            self.state.uncompile_scenes()
-            self.state.compile_scenes()
+            self.state.recompile_scenes()
 
             # prepare to rebuild scene_states dict, and scene_names, thumbnails lists
             # in the new project

--- a/tabs/video_remixer_ui.py
+++ b/tabs/video_remixer_ui.py
@@ -596,7 +596,7 @@ class VideoRemixer(TabBase):
 
                                 with gr.Tab(SimpleIcons.MENDING_HEART + " Recover Project"):
                                     gr.Markdown(
-                                    "**_Recreate source content for a deleted project_**")
+                                    "**_Restore a project from the original source video and project file_**")
                                     with gr.Row():
                                         message_box714 = gr.Markdown(format_markdown("Click Recover Project to: Restore the currently loaded project"))
                                     gr.Markdown(format_markdown("Progress can be tracked in the console", color="none", italic=True, bold=False))

--- a/tabs/video_remixer_ui.py
+++ b/tabs/video_remixer_ui.py
@@ -594,6 +594,17 @@ class VideoRemixer(TabBase):
                                             value="Delete Processed Content " +\
                                                 SimpleIcons.SLOW_SYMBOL, variant="stop")
 
+                                with gr.Tab(SimpleIcons.MENDING_HEART + " Recover Project"):
+                                    gr.Markdown(
+                                    "**_Recreate source content for a deleted project_**")
+                                    with gr.Row():
+                                        message_box714 = gr.Markdown(format_markdown("Click Recover Project to: Restore the currently loaded project"))
+                                    gr.Markdown(format_markdown("Progress can be tracked in the console", color="none", italic=True, bold=False))
+                                    with gr.Row():
+                                        restore_button714 = gr.Button(
+                                            value="Restore Project " +\
+                                                SimpleIcons.SLOW_SYMBOL, variant="stop")
+
                     with gr.Accordion(SimpleIcons.TIPS_SYMBOL + " Guide", open=False):
                         WebuiTips.video_remixer_extra.render()
 
@@ -814,6 +825,8 @@ class VideoRemixer(TabBase):
                                          delete_audio_712, delete_video_712, delete_clips_712])
 
         delete_button713.click(self.delete_button713, inputs=delete_all_713, outputs=message_box713)
+
+        restore_button714.click(self.restore_button714, outputs=message_box714)
 
     ### UTILITY FUNCTIONS
 
@@ -2071,3 +2084,9 @@ class VideoRemixer(TabBase):
         else:
             message = f"Removed: None"
         return gr.update(value=format_markdown(message))
+
+    def restore_button714(self):
+        global_options = self.config.ffmpeg_settings["global_options"]
+        self.state.recover_project(global_options=global_options,
+                                   remixer_settings=self.config.remixer_settings,
+                                   log_fn=self.log)

--- a/tabs/video_remixer_ui.py
+++ b/tabs/video_remixer_ui.py
@@ -602,7 +602,7 @@ class VideoRemixer(TabBase):
                                     gr.Markdown(format_markdown("Progress can be tracked in the console", color="none", italic=True, bold=False))
                                     with gr.Row():
                                         restore_button714 = gr.Button(
-                                            value="Restore Project " +\
+                                            value="Recover Project " +\
                                                 SimpleIcons.SLOW_SYMBOL, variant="stop")
 
                     with gr.Accordion(SimpleIcons.TIPS_SYMBOL + " Guide", open=False):
@@ -826,7 +826,8 @@ class VideoRemixer(TabBase):
 
         delete_button713.click(self.delete_button713, inputs=delete_all_713, outputs=message_box713)
 
-        restore_button714.click(self.restore_button714, outputs=message_box714)
+        restore_button714.click(self.restore_button714, outputs=[tabs_video_remixer, message_box714,
+                                    scene_index, scene_label, scene_image, scene_state, scene_info])
 
     ### UTILITY FUNCTIONS
 
@@ -2090,3 +2091,7 @@ class VideoRemixer(TabBase):
         self.state.recover_project(global_options=global_options,
                                    remixer_settings=self.config.remixer_settings,
                                    log_fn=self.log)
+        message = f"Project recovered"
+        return gr.update(selected=self.TAB_CHOOSE_SCENES), \
+            gr.update(value=format_markdown(message)), \
+            *self.scene_chooser_details(self.state.current_scene)

--- a/video_remixer.py
+++ b/video_remixer.py
@@ -1421,7 +1421,7 @@ class VideoRemixerState():
         return messages.report()
 
     def recover_project(self, global_options, remixer_settings, log_fn):
-        log_fn.log("beginning project recovery")
+        log_fn("beginning project recovery")
 
         # purge project paths ahead of recreating
         purged_path = self.purge_paths([
@@ -1437,23 +1437,23 @@ class VideoRemixerState():
             self.inflation_path,
             self.upscale_path
         ])
-        log_fn.log(f"all generated content directories purged to {purged_path}")
+        log_fn(f"all generated content directories purged to {purged_path}")
 
         self.render_source_frames(global_options=global_options, prevent_overwrite=False)
-        log_fn.log(f"source frames rendered to {self.frames_path}")
+        log_fn(f"source frames rendered to {self.frames_path}")
 
         create_directory(self.scenes_path)
-        log_fn.log(f"created scenes directory {self.scenes_path}")
+        log_fn(f"created scenes directory {self.scenes_path}")
         create_directory(self.dropped_scenes_path)
-        log_fn.log(f"created dropped scenes directory {self.dropped_scenes_path}")
+        log_fn(f"created dropped scenes directory {self.dropped_scenes_path}")
 
-        log_fn.log("beginning recreating of scenes from source frames")
+        log_fn("beginning recreating of scenes from source frames")
         source_frames = sorted(get_files(self.frames_path))
         with Mtqdm().open_bar(total=len(self.scene_names), desc="Recreating Scenes") as bar:
             for scene_name in self.scene_names:
                 scene_path = os.path.join(self.scenes_path, scene_name)
                 create_directory(scene_path)
-                log_fn.log(f"created scene directory {scene_path}")
+                log_fn(f"created scene directory {scene_path}")
 
                 first_index, last_index, _ = details_from_group_name(scene_name)
                 num_frames = (last_index - first_index) + 1
@@ -1465,20 +1465,20 @@ class VideoRemixerState():
                         shutil.copy(source_path, frame_path)
                         Mtqdm().update_bar(inner_bar)
 
-                log_fn.log(f"scene frames copied to {scene_path}")
+                log_fn(f"scene frames copied to {scene_path}")
                 Mtqdm().update_bar(bar)
-        log_fn.log(f"recreated scenes")
+        log_fn(f"recreated scenes")
 
-        log_fn.log(f"about to create thumbnails of type {self.thumbnail_type}")
+        log_fn(f"about to create thumbnails of type {self.thumbnail_type}")
         self.create_thumbnails(log_fn, global_options, remixer_settings)
         self.thumbnails = sorted(get_files(self.thumbnail_path))
 
         self.clips_path = os.path.join(self.project_path, "CLIPS")
-        log_fn.log(f"creating clips directory {self.clips_path}")
+        log_fn(f"creating clips directory {self.clips_path}")
         create_directory(self.clips_path)
 
         # user will expect to return to scene chooser on reopening
-        log_fn.log("saving project after recovery process")
+        log_fn("saving project after recovery process")
         self.save_progress("choose")
 
     @staticmethod

--- a/video_remixer.py
+++ b/video_remixer.py
@@ -1439,7 +1439,7 @@ class VideoRemixerState():
         ])
         log_fn(f"all generated content directories purged to {purged_path}")
 
-        self.render_source_frames(global_options=global_options, prevent_overwrite=False)
+        self.render_source_frames(global_options=global_options, prevent_overwrite=True)
         log_fn(f"source frames rendered to {self.frames_path}")
 
         create_directory(self.scenes_path)

--- a/video_remixer.py
+++ b/video_remixer.py
@@ -1425,7 +1425,6 @@ class VideoRemixerState():
 
         # purge project paths ahead of recreating
         purged_path = self.purge_paths([
-            self.frames_path,
             self.scenes_path,
             self.dropped_scenes_path,
             self.thumbnail_path,
@@ -1437,10 +1436,18 @@ class VideoRemixerState():
             self.inflation_path,
             self.upscale_path
         ])
-        log_fn(f"all generated content directories purged to {purged_path}")
+        log_fn(f"generated content directories purged to {purged_path}")
 
         self.render_source_frames(global_options=global_options, prevent_overwrite=True)
         log_fn(f"source frames rendered to {self.frames_path}")
+
+        source_audio_crf = remixer_settings["source_audio_crf"]
+        try:
+            self.create_source_audio(source_audio_crf, global_options, prevent_overwrite=True)
+            log_fn(f"created source audio from {self.state.source_video}")
+        except ValueError as error:
+            # ignore, don't create the file if present or same as video
+            log_fn(f"ignoring: {error}")
 
         create_directory(self.scenes_path)
         log_fn(f"created scenes directory {self.scenes_path}")

--- a/webui_utils/simple_icons.py
+++ b/webui_utils/simple_icons.py
@@ -171,6 +171,7 @@ class SimpleIcons:
         LABCOAT,
         MAGIC_WAND,
         MAGNIFIER,
+        MENDING_HEART,
         MICROSCOPE,
         MOVIE,
         NOTEBOOK,

--- a/webui_utils/simple_icons.py
+++ b/webui_utils/simple_icons.py
@@ -103,6 +103,7 @@ class SimpleIcons:
     LABCOAT = "🥼"
     MAGIC_WAND = "🪄"
     MEAT = "🥩"
+    MENDING_HEART = "❤️‍🩹"
     MICROSCOPE = "🔬"
     PACKAGE = "📦"
     ROBOT = "🤖"

--- a/webui_utils/test_simple_icons.py
+++ b/webui_utils/test_simple_icons.py
@@ -5,7 +5,7 @@ from .simple_icons import *
 
 GOOD_EXAMPLES = [
     (SimpleIcons.SYMBOLS, 8, 10),
-    (SimpleIcons.APP_ICONS, 56, 80)]
+    (SimpleIcons.APP_ICONS, 57, 84)]
 
 def test_SimpleIcons():
     for example, expected_items, expected_len in GOOD_EXAMPLES:


### PR DESCRIPTION
Adds a feature to recreate an editable project given just the source video and the `project.yaml` file.
- Meant for restoring a project after the _Remove All Processed Content_ feature has been used
- Also handy if a project becomes corrupted (as happened to me just now when an SSD drive decided to forget a lot of files)
- Regenerates the source frames, then splits the frames according to the project scenes; thumbnails are recreated
