### PR TITLE
Video Remixer: Add interactive messaging

### DIFF
--- a/tabs/frame_restoration_ui.py
+++ b/tabs/frame_restoration_ui.py
@@ -8,7 +8,7 @@ from webui_utils.image_utils import create_gif
 from webui_utils.file_utils import create_zip, create_directory
 from webui_utils.ui_utils import create_report
 from webui_utils.auto_increment import AutoIncrementDirectory
-from webui_utils.simple_utils import restored_frame_fractions, restored_frame_predictions
+from webui_utils.simple_utils import restored_frame_fractions, restored_frame_predictions, format_markdown
 from webui_utils.ui_utils import update_info_fr
 from webui_tips import WebuiTips
 from interpolate_engine import InterpolateEngine
@@ -24,6 +24,8 @@ class FrameRestoration(TabBase):
                     engine : InterpolateEngine,
                     log_fn : Callable):
         TabBase.__init__(self, config, engine, log_fn)
+
+    DEFAULT_MESSAGE = "Click Restore Frames to: Create multiple interpolated replacement frames"
 
     def render_tab(self):
         """Render tab into UI"""
@@ -59,19 +61,25 @@ class FrameRestoration(TabBase):
             predictions_default = restored_frame_predictions(default_frames, default_precision)
             predictions_output_fr = gr.Textbox(value=predictions_default,
                 label="Predicted Matches", max_lines=1, interactive=False)
-            restore_button_fr = gr.Button("Restore Frames", variant="primary")
+            message_box = gr.Markdown(format_markdown(self.DEFAULT_MESSAGE))
+            gr.Markdown("*Progress can be tracked in the console*")
+            restore_button_fr = gr.Button("Restore Frames " + SimpleIcons.SLOW_SYMBOL,
+                                          variant="primary")
             with gr.Accordion(SimpleIcons.TIPS_SYMBOL + " Guide", open=False):
                 WebuiTips.frame_restoration.render()
-        restore_button_fr.click(self.frame_restoration,
-            inputs=[img1_input_fr, img2_input_fr, frames_input_fr,
-                precision_input_fr],
-            outputs=[img_output_fr, file_output_fr])
+
         frames_input_fr.change(update_info_fr,
             inputs=[frames_input_fr, precision_input_fr],
             outputs=[times_output_fr, predictions_output_fr], show_progress=False)
+
         precision_input_fr.change(update_info_fr,
             inputs=[frames_input_fr, precision_input_fr],
             outputs=[times_output_fr, predictions_output_fr], show_progress=False)
+
+        restore_button_fr.click(self.frame_restoration,
+            inputs=[img1_input_fr, img2_input_fr, frames_input_fr,
+                precision_input_fr],
+            outputs=[img_output_fr, file_output_fr, message_box])
 
     def frame_restoration(self,
                         img_before_file : str,
@@ -79,6 +87,7 @@ class FrameRestoration(TabBase):
                         num_frames : float,
                         num_splits : float):
         """Restore Frames button handler"""
+
         if img_before_file and img_after_file:
             interpolater = Interpolate(self.engine.model, self.log)
             target_interpolater = TargetInterpolate(interpolater, self.log)
@@ -101,8 +110,6 @@ class FrameRestoration(TabBase):
                 preview_gif = os.path.join(output_path, output_basename + str(run_index) + ".gif")
                 self.log(f"creating preview file {preview_gif}")
                 duration = self.config.restoration_settings["gif_duration"] / len(output_paths)
-                # gif_paths = [img_before_file, *output_paths, img_after_file]
-                # create_gif(gif_paths, preview_gif, duration=duration)
                 create_gif(output_paths, preview_gif, duration=duration)
                 downloads.append(preview_gif)
 
@@ -118,5 +125,7 @@ class FrameRestoration(TabBase):
                     output_paths)
                 downloads.append(info_file)
 
-            return gr.Image.update(value=preview_gif), gr.File.update(value=downloads,
-                visible=True)
+            message = f"Restored frames saved to {os.path.abspath(output_path)}"
+            return gr.Image.update(value=preview_gif), \
+                gr.File.update(value=downloads, visible=True), \
+                gr.update(value=format_markdown(message))

--- a/tabs/resynthesize_video_ui.py
+++ b/tabs/resynthesize_video_ui.py
@@ -111,7 +111,7 @@ class ResynthesizeVideo(TabBase):
             message = "\r\n".join(errors)
             return gr.update(value=format_markdown(message, "error"))
         else:
