### PR TITLE
Upgrade Resequence Files Feature

### DIFF
--- a/guide/resequence_files.md
+++ b/guide/resequence_files.md
@@ -2,33 +2,34 @@
 
 ## Uses
 - Prepare a PNG sequence for import into video editing software
-- Rearrange a set of PNG frames for insertion into another set
+- Rearrange a set of files for insertion into another set
 - Split a set of deinterlaced frames into _Even_ and _Odd_ sets
 
 ## How It Works
-1. Set _File Type_ to `png` or another necessary value
+1. Set _File Type_ to `png` or any other file extension
     - This used to locate the original set of files, and name the new files
-    - A wildcard such as `*` will not work here
+    - **_A wildcard such as_** `*` **_will not work here_**
 1. Set _Base Filename_ or accept the default
-    - This is used ahead of the frame index number for new filenames
+    - This is used ahead of the file index number for new renumbered filenames
     - **⚠️ Important: use a name other than the current name of the files**
-1. Set _Starting Frame Number_ or accept the default of `0`
+1. Leave _Rename files in place_ checked to copy the renumbered files to the output path
+    - Check to rename the original files in the input path instead of copying
+1. Set _Starting File Number_ or accept the default of `0`
     - A different value might be useful if inserting a PNG sequence into another
-1. Set _Frame Number Step_ or accept the default the default of `1`
-    - This sets the increment between the added frame index numbers
-1. Set _Frame Number Padding_ or accept the default of `-1`
-    - This set the width of the added frame index numbers
-    - If set to `-1`, the width is determined based on the number of files
+1. Set _File Number Step_ or accept the default the default of `1`
+    - This sets the increment between the added file index numbers
+1. Leave _File Number Padding_ blank to automatically detect the padding width
+    - If needed, set a specific padding width
+    - _Tip: It is necessary for proper sorting that all files have the same padding
 1. Leave _Samping Stride_ set to `1` and _Sampling Offset_ set to `0`
     - These are used for special purposes, for example:
-        - To select only _even_ frames:
-            - set _Sampling Stride_ to `2`
-        - To select only _odd_ frames:
-            - set _Sampling Stride_ to `2`
-            - set _Sampling Offset_ to `1`
-        - _Tip: selecting_ even _or_ odd _frames can be useful if using de-interlaced content_
-1. Leave _Rename instead of duplicate files_ unchecked to keep a copy of the original files
-    - The original files can be handy for tracking down a source frame
+        - To select only **_even_** frames:
+            - set _Sampling Stride_ to `2` and set _Sampling Offset_ to `0`
+        - To select only **_odd_** frames:
+            - set _Sampling Stride_ to `2` and set _Sampling Offset_ to `1`
+        - _Tip: selecting_ even _or_ odd _frames might be useful when dealing with deinterlaced content_
+1. Leave _Reverse Sampling_ unchecked
+    - Check if the files/batch file groups should be sampled in reverse order
 1. Choose _Individual Path_ or _Batch Processing_
     - If **Individual Path**
         - Set _Input Path_ to a path on this server to the PNG files being resequenced

--- a/tabs/resequence_files_ui.py
+++ b/tabs/resequence_files_ui.py
@@ -4,7 +4,8 @@ from typing import Callable
 import gradio as gr
 from webui_utils.simple_config import SimpleConfig
 from webui_utils.simple_icons import SimpleIcons
-from webui_utils.file_utils import get_directories, get_files
+from webui_utils.simple_utils import format_markdown
+from webui_utils.file_utils import get_directories, get_files, create_directory, is_safe_path, split_filepath
 from webui_utils.mtqdm import Mtqdm
 from webui_tips import WebuiTips
 from interpolate_engine import InterpolateEngine
@@ -19,6 +20,9 @@ class ResequenceFiles(TabBase):
                     log_fn : Callable):
         TabBase.__init__(self, config, engine, log_fn)
 
