### PR TITLE
Add Two-Pass Resynthesis

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -118,6 +118,7 @@ remixer_settings:
   maximum_crf: 28
   min_frames_per_scene: 10
   minimum_crf: 17
+  resynth_type: 2
   scale_type_up: "lanczos"
   scale_type_down: "area"
   source_audio_crf: 28

--- a/tabs/resynthesize_video_ui.py
+++ b/tabs/resynthesize_video_ui.py
@@ -33,6 +33,9 @@ class ResynthesizeVideo(TabBase):
             gr.HTML(SimpleIcons.TWO_HEARTS +
                 "Interpolate replacement frames from an entire video for use in movie restoration",
                 elem_id="tabheading")
+            resynth_type = gr.Radio(choices=["One Pass", "Two Pass"], value="One Pass",
+                                    label="Resynthesis Type",
+            info="One Pass Resynthesis is faster, Two Pass Resynthesis is better with fast motion")
             with gr.Tabs():
                 with gr.Tab(label="Individual Path"):
                     with gr.Row():
@@ -41,22 +44,20 @@ class ResynthesizeVideo(TabBase):
                         output_path_text = gr.Text(max_lines=1, label="Output Path",
                             placeholder="Where to place the resynthesized PNG frames",
                             info="Leave blank to use default path")
-                    resynth_type = gr.Radio(choices=["One Pass", "Two Pass"], value="One Pass",
-                                            label="Resynthesis Type",
-            info="One Pass Resynthesis is faster, Two Pass Resynthesis is better with fast motion")
-                    gr.Markdown("*Progress can be tracked in the console*")
                     message_box_single = gr.Markdown(format_markdown(self.DEFAULT_MESSAGE_SINGLE))
+                    gr.Markdown("*Progress can be tracked in the console*")
                     resynthesize_button = gr.Button("Resynthesize Video " +
                                                        SimpleIcons.SLOW_SYMBOL, variant="primary")
                 with gr.Tab(label="Batch Processing"):
-                    input_path_batch = gr.Text(max_lines=1,
-                        placeholder="Path on this server to the frame groups to resynthesize",
-                        label="Input Path")
-                    output_path_batch = gr.Text(max_lines=1,
-                        placeholder="Where to place the resynthesized frame groups",
-                        label="Output Path")
-                    gr.Markdown("*Progress can be tracked in the console*")
+                    with gr.Row():
+                        input_path_batch = gr.Text(max_lines=1,
+                            placeholder="Path on this server to the frame groups to resynthesize",
+                            label="Input Path")
+                        output_path_batch = gr.Text(max_lines=1,
+                            placeholder="Where to place the resynthesized frame groups",
+                            label="Output Path")
                     message_box_batch = gr.Markdown(format_markdown(self.DEFAULT_MESSAGE_BATCH))
+                    gr.Markdown("*Progress can be tracked in the console*")
                     resynthesize_batch = gr.Button("Resynthesize Batch " +
                                                        SimpleIcons.SLOW_SYMBOL, variant="primary")
             with gr.Accordion(SimpleIcons.TIPS_SYMBOL + " Guide", open=False):
@@ -107,7 +108,7 @@ class ResynthesizeVideo(TabBase):
                 group_input_path = os.path.join(input_path, group_name)
                 group_output_path = os.path.join(output_path, group_name)
                 try:
-                    self.resynthesize_video(group_input_path, group_output_path, interactive=False)
+                    self.resynthesize_video(group_input_path, group_output_path, resynth_type=resynth_type, interactive=False)
                 except ValueError as error:
                     errors.append(f"Error handling directory {group_name}: " + str(error))
                 Mtqdm().update_bar(bar)
@@ -146,7 +147,7 @@ class ResynthesizeVideo(TabBase):
                             1, 1, # start, step
                             2, 1, # stride, offset
                             -1,   # auto-zero fill
-                            True, # rename
+                            False, # rename
                             self.log,
                             output_path=interframes_path2).resequence()
             Mtqdm().update_bar(bar)
