### PR TITLE
Video Remixer - Remix Extra: Add Cleanse Scenes tool

### DIFF
--- a/guide/video_remixer_extra.md
+++ b/guide/video_remixer_extra.md
@@ -30,6 +30,14 @@
 - _**Note:**_
     - The original source frames and dropped scenes are not duplicated
 
+#### Cleanse Scenes - Remove noise and artifacts from kept scenes
+
+- **Used For:** Cleaning scenes that are especially noisy or full of digital artifacts
+- _Use Scene Chooser to Keep the frames that should be cleansed_
+- _All kept scenes are upscaled 4X using Real-ESRGAN 4x+ then reduced 4X using "area" interpolation_
+- _**Note:**_
+    - The original scenes are purged to the _purged_content_ folder
+
 ## _Reduce Footprint_
 
 #### Remove Soft-Deleted Content - Delete content set aside when remix processing selections are changed

--- a/tabs/video_remixer_ui.py
+++ b/tabs/video_remixer_ui.py
@@ -2108,7 +2108,7 @@ class VideoRemixer(TabBase):
             gr.update(value=new_project_path), \
             gr.update(value=format_markdown(self.TAB01_DEFAULT_MESSAGE))
 
-    CLEANSE_SCENES_PATH = "cleaned_scenes"
+    CLEANSE_SCENES_PATH = "cleansed_scenes"
     CLEANSE_SCENES_FACTOR = 4.0
 
     def cleanse_button704(self):
@@ -2166,7 +2166,7 @@ class VideoRemixer(TabBase):
             for scene_name in kept_scenes:
                 downsample_scene_path = os.path.join(downsample_path, scene_name)
                 shutil.move(downsample_scene_path, self.state.scenes_path)
-            Mtqdm().update_bar(bar)
+                Mtqdm().update_bar(bar)
 
         shutil.rmtree(working_path)
         return gr.update(value=format_markdown("Kept scenes replaced with cleaned versions"))

--- a/tabs/video_remixer_ui.py
+++ b/tabs/video_remixer_ui.py
@@ -509,7 +509,7 @@ class VideoRemixer(TabBase):
                                 # Cleanse Scene
                                 with gr.Tab(SimpleIcons.SOAP + " Cleanse Scenes", id=self.TAB_EXTRA_UTIL_CLEANSE_SCENES):
                                     gr.Markdown(
-                                "**_Cleanse Kept Scenes_**")
+                                "**_Remove noise and artifacts from kept scenes_**")
                                     with gr.Row():
                                         message_box704 = gr.Markdown(format_markdown("Click Cleanse Scene to: Remove noise and artifacts from kept scenes"))
                                     cleanse_button704 = gr.Button("Cleanse Scenes " + SimpleIcons.SLOW_SYMBOL, variant="stop", scale=0)

--- a/video_remixer.py
+++ b/video_remixer.py
@@ -21,6 +21,7 @@ from deep_interpolate import DeepInterpolate
 from interpolate_series import InterpolateSeries
 from resequence_files import ResequenceFiles
 from upscale_series import UpscaleSeries
+from PIL import Image
 
 class VideoRemixerState():
     def __init__(self):
@@ -410,6 +411,23 @@ class VideoRemixerState():
             Mtqdm().update_bar(bar)
         return ffmpeg_cmd
 
+    # this is intended to be called after source frames have been rendered
+    def enhance_video_info(self, ignore_errors=True):
+        """Get the actual dimensions of the PNG frame files"""
+        source_frames = sorted(get_files(self.frames_path))
+        if source_frames:
+            sample_frame = source_frames[0]
+            try:
+                img = Image.open(sample_frame)
+                self.video_details["source_width"] = img.width
+                self.video_details["source_height"] = img.height
+            except Exception as error:
+                if not ignore_errors:
+                    raise error
+            return
+        if not ignore_errors:
+            raise ValueError(f"Error: no frame PNG files found in {self.frames_path}")
+
     def scenes_present(self):
         self.uncompile_scenes()
         return os.path.exists(self.scenes_path) and get_directories(self.scenes_path)
@@ -753,11 +771,12 @@ class VideoRemixerState():
         return format_table(header_row, data_rows, color="more")
 
     def uncompile_scenes(self):