+    DEFAULT_MESSAGE_SINGLE = "Click Resequence Files to: Assign new numbered filenames"
+    DEFAULT_MESSAGE_BATCH = "Click Resequence Batch to: Assign new numbered filenames for each batch directory"
+
     def render_tab(self):
         """Render tab into UI"""
         with gr.Tab("Resequence Files "):
@@ -26,52 +30,74 @@ class ResequenceFiles(TabBase):
                     "Rename a PNG sequence for import into video editing software",
                 elem_id="tabheading")
             with gr.Row():
-                input_filetype_text = gr.Text(value="png", max_lines=1,
-                    placeholder="File type such as png", label="File Type")
-                input_newname_text = gr.Text(value="pngsequence", max_lines=1,
-                    placeholder="Base filename for the resequenced files",
+                input_filetype = gr.Text(value="png", max_lines=1,
+                    info="Type of files to renumber such as png", label="File Type")
+                input_newname = gr.Text(value="pngsequence", max_lines=1,
+                    info="Base filename for renumbered files",
                     label="Base Filename")
+                input_rename = gr.Checkbox(value=False,
+                    label="Rename files in place (don't copy files)",
+                    info="Resequences input path files only, ignoring output path")
             with gr.Row():
-                input_start_text = gr.Text(value="0", max_lines=1,
-                    label="Starting Frame Number (usually 0)")
-                input_step_text = gr.Text(value="1", max_lines=1,
-                    label="Frame Number Step (usually 1)")
-                input_zerofill_text = gr.Text(value="-1", max_lines=1,
-                    label="Frame Number Padding (-1 for auto detect)")
+                input_start = gr.Number(value=0, precision=0, minimum=0,
+                    label="Starting File Number",
+                    info="Beginning number for renumbered files, usually 0")
+                input_step = gr.Number(value=1, precision=0, minimum=1,
+                    label="File Number Step", info="Sequential renumbering increment, usually 1")
+                input_zerofill = gr.Text(value=None, max_lines=1,
+                    label="File Number Padding", placeholder="(leave blank for auto detection)",
+                    info="Sequential file number padding width (for sorting)")
             with gr.Row():
-                input_stride = gr.Text(value="1", max_lines=1,
-                    label="Sampling Stride (usually 1)")
-                input_offset = gr.Text(value="0", max_lines=1,
-                    label="Sampling Offset (usually 0)")
-            with gr.Row():
-                input_rename_check = gr.Checkbox(value=False,
-                    label="Rename instead of duplicate files")
+                input_stride = gr.Number(value=1, precision=0, minimum=1,
+                    label="Sampling Stride",
+                    info="Takes one file for each sample group of this size")
+                input_offset = gr.Number(value=0, precision=0, minimum=0,
+                    label="Sampling Offset",
+                    info="Take this file positioned within the sample group")
+                input_reverse = gr.Checkbox(value=False,
+                    label="Reverse Sampling",
+                    info="Resequences files in the opposite direction")
             with gr.Tabs():
                 with gr.Tab(label="Individual Path"):
-                    input_path_text2 = gr.Text(max_lines=1,
-                        placeholder="Path on this server to the files to be resequenced",
-                        label="Input Path")
+                    with gr.Row():
+                        input_path = gr.Text(max_lines=1,
+                            placeholder="Path on this server to the files to be resequenced",
+                            label="Input Path")
+                        output_path = gr.Text(max_lines=1,
+                            placeholder="Path on this server to the files to be resequenced",
+                            label="Output Path (leave blank to use input path)")
+                    message_box_single = gr.Markdown(format_markdown(self.DEFAULT_MESSAGE_SINGLE))
                     resequence_button = gr.Button("Resequence Files", variant="primary")
                 with gr.Tab(label="Batch Processing"):
-                    input_path_batch = gr.Text(max_lines=1,
-                        placeholder="Path on this server to the file groups to be resequenced",
-                        label="Input Path")
+                    with gr.Row():
+                        input_path_batch = gr.Text(max_lines=1,
+                            placeholder="Path on this server to the file groups to be resequenced",
+                            label="Input Path")
+                        output_path_batch = gr.Text(max_lines=1,
+                            placeholder="Path on this server to the files to be resequenced",
+                            label="Output Path (leave blank to use input path)")
                     input_batch_contiguous = gr.Checkbox(value=False,
-                        label="Use contiguous frame indexes across groups")
+                        label="Use contiguous renumbering across file groups")
+                    message_box_batch = gr.Markdown(format_markdown(self.DEFAULT_MESSAGE_BATCH))
                     resequence_batch = gr.Button("Resequence Batch", variant="primary")
             with gr.Accordion(SimpleIcons.TIPS_SYMBOL + " Guide", open=False):
                 WebuiTips.resequence_files.render()