@@ -162,7 +163,7 @@ class ResynthesizeVideo(TabBase):
                             1, 1, # start, step
                             2, 1, # stride, offset
                             -1,   # auto-zero fill
-                            True, # rename
+                            False, # rename
                             self.log,
                             output_path=output_path).resequence()
             Mtqdm().update_bar(bar)

--- a/tabs/video_remixer_ui.py
+++ b/tabs/video_remixer_ui.py
@@ -1428,10 +1428,12 @@ class VideoRemixer(TabBase):
 
             if self.state.resynthesize:
                 if not self.state.processed_content_complete(self.state.RESYNTH_STEP):
+                    two_pass_resynth = self.config.remixer_settings["resynth_type"] == 2
                     self.state.resynthesize_scenes(self.log,
                                                 kept_scenes,
                                                 self.engine,
-                                                self.config.engine_settings)
+                                                self.config.engine_settings,
+                                                two_pass=two_pass_resynth)
                     self.log("saving project after resynthesizing frames")
                     self.state.save()
                 jot.down(f"Resynthesized scenes in {self.state.resynthesis_path}")

--- a/video_remixer.py
+++ b/video_remixer.py
@@ -1062,15 +1062,15 @@ class VideoRemixerState():
                 Mtqdm().update_bar(bar)
 
     # TODO dry up this code with same in resynthesize_video_ui - maybe a specific resynth script
-    def one_pass_resynthesis(self, input_path, output_path, output_basename, engine):
+    def one_pass_resynthesis(self, log_fn, input_path, output_path, output_basename, engine):
         file_list = sorted(get_files(input_path, extension="png"))
-        self.log(f"beginning series of frame recreations at {output_path}")
+        log_fn(f"beginning series of frame recreations at {output_path}")
         engine.interpolate_series(file_list, output_path, 1, "interframe", offset=2)
 
-        self.log(f"auto-resequencing recreated frames at {output_path}")
+        log_fn(f"auto-resequencing recreated frames at {output_path}")
         ResequenceFiles(output_path, "png", "resynthesized_frame", 1, 1, 1, 0, -1, True, self.log).resequence()
 
-    def two_pass_resynthesis(self, input_path, output_path, output_basename, engine):
+    def two_pass_resynthesis(self, log_fn, input_path, output_path, output_basename, engine):
         interframes_path1 = os.path.join(output_path, "interframes-pass1")
         interframes_path2 = os.path.join(output_path, "interframes-pass2")
         interframes_path3 = os.path.join(output_path, "interframes-final")
@@ -1080,10 +1080,10 @@ class VideoRemixerState():
 
         with Mtqdm().open_bar(total=2, desc="Two-Pass Resynthesis") as bar:
             file_list = sorted(get_files(input_path, extension="png"))
-            self.log(f"beginning pass #1 of series of frame recreations at {interframes_path1}")
+            log_fn(f"beginning pass #1 of series of frame recreations at {interframes_path1}")
             engine.interpolate_series(file_list, interframes_path1, 1, "interframe")
 