-        dropped_dirs = get_directories(self.dropped_scenes_path)
-        for dir in dropped_dirs:
-            current_path = os.path.join(self.dropped_scenes_path, dir)
-            undropped_path = os.path.join(self.scenes_path, dir)
-            shutil.move(current_path, undropped_path)
+        if self.dropped_scenes_path:
+            dropped_dirs = get_directories(self.dropped_scenes_path)
+            for dir in dropped_dirs:
+                current_path = os.path.join(self.dropped_scenes_path, dir)
+                undropped_path = os.path.join(self.scenes_path, dir)
+                shutil.move(current_path, undropped_path)
 
     def compile_scenes(self):
         dropped_scenes = self.dropped_scenes()
@@ -975,47 +994,69 @@ class VideoRemixerState():
 
         return processing_path
 
+    def get_resize_params(self, content_width, content_height, remixer_settings):
+        if self.resize_w == content_width and self.resize_h == content_height:
+            scale_type = "none"
+        else:
+            if self.resize_w <= content_width and self.resize_h <= content_height:
+                # use the down scaling type if there are only reductions
+                # the default "area" type preserves details better on reducing
+                scale_type = remixer_settings["scale_type_down"]
+            else:
+                # otherwise use the upscaling type
+                # the default "lanczos" type preserves details better on enlarging
+                scale_type = remixer_settings["scale_type_up"]
+
+        if self.crop_w == self.resize_w and \
+                self.crop_h == self.resize_h:
+            crop_type = "none"
+        else:
+            crop_type = "crop"
+        crop_offset = -1
+        return scale_type, crop_type, crop_offset
+
+    def resize_scene(self,
+                     log_fn,
+                     scene_input_path,
+                     scene_output_path,
+                     resize_w,
+                     resize_h,
+                     scale_type,
+                     crop_type="none",
+                     crop_offset=-1):
+
+        ResizeFrames(scene_input_path,
+                    scene_output_path,
+                    resize_w,
+                    resize_h,
+                    scale_type,
+                    log_fn,
+                    crop_type=crop_type,
+                    crop_width=self.crop_w,
+                    crop_height=self.crop_h,
+                    crop_offset_x=crop_offset,
+                    crop_offset_y=crop_offset).resize()
+
     def resize_scenes(self, log_fn, kept_scenes, remixer_settings):
         scenes_base_path = self.scenes_source_path(self.RESIZE_STEP)
         create_directory(self.resize_path)
+
+        content_width = self.video_details["content_width"]
+        content_height = self.video_details["content_height"]
+        scale_type, crop_type, crop_offset = self.get_resize_params(content_width, content_height, remixer_settings)
 
         with Mtqdm().open_bar(total=len(kept_scenes), desc="Resize") as bar:
             for scene_name in kept_scenes:
                 scene_input_path = os.path.join(scenes_base_path, scene_name)
                 scene_output_path = os.path.join(self.resize_path, scene_name)
-                content_width = self.video_details["content_width"]
-                content_height = self.video_details["content_height"]
-
-                if self.resize_w == content_width and self.resize_h == content_height:
-                    scale_type = "none"
-                else:
-                    if self.resize_w <= content_width and self.resize_h <= content_height:
-                        # use the down scaling type if there are only reductions
-                        # the default "area" type preserves details better on reducing
-                        scale_type = remixer_settings["scale_type_down"]
-                    else:
-                        # otherwise use the upscaling type
-                        # the default "lanczos" type preserves details better on enlarging
-                        scale_type = remixer_settings["scale_type_up"]
-
-                if self.crop_w == self.resize_w and \
-                        self.crop_h == self.resize_h:
-                    crop_type = "none"
-                else:
-                    crop_type = "crop"
-                crop_offset = -1
-
-                ResizeFrames(scene_input_path,
-                            scene_output_path,
-                            int(self.resize_w),
-                            int(self.resize_h),
-                            scale_type,
-                            log_fn,
-                            crop_type=crop_type,
-                            crop_width=self.crop_w,
-                            crop_height=self.crop_h,
-                            crop_offset_x=crop_offset,
-                            crop_offset_y=crop_offset).resize()
+                self.resize_scene(log_fn,
+                                  scene_input_path,
+                                  scene_output_path,
+                                  int(self.resize_w),
+                                  int(self.resize_h),
+                                  scale_type,
+                                  crop_type,
+                                  crop_offset).resize()
                 Mtqdm().update_bar(bar)
 
     def resynthesize_scenes(self, log_fn, kept_scenes, engine, engine_settings):
@@ -1085,7 +1126,7 @@ class VideoRemixerState():
                                 log_fn).resequence()
                 Mtqdm().update_bar(bar)
 