+
         resequence_button.click(self.resequence_files,
-            inputs=[input_path_text2, input_filetype_text, input_newname_text,
-                input_start_text, input_step_text, input_stride, input_offset, input_zerofill_text,
-                input_rename_check])
+            inputs=[input_path, output_path, input_filetype, input_newname,
+                input_start, input_step, input_stride, input_offset, input_zerofill,
+                input_rename, input_reverse],
+            outputs=message_box_single)
+
         resequence_batch.click(self.resequence_batch,
-            inputs=[input_path_batch, input_filetype_text, input_newname_text,
-                input_start_text, input_step_text, input_stride, input_offset, input_zerofill_text,
-                input_rename_check, input_batch_contiguous])
+            inputs=[input_path_batch, output_path_batch, input_filetype, input_newname,
+                input_start, input_step, input_stride, input_offset, input_zerofill,
+                input_rename, input_reverse, input_batch_contiguous],
+            outputs=message_box_batch)
 
     def resequence_batch(self,
                         input_path : str,
+                        output_path : str,
                         input_filetype : str,
                         input_newname : str,
                         input_start : str,
@@ -79,40 +105,93 @@ class ResequenceFiles(TabBase):
                         input_stride : str,
                         input_offset : str,
                         input_zerofill : str,
-                        input_rename_check : bool,
+                        input_rename : bool,
+                        input_reverse : bool,
                         input_batch_contiguous : bool):
         """Resequence Button handler"""
-        if input_path:
-            self.log(f"beginning batch ResequenceFiles processing with input_path={input_path}")
-            group_names = get_directories(input_path)
-            self.log(f"found {len(group_names)} groups to process")
+        if not input_path:
+            return gr.update(value=format_markdown(
+                "Please enter an input path to begin", "warning"))
+        if not os.path.exists(input_path):
+            return gr.update(value=format_markdown(
+                f"The input path {input_path} was not found", "error"))
+        if not is_safe_path(input_path):
+            return gr.update(value=format_markdown(
+                f"The input path {input_path} is not valid", "error"))
 
-            if group_names:
-                with Mtqdm().open_bar(total=len(group_names), desc="Frame Group") as bar:
-                    running_start = int(input_start)
-                    for group_name in group_names:
-                        group_input_path = os.path.join(input_path, group_name)
+        output_path = output_path or input_path
+        if not is_safe_path(output_path):
+            return gr.update(value=format_markdown(
+                f"The input path {output_path} is not valid", "error"))
 