-            message = f"Batch processed resynthesized frames saved to {output_path}"
+            message = f"Batch processed resynthesized frames saved to {os.path.abspath(output_path)}"
             return gr.update(value=format_markdown(message))
 
     def resynthesize_video(self, input_path : str, output_path : str | None, interactive : bool=True):
@@ -162,7 +162,7 @@ class ResynthesizeVideo(TabBase):
         ResequenceFiles(output_path, "png", "resynthesized_frame", 1, 1, 1, 0, -1, True,
             self.log).resequence()
 
-        message = f"Resynthesized frames saved to {output_path}"
+        message = f"Resynthesized frames saved to {os.path.abspath(output_path)}"
         if interactive:
             return gr.update(value=format_markdown(message))
         else:

--- a/tabs/upscale_frames_ui.py
+++ b/tabs/upscale_frames_ui.py
@@ -4,8 +4,8 @@ from typing import Callable
 import gradio as gr
 from webui_utils.simple_config import SimpleConfig
 from webui_utils.simple_icons import SimpleIcons
+from webui_utils.simple_utils import format_markdown
 from webui_utils.file_utils import create_directory, get_files, get_directories
-# from webui_utils.auto_increment import AutoIncrementDirectory
 from webui_utils.ui_utils import update_splits_info
 from webui_utils.mtqdm import Mtqdm
 from webui_tips import WebuiTips
@@ -19,6 +19,9 @@ class UpscaleFrames(TabBase):
                     engine : any,
                     log_fn : Callable):
         TabBase.__init__(self, config, engine, log_fn)
+
+    DEFAULT_MESSAGE_SINGLE = "Click Upscale Frames to: Create cleansed and enlarged frames"
+    DEFAULT_MESSAGE_BATCH = "Click Upscale Batch to: Create cleansed and enlarged frames for each batch directory"
 
     def render_tab(self):
         """Render tab into UI"""
@@ -46,6 +49,7 @@ class UpscaleFrames(TabBase):
                                         placeholder="Where to place the upscaled frames",
                                         info="Leave blank save to Input Path")
                     gr.Markdown("*Progress can be tracked in the console*")
+                    message_box_single = gr.Markdown(format_markdown(self.DEFAULT_MESSAGE_SINGLE))
                     upscale_button = gr.Button("Upscale Frames " + SimpleIcons.SLOW_SYMBOL,
                                             variant="primary")
                 with gr.Tab(label="Batch Processing"):
@@ -54,15 +58,19 @@ class UpscaleFrames(TabBase):
                     output_path_batch = gr.Text(max_lines=1, label="Output Path",
                                         placeholder="Where to place the upscaled frame groups")
                     gr.Markdown("*Progress can be tracked in the console*")
+                    message_box_batch = gr.Markdown(format_markdown(self.DEFAULT_MESSAGE_BATCH))
                     upscale_batch = gr.Button("Upscale Batch " + SimpleIcons.SLOW_SYMBOL,
                                             variant="primary")
-
             with gr.Accordion(SimpleIcons.TIPS_SYMBOL + " Guide", open=False):
                 WebuiTips.upscale_frames.render()
+
         upscale_button.click(self.upscale_frames,
-            inputs=[input_path_text, output_path_text, scale_input, use_tiling])
+            inputs=[input_path_text, output_path_text, scale_input, use_tiling],
+            outputs=message_box_single)
+
         upscale_batch.click(self.upscale_batch,
-            inputs=[input_path_batch, output_path_batch, scale_input, use_tiling])
+            inputs=[input_path_batch, output_path_batch, scale_input, use_tiling],
+            outputs=message_box_batch)
 
     def upscale_batch(self,
                        input_path : str,
@@ -88,19 +96,26 @@ class UpscaleFrames(TabBase):
                         self.upscale_frames(group_input_path,
                                             group_output_path,
                                             upscale_factor,
-                                            use_tiling)
+                                            use_tiling,
+                                            interactive=False)
                         Mtqdm().update_bar(bar)
+
+        message = f"Batch processed upscaled frames saved to {os.path.abspath(output_path)}"
+        return gr.update(value=format_markdown(message))
 
     def upscale_frames(self,
                        input_path : str,
                        output_path : str | None,
                        upscale_factor : float,
-                       use_tiling : str):
+                       use_tiling : str,
+                       interactive : bool=True):
         """Upscale Frames button handler"""