-    def upscale_scenes(self, log_fn, kept_scenes, realesrgan_settings, remixer_settings):
+    def get_upscaler(self, log_fn, realesrgan_settings, remixer_settings):
         model_name = realesrgan_settings["model_name"]
         gpu_ids = realesrgan_settings["gpu_ids"]
         fp32 = realesrgan_settings["fp32"]
@@ -1096,8 +1137,16 @@ class VideoRemixerState():
         else:
             tiling = 0
             tile_pad = 0
-        upscaler = UpscaleSeries(model_name, gpu_ids, fp32, tiling, tile_pad, log_fn)
+        return UpscaleSeries(model_name, gpu_ids, fp32, tiling, tile_pad, log_fn)
 
+    def upscale_scene(self, upscaler, scene_input_path, scene_output_path, upscale_factor):
+        create_directory(scene_output_path)
+        file_list = sorted(get_files(scene_input_path))
+        output_basename = "upscaled_frames"
+        upscaler.upscale_series(file_list, scene_output_path, upscale_factor, output_basename, "png")
+
+    def upscale_scenes(self, log_fn, kept_scenes, realesrgan_settings, remixer_settings):
+        upscaler = self.get_upscaler(log_fn, realesrgan_settings, remixer_settings)
         scenes_base_path = self.scenes_source_path(self.UPSCALE_STEP)
         create_directory(self.upscale_path)
 
@@ -1112,13 +1161,7 @@ class VideoRemixerState():
             for scene_name in kept_scenes:
                 scene_input_path = os.path.join(scenes_base_path, scene_name)
                 scene_output_path = os.path.join(self.upscale_path, scene_name)
-                create_directory(scene_output_path)
-
-                file_list = sorted(get_files(scene_input_path))
-                output_basename = "upscaled_frames"
-
-                upscaler.upscale_series(file_list, scene_output_path, upscale_factor,
-                                                    output_basename, "png")
+                self.upscale_scene(upscaler, scene_input_path, scene_output_path, upscale_factor)
                 Mtqdm().update_bar(bar)
 
     def remix_filename_suffix(self, extra_suffix):
@@ -1621,6 +1664,8 @@ class VideoRemixerState():
                         state.source_audio = state.source_video
                 except AttributeError:
                     state.source_audio = state.source_video
+                # new source video properties
+                state.enhance_video_info()
 
                 return state
             except YAMLError as error:

--- a/video_remixer.py
+++ b/video_remixer.py
@@ -430,7 +430,9 @@ class VideoRemixerState():
 
     def scenes_present(self):
         self.uncompile_scenes()
-        return os.path.exists(self.scenes_path) and get_directories(self.scenes_path)
+        return self.scenes_path and \
+            os.path.exists(self.scenes_path) and \
+            get_directories(self.scenes_path)
 
     def split_scenes(self, log_fn, prevent_overwrite=False):
         if prevent_overwrite and self.scenes_present():

--- a/video_remixer.py
+++ b/video_remixer.py
@@ -1058,7 +1058,7 @@ class VideoRemixerState():
                                   int(self.resize_h),
                                   scale_type,
                                   crop_type,
-                                  crop_offset).resize()
+                                  crop_offset)
                 Mtqdm().update_bar(bar)
 
     def resynthesize_scenes(self, log_fn, kept_scenes, engine, engine_settings):

--- a/video_remixer.py
+++ b/video_remixer.py
@@ -1365,7 +1365,7 @@ class VideoRemixerState():
         else:
             scenes_base_path = self.scenes_path
 
-        if custom_video_options.find("<LABEL>"):
+        if custom_video_options.find("<LABEL>") != -1:
             if not draw_text_options:
                 raise RuntimeError("'draw_text_options' is None at create_custom_video_clips()")
             try:
@@ -1393,7 +1393,7 @@ class VideoRemixerState():
                 scene_output_filepath = os.path.join(self.video_clips_path,
                                                      f"{scene_name}.{custom_ext}")
                 use_custom_video_options = custom_video_options
-                if use_custom_video_options.find("<LABEL>"):
+                if use_custom_video_options.find("<LABEL>") != -1:
                     label = draw_text_options.get("label")
                     if not label:
                         scene_index = self.scene_names.index(scene_name)


### PR DESCRIPTION
When used, applies a cleansing technique that was found to be effective denoising and removing artifacts:
- Applies to all current _Kept_ scenes
- Scenes are upscaled by 4X using Real-ESRGAN 4x+ upscaler
- Then reduced by 4X back to the original frame size using the OpenCV _area_ filter that best preserves small details
- Can be applies selectively to scenes needing extra cleaning
- Can also be applied multiple times to enhance the cleansing