### PR TITLE
Video Remixer: Rebuild scene split cache if scenes are cleansed

### DIFF
--- a/tabs/video_remixer_ui.py
+++ b/tabs/video_remixer_ui.py
@@ -2200,6 +2200,7 @@ class VideoRemixer(TabBase):
                 Mtqdm().update_bar(bar)
 
         shutil.rmtree(working_path)
+        self.invalidate_split_scene_cache()
         return gr.update(value=format_markdown("Kept scenes replaced with cleaned versions"))
 
 


### PR DESCRIPTION
This is needed because the scene PNG files could be renamed