### PR TITLE
Video Remixer: Split processed scene

### DIFF
--- a/tabs/video_remixer_ui.py
+++ b/tabs/video_remixer_ui.py
@@ -1891,6 +1891,20 @@ class VideoRemixer(TabBase):
             gr.update(value=format_markdown(message)), \
             *self.scene_chooser_details(self.state.current_scene)
 
+    def valid_split_scene_cache(self, scene_index):
+        if self.split_scene_cache and self.split_scene_cached_index == scene_index:
+            return self.split_scene_cache
+        else:
+            return None
+
+    def fill_split_scene_cache(self, scene_index, data):
+        self.split_scene_cache = data
+        self.split_scene_cached_index = scene_index
+
+    def invalidate_split_scene_cache(self):
+        self.split_scene_cache = []
+        self.split_scene_cached_index = -1
+
     def compute_scene_split(self, scene_name : str, split_percent : float, override_num_frames=0):
         split_percent = 0.0 if isinstance(split_percent, type(None)) else split_percent
         split_point = split_percent / 100.0
@@ -1907,20 +1921,6 @@ class VideoRemixer(TabBase):
         split_frame = num_frames-1 if split_frame >= num_frames else split_frame
 
         return num_width, num_frames, first_frame, last_frame, split_frame
-
-    def valid_split_scene_cache(self, scene_index):
-        if self.split_scene_cache and self.split_scene_cached_index == scene_index:
-            return self.split_scene_cache
-        else:
-            return None
-
-    def fill_split_scene_cache(self, scene_index, data):
-        self.split_scene_cache = data
-        self.split_scene_cached_index = scene_index
-
-    def invalidate_split_scene_cache(self):
-        self.split_scene_cache = []
-        self.split_scene_cached_index = -1
 
     def split_scene_content(self,
                             content_path : str,
@@ -1966,7 +1966,6 @@ class VideoRemixer(TabBase):
 
         _, _, _, _, split_frame = self.compute_scene_split(
             scene_name, split_percent, override_num_frames=len(frame_files))
-
         for index, frame_file in enumerate(frame_files):
             if index < split_frame:
                 continue
@@ -2058,7 +2057,7 @@ class VideoRemixer(TabBase):
                                                     scene_name,
                                                     new_lower_scene_name,
                                                     new_upper_scene_name,
-                                                    split_frame)
+                                                    split_percent)
                     except ValueError as error:
                         self.log(
                             f"Error splitted processed content path {path}: {error} - ignored")

--- a/tabs/video_remixer_ui.py
+++ b/tabs/video_remixer_ui.py
@@ -2049,7 +2049,7 @@ class VideoRemixer(TabBase):
                 if scene_name in dirs:
                     scene_path = os.path.join(path, scene_name)
                     try:
-                        self.split_processed_content(path,
+                        self.split_processed_content(scene_path,
                                                     scene_name,
                                                     new_lower_scene_name,
                                                     new_upper_scene_name,

--- a/tabs/video_remixer_ui.py
+++ b/tabs/video_remixer_ui.py
@@ -1922,7 +1922,13 @@ class VideoRemixer(TabBase):
         self.split_scene_cache = []
         self.split_scene_cached_index = -1
 
-    def split_scene_content(self, content_path : str, scene_name : str, new_lower_scene_name : str, new_upper_scene_name : str, num_frames : int, split_frame : int):
+    def split_scene_content(self,
+                            content_path : str,
+                            scene_name : str,
+                            new_lower_scene_name : str,
+                            new_upper_scene_name : str,
+                            num_frames : int,
+                            split_frame : int):
         original_scene_path = os.path.join(content_path, scene_name)
         new_lower_scene_path = os.path.join(content_path, new_lower_scene_name)
         new_upper_scene_path = os.path.join(content_path, new_upper_scene_name)
@@ -2047,9 +2053,8 @@ class VideoRemixer(TabBase):
             if path and os.path.exists(path):
                 dirs = get_directories(path)
                 if scene_name in dirs:
-                    scene_path = os.path.join(path, scene_name)
                     try:
-                        self.split_processed_content(scene_path,
+                        self.split_processed_content(path,
                                                     scene_name,
                                                     new_lower_scene_name,
                                                     new_upper_scene_name,

--- a/tabs/video_remixer_ui.py
+++ b/tabs/video_remixer_ui.py
@@ -2037,7 +2037,6 @@ class VideoRemixer(TabBase):
                                     self.config.remixer_settings)
         self.state.thumbnails = sorted(get_files(self.state.thumbnail_path))
 
-        # also split processed content if it happens to have exactly
         paths = [
             self.state.resize_path,
             self.state.resynthesis_path,
@@ -2049,21 +2048,16 @@ class VideoRemixer(TabBase):
                 dirs = get_directories(path)
                 if scene_name in dirs:
                     scene_path = os.path.join(path, scene_name)
-                    files = get_files(scene_path)
-                    num_files = len(files)
-                    if num_files == num_frames:
-                        try:
-                            self.split_processed_content(path,
-                                                        scene_name,
-                                                        new_lower_scene_name,
-                                                        new_upper_scene_name,
-                                                        split_frame)
-                        except ValueError as error:
-                            self.log(
-                                f"Error splitted processed content path {path}: {error} - ignored")
-                            continue
-                    else:
-                        self.log(f"Planned skip of splitting processed content path {path}: expected {num_frames} files but found {num_files}")
+                    try:
+                        self.split_processed_content(path,
+                                                    scene_name,
+                                                    new_lower_scene_name,
+                                                    new_upper_scene_name,
+                                                    split_frame)
+                    except ValueError as error:
+                        self.log(
+                            f"Error splitted processed content path {path}: {error} - ignored")
+                        continue
                 else:
                     self.log(f"Planned skip of splitting processed content path {path}: scene {scene_name} not found")
             else:

--- a/tabs/video_remixer_ui.py
+++ b/tabs/video_remixer_ui.py
@@ -1921,7 +1921,7 @@ class VideoRemixer(TabBase):
         self.split_scene_cache = []
         self.split_scene_cached_index = -1
 
-    def split_scene_content(self, content_path : str, scene_name : str, new_lower_scene_name : str, new_upper_scene_name : str, num_frames : int, split_frame : int, scene_index : int):
+    def split_scene_content(self, content_path : str, scene_name : str, new_lower_scene_name : str, new_upper_scene_name : str, num_frames : int, split_frame : int):
         original_scene_path = os.path.join(content_path, scene_name)
         new_lower_scene_path = os.path.join(content_path, new_lower_scene_name)
         new_upper_scene_path = os.path.join(content_path, new_upper_scene_name)
@@ -1944,16 +1944,6 @@ class VideoRemixer(TabBase):
             shutil.move(frame_path, new_frame_path)
         os.replace(original_scene_path, new_lower_scene_path)
 
-        self.state.scene_names[scene_index] = new_lower_scene_name
-        self.state.scene_names.append(new_upper_scene_name)
-        self.state.scene_names = sorted(self.state.scene_names)
-
-        scene_state = self.state.scene_states[scene_name]
-        del self.state.scene_states[scene_name]
-        self.state.scene_states[new_lower_scene_name] = scene_state
-        self.state.scene_states[new_upper_scene_name] = scene_state
-        # self.state.current_scene = scene_index
-
 
     def split_button702(self, scene_index, split_percent):
         global_options = self.config.ffmpeg_settings["global_options"]
@@ -1962,10 +1952,10 @@ class VideoRemixer(TabBase):
             return gr.update(selected=self.TAB_REMIX_EXTRA), \
                 gr.update(value=format_markdown("Please enter a Scene Index to get started", "warning")), \
                 *self.empty_args(5)
-
         num_scenes = len(self.state.scene_names)
         last_scene = num_scenes - 1
         scene_index = int(scene_index)
+
         if scene_index < 0 or scene_index > last_scene:
             return gr.update(selected=self.TAB_REMIX_EXTRA), \
                 gr.update(value=format_markdown(f"Please enter a Scene Index from 0 to {last_scene}", "warning")), \
@@ -1973,109 +1963,97 @@ class VideoRemixer(TabBase):
 
         scene_name, num_width, num_frames, first_frame, last_frame, split_frame \
             = self.compute_scene_split(scene_index, split_percent)
-
         if num_frames < 2:
             return gr.update(selected=self.TAB_REMIX_EXTRA), \
                 gr.update(value=format_markdown("Scene must have at least two frames to be split", "error")), \
                 *self.empty_args(5)
 
-        self.log(f"setting split frame to {split_frame}")
-
         new_lower_first_frame = first_frame
         new_lower_last_frame = first_frame + (split_frame - 1)
         new_lower_scene_name = VideoRemixerState.encode_scene_label(num_width,
                                                 new_lower_first_frame, new_lower_last_frame, 0, 0)
-        self.log(f"new lower scene name: {new_lower_scene_name}")
-
         new_upper_first_frame = first_frame + split_frame
         new_upper_last_frame = last_frame
         new_upper_scene_name = VideoRemixerState.encode_scene_label(num_width,
                                                 new_upper_first_frame, new_upper_last_frame, 0, 0)
-        self.log(f"new upper scene name: {new_upper_scene_name}")
-
         self.state.uncompile_scenes()
 
+        try:
+            self.split_scene_content(self.state.scenes_path,
+                                    scene_name,
+                                    new_lower_scene_name,
+                                    new_upper_scene_name,
+                                    num_frames,
+                                    split_frame)
+        except ValueError as error:
+            return gr.update(selected=self.TAB_REMIX_EXTRA), \
+                gr.update(value=format_markdown(f"Error: {error}", "error")), \
+                *self.empty_args(5)
 
+        self.state.scene_names[scene_index] = new_lower_scene_name
+        self.state.scene_names.append(new_upper_scene_name)
+        self.state.scene_names = sorted(self.state.scene_names)
 
-        # original_scene_path = os.path.join(self.state.scenes_path, scene_name)
-        # new_lower_scene_path = os.path.join(self.state.scenes_path, new_lower_scene_name)
-        # new_upper_scene_path = os.path.join(self.state.scenes_path, new_upper_scene_name)
-        # self.log(f"new lower scene path: {new_lower_scene_path}")
-        # self.log(f"new upper scene path: {new_upper_scene_path}")
-
-        # frame_files = sorted(get_files(original_scene_path))
-        # num_frame_files = len(frame_files)
-        # if num_frame_files != num_frames:
-        #     message = f"Mismatch between expected frames ({num_frames}) and found frames " + \
-        #         f"({num_frame_files}) in scene path '{original_scene_path}'"
-        #     return gr.update(selected=self.TAB_REMIX_EXTRA), \
-        #         gr.update(value=format_markdown(message, "error")), \
-        #             *self.empty_args(5)
-
-        # messages = Jot()
-
-        # self.log(f"about to create directory '{new_upper_scene_path}'")
-        # create_directory(new_upper_scene_path)
-        # messages.add(f"Created directory {new_upper_scene_path}")
-
-        # move_count = 0
-        # for index, frame_file in enumerate(frame_files):
-        #     if index < split_frame:
-        #         continue
-        #     frame_path = os.path.join(original_scene_path, frame_file)
-        #     _, filename, ext = split_filepath(frame_path)
-        #     new_frame_path = os.path.join(new_upper_scene_path, filename + ext)
-
-        #     self.log(f"about to move '{frame_path}' to '{new_frame_path}'")
-        #     shutil.move(frame_path, new_frame_path)
-        #     move_count += 1
-        # messages.add(f"Moved {move_count} frames to {new_upper_scene_path}")
-
-        # self.log(f"about to rename '{original_scene_path}' to '{new_lower_scene_path}'")
-        # os.replace(original_scene_path, new_lower_scene_path)
-        # messages.add(f"Renamed {original_scene_path} to {new_lower_scene_path}")
-
-        # self.log(f"about to rename scene name '{scene_name}' to '{new_lower_scene_name}'")
-        # self.state.scene_names[scene_index] = new_lower_scene_name
-        # self.log(f"about to add new scene name '{new_upper_scene_name}'")
-        # self.state.scene_names.append(new_upper_scene_name)
-        # self.log(f"sorting scene names")
-        # self.state.scene_names = sorted(self.state.scene_names)
-
-        # scene_state = self.state.scene_states[scene_name]
-        # self.log(f"about to delete the original scene state for scene '{scene_name}'")
-        # del self.state.scene_states[scene_name]
-        # self.log(f"adding scene state for new lower scene '{new_lower_scene_name}'")
-        # self.state.scene_states[new_lower_scene_name] = scene_state
-        # messages.add(f"Set scene {new_lower_scene_name} to {scene_state}")
-        # self.log(f"adding scene state for new upper scene '{new_upper_scene_name}'")
-        # self.state.scene_states[new_upper_scene_name] = scene_state
-        # messages.add(f"Set scene {new_upper_scene_name} to {scene_state}")
+        scene_state = self.state.scene_states[scene_name]
+        del self.state.scene_states[scene_name]
+        self.state.scene_states[new_lower_scene_name] = scene_state
+        self.state.scene_states[new_upper_scene_name] = scene_state
 
         self.state.current_scene = scene_index
 
         thumbnail_file = self.state.thumbnails[scene_index]
         self.log(f"about to delete original thumbnail file '{thumbnail_file}'")
         os.remove(thumbnail_file)
-        messages.add(f"Deleted thumbnail {thumbnail_file}")
-        self.log(f"about to create thumbnail for new lower scene {new_lower_scene_name}")
         self.state.create_thumbnail(new_lower_scene_name, self.log, global_options,
                                     self.config.remixer_settings)
-        messages.add(f"Created thumbnail for scene {new_lower_scene_name}")
         self.log(f"about to create thumbnail for new upper scene {new_upper_scene_name}")
         self.state.create_thumbnail(new_upper_scene_name, self.log, global_options,
                                     self.config.remixer_settings)
         self.state.thumbnails = sorted(get_files(self.state.thumbnail_path))
-        messages.add(f"Created thumbnail for scene {new_upper_scene_name}")
+
+        # also split processed content if it happens to have exactly
+        # the same number of frames
+        # will not typically work for resynthesized frames
+        #   (loss of two outer frames has to be accounted for)
+        # will not typically work for inflated frames
+        #   (addition of one-frame less than 2X additional between frames has to be accounted for)
+        paths = [
+            self.state.resize_path,
+            self.state.resynthesis_path,
+            self.state.inflation_path,
+            self.state.upscale_path
+        ]
+        for path in paths:
+            if path and os.path.exists(path):
+                dirs = get_directories(path)
+                if scene_name in dirs:
+                    scene_path = os.path.join(path, scene_name)
+                    files = get_files(scene_path)
+                    num_files = len(files)
+                    if num_files == num_frames:
+                        try:
+                            self.split_scene_content(path,
+                                                    scene_name,
+                                                    new_lower_scene_name,
+                                                    new_upper_scene_name,
+                                                    num_frames,
+                                                    split_frame)
+                        except ValueError as error:
+                            self.log(
+                                f"Error splitted processed content path {path}: {error} - ignored")
+                            continue
+                    else:
+                        self.log(f"Planned skip of splitting processed content path {path}: expected {num_frames} files but found {num_files}")
+                else:
+                    self.log(f"Planned skip of splitting processed content path {path}: scene {scene_name} not found")
+            else:
+                self.log(f"Planned skip of splitting processed content path {path}: path not found")
 
         self.log("saving project after completing scene split")
         self.state.save()
 
         self.log("invalidating scene split cache after splitting")
         self.invalidate_split_scene_cache()
-
-        report = messages.report()
-        self.log(report)
 
         message = f"Scene split into new scenes {new_lower_scene_name} and {new_upper_scene_name}"
         return gr.update(selected=self.TAB_CHOOSE_SCENES), \


### PR DESCRIPTION
When using the _Split Scene_ feature, if freshly processed content is found with the same scene, it will be split also
- The split percentage is applied to the frame counts found in the processed content directories, since the count may differ from the scene frame count
  - _Resynthesis_ and _Inflation_ have frame counts different from the source due to their processing techniques