-            self.log(f"selecting odd interframes only at {interframes_path1}")
+            log_fn(f"selecting odd interframes only at {interframes_path1}")
             ResequenceFiles(interframes_path1,
                             "png",
                             "odd_interframe",
@@ -1096,10 +1096,10 @@ class VideoRemixerState():
             Mtqdm().update_bar(bar)
 
             file_list = sorted(get_files(interframes_path2, extension="png"))
-            self.log(f"beginning pass #2 of series of frame recreations at {interframes_path2}")
+            log_fn(f"beginning pass #2 of series of frame recreations at {interframes_path2}")
             engine.interpolate_series(file_list, interframes_path3, 1, "interframe")
 
-            self.log(f"selecting odd interframes only at {interframes_path3}")
+            log_fn(f"selecting odd interframes only at {interframes_path3}")
             ResequenceFiles(interframes_path3,
                             "png",
                             output_basename,
@@ -1129,9 +1129,9 @@ class VideoRemixerState():
                 create_directory(scene_output_path)
 
                 if two_pass:
-                    self.two_pass_resynthesis(scene_input_path, scene_output_path, output_basename, series_interpolater)
+                    self.two_pass_resynthesis(log_fn, scene_input_path, scene_output_path, output_basename, series_interpolater)
                 else:
-                    self.one_pass_resynthesis(scene_input_path, scene_output_path, output_basename, series_interpolater)
+                    self.one_pass_resynthesis(log_fn, scene_input_path, scene_output_path, output_basename, series_interpolater)
 
                 Mtqdm().update_bar(bar)
 

--- a/video_remixer.py
+++ b/video_remixer.py
@@ -1112,7 +1112,7 @@ class VideoRemixerState():
                             2, 1, # stride, offset
                             -1,   # auto-zero fill
                             False, # rename
-                            self.log,
+                            log_fn,
                             output_path=output_path).resequence()
             Mtqdm().update_bar(bar)
             remove_directories([interframes_path1, interframes_path2, interframes_path3])

--- a/video_remixer.py
+++ b/video_remixer.py
@@ -1068,7 +1068,13 @@ class VideoRemixerState():
         engine.interpolate_series(file_list, output_path, 1, "interframe", offset=2)
 
         log_fn(f"auto-resequencing recreated frames at {output_path}")
-        ResequenceFiles(output_path, "png", "resynthesized_frame", 1, 1, 1, 0, -1, True, self.log).resequence()
+        ResequenceFiles(output_path,
+                        "png", "resynthesized_frame",
+                        1, 1, # start, step
+                        1, 0, # stride, offset
+                        -1,   # auto-zero fill
+                        True, # rename
+                        log_fn).resequence()
 
     def two_pass_resynthesis(self, log_fn, input_path, output_path, output_basename, engine):
         interframes_path1 = os.path.join(output_path, "interframes-pass1")
@@ -1085,13 +1091,12 @@ class VideoRemixerState():
 
             log_fn(f"selecting odd interframes only at {interframes_path1}")
             ResequenceFiles(interframes_path1,
-                            "png",
-                            "odd_interframe",
-                            1, 1, # start, step
-                            2, 1, # stride, offset
-                            -1,   # auto-zero fill
+                            "png", "odd_interframe",
+                            1, 1,  # start, step
+                            2, 1,  # stride, offset
+                            -1,    # auto-zero fill
                             False, # rename
-                            self.log,
+                            log_fn,
                             output_path=interframes_path2).resequence()
             Mtqdm().update_bar(bar)
 


### PR DESCRIPTION
_Two-Pass Resynthesis_ is a new resynthesis method that was found to be very effective at cleaning noise and artifacts from compressed digital content. One-Pass vs. Two-Pass resynthesis can now be chosen on the _Resynthesize Video_ tab. Also Video Remixer now uses Two-Pass resynthesis.

About _Two-Pass Resynthesis_
- The original real frames are first _inflated_ to create temporary _between frames_ adjacent to all real frames
- The original frames are then discarded, leaving only the newly interpolated frames
- The process is repeated again, inflating and then keeping only the interpolated frames
- After the second pass, the remaining frames are exact-timing replacement for the original real frames
- During each pass, noise and artifacts not common to adjacent frames are removed
- The final set of resynthesized frames are highly cleansed due to retaining only features common to both frames
- This process takes twice as much time as _One-Pass Resynthesis_

About _One-Pass Resynthesis_
- In One-Pass Resynthesis, frames are reconstructed from their original adjacent frames
- This works well in cases of not much movement frame-to-frame
- When there is fast movement between frames, this resynthesis method breaks down
- The reason is presumed to be: the motion flow between the two surrounding frames exceeds the motion velocity on which the EMA-VFI model was trained
- In other words, the engine has difficulty tracking motion between objects that are too far apart frame-to-frame