+
         if input_path:
             model_name = self.config.realesrgan_settings["model_name"]
             gpu_ids = self.config.realesrgan_settings["gpu_ids"]
             fp32 = self.config.realesrgan_settings["fp32"]
+
             if use_tiling.startswith("Yes"):
                 tiling = self.config.realesrgan_settings["tiling"]
                 tile_pad = self.config.realesrgan_settings["tile_pad"]
@@ -120,20 +135,29 @@ class UpscaleFrames(TabBase):
 
             image_extensions = self.config.upscale_settings["file_types"]
             file_list = get_files(input_path, image_extensions)
+
             self.log(f"beginning series of upscaling of {image_extensions} files at {output_path}")
             output_dict = upscaler.upscale_series(file_list, output_path, upscale_factor,
                                                   output_basename, output_type)
+
             if use_tiling.startswith("Auto"):
                 file_list = [key for key in output_dict.keys() if output_dict[key] == None]
                 if file_list:
                     self.log(
                 f"redoing upscaling with tiling for {len(file_list)} failed files at {output_path}")
+
                     tiling = self.config.realesrgan_settings["tiling"]
                     tile_pad = self.config.realesrgan_settings["tile_pad"]
                     upscaler = UpscaleSeries(model_name, gpu_ids, fp32, tiling, tile_pad, self.log)
                     output_dict = upscaler.upscale_series(file_list, output_path, upscale_factor,
                                                         output_basename, output_type)
+
                     file_list = [key for key in output_dict.keys() if output_dict[key] == None]
                     if file_list:
                         self.log(f"unable to upscale files:\n{file_list}")
 
+        message = f"Upscaled frames saved to {os.path.abspath(output_path)}"
+        if interactive:
+            return gr.update(value=format_markdown(message))
+        else:
+            self.log(message)

--- a/tabs/upscale_frames_ui.py
+++ b/tabs/upscale_frames_ui.py
@@ -87,9 +87,6 @@ class UpscaleFrames(TabBase):
         if not is_safe_path(input_path):
             return gr.update(value=format_markdown(
                 f"The input path {input_path} is not valid", "error"))
-        if not os.path.exists(output_path):
-            return gr.update(value=format_markdown(
-                f"The input path {output_path} was not found", "error"))
         if not is_safe_path(output_path):
             return gr.update(value=format_markdown(
                 f"The input path {output_path} is not valid", "error"))

--- a/tabs/upscale_frames_ui.py
+++ b/tabs/upscale_frames_ui.py
@@ -5,7 +5,7 @@ import gradio as gr
 from webui_utils.simple_config import SimpleConfig
 from webui_utils.simple_icons import SimpleIcons
 from webui_utils.simple_utils import format_markdown
-from webui_utils.file_utils import create_directory, get_files, get_directories
+from webui_utils.file_utils import create_directory, get_files, get_directories, is_safe_path
 from webui_utils.ui_utils import update_splits_info
 from webui_utils.mtqdm import Mtqdm
 from webui_tips import WebuiTips
@@ -78,30 +78,55 @@ class UpscaleFrames(TabBase):
                        upscale_factor : float,
                        use_tiling : str):
         """Upscale Frames button handler"""
-        if input_path and output_path:
-            self.log(f"beginning batch UpscaleFrames processing with input_path={input_path}" +\
-                     f" output_path={output_path}")
-            group_names = get_directories(input_path)
-            self.log(f"found {len(group_names)} groups to process")
+        if not input_path or not output_path:
+            return gr.update(value=format_markdown(
+                "Please enter an input path and output path to begin", "warning"))
+        if not os.path.exists(input_path):
+            return gr.update(value=format_markdown(
+                f"The input path {input_path} was not found", "error"))
+        if not is_safe_path(input_path):
+            return gr.update(value=format_markdown(
+                f"The input path {input_path} is not valid", "error"))
+        if not os.path.exists(output_path):
+            return gr.update(value=format_markdown(
+                f"The input path {output_path} was not found", "error"))
+        if not is_safe_path(output_path):
+            return gr.update(value=format_markdown(
+                f"The input path {output_path} is not valid", "error"))
 
-            if group_names:
-                self.log(f"creating group output path {output_path}")
-                create_directory(output_path)
+        group_names = get_directories(input_path)
+        if not group_names:
+            return gr.update(value=format_markdown(
+                f"No directories were found at the input path {input_path}", "error"))
 
