### PR TITLE
Video Remixer: Add "Middle" as an option for remix video labels

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -111,7 +111,6 @@ remixer_settings:
   gif_factor: 10
   labeled_ffmpeg_video: -vf "drawtext=<LABEL>" -c:v libx264 -crf <CRF>
   labeled_ffmpeg_audio: -c:a aac -shortest
-  marked_at_top: True
   marked_border_size: 5
   marked_box_color: black@0.5
   marked_draw_box: True
@@ -120,6 +119,7 @@ remixer_settings:
   marked_font_color: white@0.9
   marked_font_size: 30
   marked_font_file: fonts/trim.ttf
+  marked_position: "Top"
   max_project_fps: 60.0
   max_thumb_size: 512
   maximum_crf: 28

--- a/tabs/video_remixer_ui.py
+++ b/tabs/video_remixer_ui.py
@@ -81,7 +81,7 @@ class VideoRemixer(TabBase):
         default_label_draw_box = self.config.remixer_settings["marked_draw_box"]
         default_label_box_color = self.config.remixer_settings["marked_box_color"]
         default_label_border_size = self.config.remixer_settings["marked_border_size"]
-        default_label_at_top = self.config.remixer_settings["marked_at_top"]
+        default_label_position = self.config.remixer_settings["marked_position"]
         custom_ffmpeg_video = self.config.remixer_settings["custom_ffmpeg_video"]
         custom_ffmpeg_audio = self.config.remixer_settings["custom_ffmpeg_audio"]
 
@@ -429,7 +429,7 @@ class VideoRemixer(TabBase):
                         with gr.Tab(label="Create Labeled Remix"):
                             with gr.Row():
                                 label_text = gr.Textbox(label="Label Text", max_lines=1, info="Scenes with set labels will override this label")
-                                label_at_top = gr.Checkbox(value=default_label_at_top, label="Label at Top", info="Whether to place the label at the top or at the bottom")
+                                label_position = gr.Radio(choices=["Top", "Middle", "Bottom"], value=default_label_position, label="Label Position", info="Vertical location for the label")
                             with gr.Row():
                                 label_font_file = gr.Textbox(value=default_label_font_file, label="Font File", max_lines=1, info="Font file within the application directory")
                                 label_font_size = gr.Number(value=default_label_font_size, label="Font Factor", info="Size as a factor of frame width, smaller values produce larger text")
@@ -921,7 +921,7 @@ class VideoRemixer(TabBase):
 
         next_button63.click(self.next_button63,
                         inputs=[label_text, label_font_size, label_font_color, label_font_file,
-                                label_draw_box, label_box_color, label_border_size, label_at_top,
+                                label_draw_box, label_box_color, label_border_size, label_position,
                                 output_filepath_labeled, quality_slider_labeled],
                         outputs=message_box63)
 
@@ -1804,7 +1804,7 @@ class VideoRemixer(TabBase):
             draw_text_options["draw_box"] = self.config.remixer_settings["marked_draw_box"]
             draw_text_options["box_color"] = self.config.remixer_settings["marked_box_color"]
             draw_text_options["border_size"] = self.config.remixer_settings["marked_border_size"]
-            draw_text_options["marked_at_top"] = self.config.remixer_settings["marked_at_top"]
+            draw_text_options["marked_position"] = self.config.remixer_settings["marked_position"]
 
             # account for upscaling
             upscale_factor = 1
@@ -1841,7 +1841,7 @@ class VideoRemixer(TabBase):
                       label_draw_box,
                       label_box_color,
                       label_border_size,
-                      label_at_top,
+                      label_position,
                       output_filepath,
                       quality):
         if not self.state.project_path:
@@ -1878,7 +1878,7 @@ class VideoRemixer(TabBase):
             draw_text_options["draw_box"] = label_draw_box
             draw_text_options["box_color"] = label_box_color
             draw_text_options["border_size"] = label_border_size
-            draw_text_options["marked_at_top"] = label_at_top
+            draw_text_options["marked_position"] = label_position
 
             # account for upscaling
             upscale_factor = 1

--- a/video_remixer.py
+++ b/video_remixer.py
@@ -1484,7 +1484,7 @@ class VideoRemixerState():
                 draw_box = draw_text_options["draw_box"]
                 box_color = draw_text_options["box_color"]
                 border_factor = draw_text_options["border_size"]
-                marked_at_top = draw_text_options["marked_at_top"]
+                marked_position = draw_text_options["marked_position"]
                 crop_width = draw_text_options["crop_width"]
                 labels = draw_text_options["labels"]
             except IndexError as error:
@@ -1493,7 +1493,13 @@ class VideoRemixerState():
             font_size = crop_width / float(font_factor)
             border_size = font_size / float(border_factor)
             box_x = "(w-text_w)/2"
-            box_y = "(text_h*1)" if marked_at_top else f"h-(text_h*2)-({2*int(border_size)})"
+
+            if marked_position == "Bottom":
+                box_y = f"h-(text_h*2)-({2*int(border_size)})"
+            elif marked_position == "Middle":
+                box_y = f"(h/2)-(text_h/2)-({int(border_size)})"
+            else:
+                box_y = "(text_h*1)"
             box = "1" if draw_box else "0"
 
         video_clip_fps = 2 * self.project_fps if self.inflate else self.project_fps


### PR DESCRIPTION
Formerly only Top and Bottom position were supported. Middle is good for published videos.