### PR TITLE
Video Remixer: new feature: coalesce scenes

### DIFF
--- a/tabs/video_remixer_ui.py
+++ b/tabs/video_remixer_ui.py
@@ -2573,6 +2573,8 @@ class VideoRemixer(TabBase):
                     format_markdown("No scenes were found to coalesce", "warning"), \
                     *empty_args
 
+            return_to_scene_index = self.state.scene_names.index(merge_pairs[0][0])
+
             with Mtqdm().open_bar(total=len(merge_pairs), desc="Coalescing Scenes") as bar:
                 for merge_pair in merge_pairs:
                     first_index = self.state.scene_names.index(merge_pair[0])
@@ -2585,7 +2587,7 @@ class VideoRemixer(TabBase):
                             *empty_args
                     Mtqdm().update_bar(bar)
 
-            self.state.current_scene = self.state.scene_names.index(merge_pairs[0][0])
+            self.state.current_scene = return_to_scene_index
             self.log("Saving project after consolidating scenes")
 
             return gr.update(selected=self.TAB_CHOOSE_SCENES), \

--- a/tabs/video_remixer_ui.py
+++ b/tabs/video_remixer_ui.py
@@ -2520,8 +2520,10 @@ class VideoRemixer(TabBase):
 
         for index, this_scene_name in enumerate(kept_scenes[:-1]):
             next_scene_name = kept_scenes[index + 1]
+            print("@", this_scene_name, next_scene_name)
             this_scene_index = self.state.scene_names.index(this_scene_name)
             next_scene_index = self.state.scene_names.index(next_scene_name)
+            print("#", this_scene_index, next_scene_index)
             _, this_last_frame_index, _ = details_from_group_name(this_scene_name)
             next_first_frame_index, _, _ = details_from_group_name(next_scene_name)
             mergeable = next_first_frame_index == this_last_frame_index + 1
@@ -2535,7 +2537,7 @@ class VideoRemixer(TabBase):
             else:
                 if mergeable:
                     # extend current merge range
-                    last_merge_index = index + 1
+                    last_merge_index = next_scene_index
                 else:
                     # not mergeable, end capture mode and save merge pair
                     print("!" * 100, first_merge_index, last_merge_index)

--- a/tabs/video_remixer_ui.py
+++ b/tabs/video_remixer_ui.py
@@ -550,6 +550,7 @@ class VideoRemixer(TabBase):
                                         message_box705 = gr.Markdown(
                                             format_markdown(
                                     "Click Merge Scene Range to: Combine the chosen scenes into a single scene"))
+                                    with gr.Row():
                                         merge_button705 = gr.Button("Merge Scene Range",
                                                                 variant="stop", scale=0)
                                 with gr.Tab("Coalesce Scenes"):
@@ -562,6 +563,7 @@ class VideoRemixer(TabBase):
                                         message_box706 = gr.Markdown(
                                             format_markdown(
                                     "Click Coalesce to: Consolidate all adjacent kept scenes"))
+                                    with gr.Row():
                                         coalesce_button706 = gr.Button("Coalesce Scenes",
                                                                 variant="stop", scale=0)
                         # EXPORT KEPT SCENES
@@ -2536,6 +2538,7 @@ class VideoRemixer(TabBase):
                     last_merge_index = index + 1
                 else:
                     # not mergeable, end capture mode and save merge pair
+                    print("!" * 100, first_merge_index, last_merge_index)
                     merge_pairs.append([first_merge_index, last_merge_index])
                     capture_mode = False
 
@@ -2553,9 +2556,9 @@ class VideoRemixer(TabBase):
                     message_line.append(scene_name)
                 first_scene_name = self.state.scene_names[first_index]
                 last_scene_name = self.state.scene_names[last_index]
-                first_frame_index, _, _ = details_from_group_name(first_scene_name)
+                first_frame_index, _, num_width = details_from_group_name(first_scene_name)
                 _, last_frame_index, _ = details_from_group_name(last_scene_name)
-                new_scene_name = f"{first_frame_index}-{last_frame_index}"
+                new_scene_name = f"{str(first_frame_index).zfill(num_width)}-{str(last_frame_index).zfill(num_width)}"
                 message.add(f"{','.join(message_line)} -> {new_scene_name}")
 
             return gr.update(selected=self.TAB_REMIX_EXTRA), \

--- a/tabs/video_remixer_ui.py
+++ b/tabs/video_remixer_ui.py
@@ -2575,8 +2575,8 @@ class VideoRemixer(TabBase):
 
             with Mtqdm().open_bar(total=len(merge_pairs), desc="Coalescing Scenes") as bar:
                 for merge_pair in merge_pairs:
-                    first_index = merge_pair[0]
-                    last_index = merge_pair[1]
+                    first_index = self.state.scene_names.index(merge_pair[0])
+                    last_index = self.state.scene_names.index(merge_pair[1])
                     try:
                         self.merge_scenes(first_index, last_index)
                     except ValueError as error:

--- a/tabs/video_remixer_ui.py
+++ b/tabs/video_remixer_ui.py
@@ -2520,10 +2520,8 @@ class VideoRemixer(TabBase):
 
         for index, this_scene_name in enumerate(kept_scenes[:-1]):
             next_scene_name = kept_scenes[index + 1]