-                with Mtqdm().open_bar(total=len(group_names), desc="Frame Group") as bar:
-                    for group_name in group_names:
-                        group_input_path = os.path.join(input_path, group_name)
-                        group_output_path = os.path.join(output_path, group_name)
+        self.log(f"beginning batch UpscaleFrames processing with input_path={input_path}" +\
+                    f" output_path={output_path}")
+        self.log(f"found {len(group_names)} groups to process")
 
-                        self.upscale_frames(group_input_path,
-                                            group_output_path,
-                                            upscale_factor,
-                                            use_tiling,
-                                            interactive=False)
-                        Mtqdm().update_bar(bar)
+        self.log(f"creating group output path {output_path}")
+        create_directory(output_path)
 
-        message = f"Batch processed upscaled frames saved to {os.path.abspath(output_path)}"
-        return gr.update(value=format_markdown(message))
+        errors = []
+        with Mtqdm().open_bar(total=len(group_names), desc="Frame Group") as bar:
+            for group_name in group_names:
+                group_input_path = os.path.join(input_path, group_name)
+                group_output_path = os.path.join(output_path, group_name)
+
+                try:
+                    self.upscale_frames(group_input_path,
+                                        group_output_path,
+                                        upscale_factor,
+                                        use_tiling,
+                                        interactive=False)
+                except ValueError as error:
+                    errors.append(f"Error handling directory {group_name}: " + str(error))
+                Mtqdm().update_bar(bar)
+        if errors:
+            message = "\r\n".join(errors)
+            return gr.update(value=format_markdown(message, "error"))
+        else:
+            message = f"Batch processed upscaled frames saved to {os.path.abspath(output_path)}"
+            return gr.update(value=format_markdown(message))
 
     def upscale_frames(self,
                        input_path : str,
@@ -110,51 +135,74 @@ class UpscaleFrames(TabBase):
                        use_tiling : str,
                        interactive : bool=True):
         """Upscale Frames button handler"""
+        if not input_path:
+            if interactive:
+                return gr.update(value=format_markdown("Please enter an input path to begin", "warning"))
+            else:
+                raise ValueError(f"The input path is empty")
+        if not os.path.exists(input_path):
+            message = f"The input path {input_path} was not found"
+            if interactive:
+                return gr.update(value=format_markdown(message, "error"))
+            else:
+                raise ValueError(message)
+        if not is_safe_path(input_path):
+            message = f"The input path {input_path} is not valid"
+            if interactive:
+                return gr.update(value=format_markdown(message, "error"))
+            else:
+                raise ValueError(message)
 
-        if input_path:
-            model_name = self.config.realesrgan_settings["model_name"]
-            gpu_ids = self.config.realesrgan_settings["gpu_ids"]
-            fp32 = self.config.realesrgan_settings["fp32"]
+        model_name = self.config.realesrgan_settings["model_name"]
+        gpu_ids = self.config.realesrgan_settings["gpu_ids"]
+        fp32 = self.config.realesrgan_settings["fp32"]
 
-            if use_tiling.startswith("Yes"):
+        if use_tiling.startswith("Yes"):
+            tiling = self.config.realesrgan_settings["tiling"]
+            tile_pad = self.config.realesrgan_settings["tile_pad"]
+        else:
+            tiling = 0
+            tile_pad = 0
+        upscaler = UpscaleSeries(model_name, gpu_ids, fp32, tiling, tile_pad, self.log)
+
+        if output_path:
+            if not is_safe_path(output_path):
+                message = f"The output path {output_path} is not valid"
+                if interactive:
+                    return gr.update(value=format_markdown(message, "error"))
+                else:
+                    raise ValueError(f"The output path {input_path} is not valid")
+            self.log(f"creating output path {output_path}")
+            create_directory(output_path)
+            output_basename = "upscaled_frames"
+            output_type = "png"
+        else:
+            output_path = input_path
+            output_basename = None
+            output_type = None
+
+        image_extensions = self.config.upscale_settings["file_types"]
+        file_list = get_files(input_path, image_extensions)
+
+        self.log(f"beginning series of upscaling of {image_extensions} files at {output_path}")
+        output_dict = upscaler.upscale_series(file_list, output_path, upscale_factor,
+                                                output_basename, output_type)
+
+        if use_tiling.startswith("Auto"):
+            file_list = [key for key in output_dict.keys() if output_dict[key] == None]
+            if file_list:
+                self.log(
+            f"redoing upscaling with tiling for {len(file_list)} failed files at {output_path}")
+
                 tiling = self.config.realesrgan_settings["tiling"]
                 tile_pad = self.config.realesrgan_settings["tile_pad"]