+        self.log(f"beginning batch ResequenceFiles processing with input_path={input_path} " +\
+                 f"and output_path={output_path}")
+
+        if output_path != input_path and not input_rename:
+            self.log(f"creating group output path {output_path}")
+            create_directory(output_path)
+
+        group_names = sorted(get_directories(input_path), reverse=input_reverse)
+        self.log(f"found {len(group_names)} groups to process")
+
+        for group_name in group_names:
+            check_path = input_path if input_rename else output_path
+            group_check_path = os.path.join(check_path, group_name)
+            try:
+                self._check_for_name_clash(group_check_path, input_filetype, input_newname)
+            except ValueError as error:
+                return gr.update(value=format_markdown(
+                    f"Error: {error}", "error"))
+
+        errors = []
+        if group_names:
+            with Mtqdm().open_bar(total=len(group_names), desc="File Group") as bar:
+                running_start = int(input_start)
+                for group_name in group_names:
+                    group_input_path = os.path.join(input_path, group_name)
+                    group_output_path = os.path.join(output_path, group_name)
+
+                    try:
                         if input_batch_contiguous:
                             group_start = running_start
                             group_files = get_files(group_input_path, input_filetype)
                             running_start += len(group_files)
                         else:
                             group_start = int(input_start)
-
                         self.resequence_files(group_input_path,
-                                              input_filetype,
-                                              input_newname,
-                                              group_start,
-                                              input_step,
-                                              input_stride,
-                                              input_offset,
-                                              input_zerofill,
-                                              input_rename_check)
-                        Mtqdm().update_bar(bar)
+                                                group_output_path,
+                                                input_filetype,
+                                                input_newname,
+                                                group_start,
+                                                input_step,
+                                                input_stride,
+                                                input_offset,
+                                                input_zerofill,
+                                                input_rename,
+                                                input_reverse,
+                                                interactive=False)
+                    except ValueError as error:
+                        errors.append(f"Error handling directory {group_name}: " + str(error))
+                    Mtqdm().update_bar(bar)
+        if errors:
+            message = "\r\n".join(errors)
+            return gr.update(value=format_markdown(message, "error"))
+        else:
+            message = f"Batch processed resequenced files saved to {os.path.abspath(output_path)}"
+            return gr.update(value=format_markdown(message))
+
+    def _check_for_name_clash(self, path, filetype, base_filename):
+        files = get_files(path, filetype)
+        file : str
+        for file in files:
+            _, filename, _ = split_filepath(file)
+            if filename.startswith(base_filename):
+                message = f"Existing files were found in {path} with the base filename {base_filename}"
+                raise ValueError(message)
 
     def resequence_files(self,
                         input_path : str,
+                        output_path : str,
                         input_filetype : str,
                         input_newname : str,
                         input_start : str,
@@ -120,11 +199,78 @@ class ResequenceFiles(TabBase):
                         input_stride : str,
                         input_offset : str,
                         input_zerofill : str,
-                        input_rename_check : bool):
+                        input_rename : bool,
+                        input_reverse : bool,
+                        interactive : bool=True):
         """Resequence Button handler"""
-        if input_path and input_filetype and input_newname and input_start != ""\
-            and input_step != 0 and input_zerofill:
+        if not input_path:
+            if interactive:
+                return gr.update(value=format_markdown("Please enter an input path to begin", "warning"))
+            else:
+                raise ValueError(f"The input path is empty")
+        if not os.path.exists(input_path):
+            message = f"The input path {input_path} was not found"
+            if interactive:
+                return gr.update(value=format_markdown(message, "error"))
+            else:
+                raise ValueError(message)
+        if not is_safe_path(input_path):
+            message = f"The input path {input_path} is not valid"
+            if interactive:
+                return gr.update(value=format_markdown(message, "error"))
+            else:
+                raise ValueError(message)
+        output_path = output_path or input_path
+        if not is_safe_path(output_path):
+            return gr.update(value=format_markdown(
+                f"The input path {output_path} is not valid", "error"))
 