-            print("@", this_scene_name, next_scene_name)
             this_scene_index = self.state.scene_names.index(this_scene_name)
             next_scene_index = self.state.scene_names.index(next_scene_name)
-            print("#", this_scene_index, next_scene_index)
             _, this_last_frame_index, _ = details_from_group_name(this_scene_name)
             next_first_frame_index, _, _ = details_from_group_name(next_scene_name)
             mergeable = next_first_frame_index == this_last_frame_index + 1
@@ -2540,36 +2538,36 @@ class VideoRemixer(TabBase):
                     last_merge_index = next_scene_index
                 else:
                     # not mergeable, end capture mode and save merge pair
-                    print("!" * 100, first_merge_index, last_merge_index)
                     merge_pairs.append([first_merge_index, last_merge_index])
                     capture_mode = False
 
         if capture_mode:
             merge_pairs.append([first_merge_index, last_merge_index])
 
-        if not coalesce_scenes:
-            message = Jot(title="The following scenes would be consolidated:")
-            for merge_pair in merge_pairs:
-                first_index = merge_pair[0]
-                last_index = merge_pair[1]
-                message_line = []
-                for index in range(first_index, last_index + 1):
-                    scene_name = self.state.scene_names[index]
-                    message_line.append(scene_name)
-                first_scene_name = self.state.scene_names[first_index]
-                last_scene_name = self.state.scene_names[last_index]
-                first_frame_index, _, num_width = details_from_group_name(first_scene_name)
-                _, last_frame_index, _ = details_from_group_name(last_scene_name)
-                new_scene_name = f"{str(first_frame_index).zfill(num_width)}-{str(last_frame_index).zfill(num_width)}"
-                message.add(f"{','.join(message_line)} -> {new_scene_name}")
-
-            return gr.update(selected=self.TAB_REMIX_EXTRA), \
-                format_markdown(message.report()), \
-                *empty_args
+        if coalesce_scenes:
+            title="Scenes have been consolidated:"
         else:
-            return gr.update(selected=self.TAB_REMIX_EXTRA), \
-                format_markdown("To Be Implemented"), \
-                *empty_args
+            title="Scenes to be consolidated:"
+        message = Jot(title=title)
+        for merge_pair in merge_pairs:
+            first_index = merge_pair[0]
+            last_index = merge_pair[1]
+            message_line = []
+            for index in range(first_index, last_index + 1):
+                scene_name = self.state.scene_names[index]
+                message_line.append(scene_name)
+            first_scene_name = self.state.scene_names[first_index]
+            last_scene_name = self.state.scene_names[last_index]
+            first_frame_index, _, num_width = details_from_group_name(first_scene_name)
+            _, last_frame_index, _ = details_from_group_name(last_scene_name)
+            new_scene_name = f"{str(first_frame_index).zfill(num_width)}-{str(last_frame_index).zfill(num_width)}"
+            message.add(f"{','.join(message_line)} -> {new_scene_name}")
+        report = message.report(separator_line="-")
+
+        if coalesce_scenes:
+            pass
+
+        return gr.update(selected=self.TAB_REMIX_EXTRA), format_markdown(report), *empty_args
 
 
     def delete_button710(self, delete_purged):

--- a/video_remixer.py
+++ b/video_remixer.py
@@ -747,9 +747,11 @@ class VideoRemixerState():
                 f"ValueError encountered while getting scene chooser data: {error}")
 
     def kept_scenes(self):
+        "Returns scene names of kept scenes"
         return sorted([scene for scene in self.scene_states if self.scene_states[scene] == "Keep"])
 
     def dropped_scenes(self):
+        "Returns scene names of dropped scenes"
         return sorted([scene for scene in self.scene_states if self.scene_states[scene] == "Drop"])
 
     def scene_frames(self, type : str="all") -> int:

--- a/webui_utils/jot.py
+++ b/webui_utils/jot.py
@@ -29,10 +29,8 @@ class Jot():
         _report = []
         if self.title:
             _report.append(f"{self.title}")
-            if len(separator_line) == 1:
-                # extend into a full line
-                separator_line = separator_line * len(self.title)
-            _report.append(separator_line)
+            if separator_line:
+                _report.append(separator_line)
         _report += self.lines
         return "\r\n".join(_report)
     report = grab

--- a/webui_utils/jot.py
+++ b/webui_utils/jot.py
@@ -24,12 +24,15 @@ class Jot():
         self.lines.append(str(text))
     add = down
 
-    def grab(self):
+    def grab(self, separator_line = BLANK):
         """Grab a current version of the report"""
         _report = []
         if self.title:
             _report.append(f"{self.title}")
-            _report.append(self.BLANK)
+            if len(separator_line) == 1:
+                # extend into a full line
+                separator_line = separator_line * len(self.title)
+            _report.append(separator_line)
         _report += self.lines
         return "\r\n".join(_report)
     report = grab


### PR DESCRIPTION
In _Remix Extra_, _Merge Scenes_ there is a new _Coalesce Scenes_ feature
- Automatically merges adjacent kept scenes
- Helps to improve audio between cuts
- Removes excess or unwanted cuts

To see which scenes will be consolidated, leave the checkbox unchecked and click _Coalesce Scenes_.