-            else:
-                tiling = 0
-                tile_pad = 0
-            upscaler = UpscaleSeries(model_name, gpu_ids, fp32, tiling, tile_pad, self.log)
+                upscaler = UpscaleSeries(model_name, gpu_ids, fp32, tiling, tile_pad, self.log)
+                output_dict = upscaler.upscale_series(file_list, output_path, upscale_factor,
+                                                    output_basename, output_type)
 
-            if output_path:
-                create_directory(output_path)
-                output_basename = "upscaled_frames"
-                output_type = "png"
-            else:
-                output_path = input_path
-                output_basename = None
-                output_type = None
-
-            image_extensions = self.config.upscale_settings["file_types"]
-            file_list = get_files(input_path, image_extensions)
-
-            self.log(f"beginning series of upscaling of {image_extensions} files at {output_path}")
-            output_dict = upscaler.upscale_series(file_list, output_path, upscale_factor,
-                                                  output_basename, output_type)
-
-            if use_tiling.startswith("Auto"):
                 file_list = [key for key in output_dict.keys() if output_dict[key] == None]
                 if file_list:
-                    self.log(
-                f"redoing upscaling with tiling for {len(file_list)} failed files at {output_path}")
-
-                    tiling = self.config.realesrgan_settings["tiling"]
-                    tile_pad = self.config.realesrgan_settings["tile_pad"]
-                    upscaler = UpscaleSeries(model_name, gpu_ids, fp32, tiling, tile_pad, self.log)
-                    output_dict = upscaler.upscale_series(file_list, output_path, upscale_factor,
-                                                        output_basename, output_type)
-
-                    file_list = [key for key in output_dict.keys() if output_dict[key] == None]
-                    if file_list:
-                        self.log(f"unable to upscale files:\n{file_list}")
+                    self.log(f"unable to upscale files:\n{file_list}")
 
         message = f"Upscaled frames saved to {os.path.abspath(output_path)}"
         if interactive:

--- a/tabs/video_inflation_ui.py
+++ b/tabs/video_inflation_ui.py
@@ -119,7 +119,7 @@ class VideoInflation(TabBase):
             message = "\r\n".join(errors)
             return gr.update(value=format_markdown(message, "error"))
         else:
-            message = f"Batch processed inflated frames saved to {output_path}"
+            message = f"Batch processed inflated frames saved to {os.path.abspath(output_path)}"
             return gr.update(value=format_markdown(message))
 
     def video_inflation(self, input_path : str, output_path : str | None, num_splits : float, interactive : bool=True):
@@ -166,7 +166,7 @@ class VideoInflation(TabBase):
         series_interpolater.interpolate_series(file_list, output_path, num_splits,
             output_basename)
 
-        message = f"Inflated frames saved to {output_path}"
+        message = f"Inflated frames saved to {os.path.abspath(output_path)}"
         if interactive:
             return gr.update(value=format_markdown(message))
         else:


### PR DESCRIPTION
Video Remixer uses a unique feature not found in other tabs: a message area with instructions on what to do next, and color-coded messages when something goes wrong. Older feature tabs feel _muted_ now in comparison when using them.

Add the same kind of interactive messaging to other tabs.

_Done so far_
✅ Frame Interpolation
✅ Frame Search
✅ Video Inflation
✅ Resynthesize Video
✅ Frame Restoration
✅ Upscale Frames

_TO DO_
🟩 Deduplication (4 tabs)
      🟩 Duplicate Frames Report
      🟩 Duplicate Threshold Tuning
      🟩 Remove Duplicate Frames
      🟩 Auto-Fill Duplicate Frames

🟩 Split & Merge (5 tabs)
      🟩 Split Frames
      🟩 Merge Frames
      🟩 Split Scenes
      🟩 Slice Video
      🟩 Strip Scenes

🟩 Video Blender (5 of 6 tabs)
      🟩 Project Settings
      🟩 Frame Fixer
      🟩 Video Preview
      🟩 New Project
      🟩 Reset Project

🟩 Tools (6 of 7 tabs)
      🟩 Video Details
      🟩 Resequence Files
      🟩 Resize Frames
      🟩 Change FPS
      🟩 GIF to MP4

🟩 File Conversion (7 Tabs)
      🟩 MP4 to PNG Sequence
      🟩 PNG Sequence to MP4
      🟩 GIF to PNG Sequence
      🟩 PNG Sequence to GIF
      🟩 Transpose PNG Files
      🟩 Clean PNG Files
      🟩 Video Assembler