+        if not input_filetype:
+            if interactive:
+                return gr.update(value=format_markdown("Please enter the file type to begin", "warning"))
+            else:
+                raise ValueError(f"The file type is empty")
+        if not input_newname:
+            if interactive:
+                return gr.update(value=format_markdown("Please enter the base filename to begin", "warning"))
+            else:
+                raise ValueError(f"The base filename is empty")
+        input_start = int(input_start)
+        input_step = int(input_step)
+        if input_step == 0:
+            if interactive:
+                return gr.update(value=format_markdown("Please enter a non-zero file number step to begin", "warning"))
+            else:
+                raise ValueError(f"The file number step is zero")
+        input_stride = int(input_stride)
+        if input_stride == 0:
+            if interactive:
+                return gr.update(value=format_markdown("Please enter a non-zero sampling stride to begin", "warning"))
+            else:
+                raise ValueError(f"The sampling stride is zero")
+        input_offset = int(input_offset)
+        input_zerofill = input_zerofill or _ResequenceFiles.ZERO_FILL_AUTO_DETECT
+
+        if output_path != input_path and not input_rename:
+            self.log(f"creating group output path {output_path}")
+            create_directory(output_path)
+
+        check_path = input_path if input_rename else output_path
+        try:
+            self._check_for_name_clash(check_path, input_filetype, input_newname)
             _ResequenceFiles(input_path, input_filetype, input_newname, int(input_start),
                 int(input_step), int(input_stride), int(input_offset), int(input_zerofill),
-                input_rename_check, self.log).resequence()
+                input_rename, self.log, output_path=output_path, reverse=input_reverse).resequence()
+        except ValueError as error:
+            message = f"Error: {error}"
+            if interactive:
+                return gr.update(value=format_markdown(message, "error"))
+            else:
+                self.log(message)
+                raise error
+
+        message = f"Resequenced files saved to {os.path.abspath(output_path)}"
+        if interactive:
+            return gr.update(value=format_markdown(message))
+        else:
+            self.log(message)

--- a/tabs/upscale_frames_ui.py
+++ b/tabs/upscale_frames_ui.py
@@ -29,7 +29,6 @@ class UpscaleFrames(TabBase):
             gr.HTML(SimpleIcons.INCREASING + "Use Real-ESRGAN to Enlarge and Denoise Frames",
                 elem_id="tabheading")
             with gr.Row():
-                # with gr.Column():
                 with gr.Row():
                     scale_input = gr.Slider(value=4.0, minimum=1.0, maximum=8.0, step=0.05,
                         label="Frame Upscale Factor")


### PR DESCRIPTION
- Added interactive messaging like Video Remixer
- Add strong error checking, to prevent wiping out files when filenames clash
- Added the ability to write the resequenced files to another directory
- Added a _Reverse Sampling_ feature to invert the order of frames

Video Remixer uses a unique feature not found in other tabs: a message area with instructions on what to do next, and color-coded messages when something goes wrong. Older feature tabs feel _muted_ now in comparison when using them.

Add the same kind of interactive messaging to other tabs.

_Done so far_
✅ Frame Interpolation
✅ Frame Search
✅ Video Inflation
✅ Resynthesize Video
✅ Frame Restoration
✅ Upscale Frames

🟩 Tools (1 of 7 tabs)
      ✅ Resequence Files

_TO DO_
🟩 Deduplication (4 tabs)
      🟩 Duplicate Frames Report
      🟩 Duplicate Threshold Tuning
      🟩 Remove Duplicate Frames
      🟩 Auto-Fill Duplicate Frames

🟩 Split & Merge (5 tabs)
      🟩 Split Frames
      🟩 Merge Frames
      🟩 Split Scenes
      🟩 Slice Video
      🟩 Strip Scenes

🟩 Video Blender (5 of 6 tabs)
      🟩 Project Settings
      🟩 Frame Fixer
      🟩 Video Preview
      🟩 New Project
      🟩 Reset Project

🟩 Tools (5 of 7 tabs)
      🟩 Video Details
      🟩 Resize Frames
      🟩 Change FPS
      🟩 GIF to MP4

🟩 File Conversion (7 Tabs)
      🟩 MP4 to PNG Sequence
      🟩 PNG Sequence to MP4
      🟩 GIF to PNG Sequence
      🟩 PNG Sequence to GIF
      🟩 Transpose PNG Files
      🟩 Clean PNG Files
      🟩 Video Assembler
