### PR TITLE
Video Remixer: Some clean ups

### DIFF
--- a/resequence_files.py
+++ b/resequence_files.py
@@ -15,7 +15,7 @@ def main():
     parser.add_argument("--input_path", default="./images", type=str,
         help="Path to files to resequence")
     parser.add_argument("--output_path", default="", type=str,
-        help="Path to store resequnced files (leave blank to use input path)")
+        help="Path to store resequenced files (leave blank to use input path)")
     parser.add_argument("--file_type", default="png", type=str,
         help="File type of the files to resequence")
     parser.add_argument("--new_name", default="pngsequence", type=str,

--- a/tabs/video_remixer_ui.py
+++ b/tabs/video_remixer_ui.py
@@ -2146,11 +2146,13 @@ class VideoRemixer(TabBase):
             self.state.inflation_path,
             self.state.upscale_path
         ]
+        processed_content_split = False
         for path in paths:
             if path and os.path.exists(path):
                 dirs = get_directories(path)
                 if scene_name in dirs:
                     try:
+                        processed_content_split = True
                         self.split_processed_content(path,
                                                     scene_name,
                                                     new_lower_scene_name,
@@ -2170,6 +2172,10 @@ class VideoRemixer(TabBase):
 
         self.log("invalidating scene split cache after splitting")
         self.invalidate_split_scene_cache()
+
+        if processed_content_split:
+            self.log("invalidating processed audio content after splitting")
+            self.state.clean_remix_audio()
 
         message = f"Scene split into new scenes {new_lower_scene_name} and {new_upper_scene_name}"
         return gr.update(selected=self.TAB_CHOOSE_SCENES), \

--- a/tabs/video_remixer_ui.py
+++ b/tabs/video_remixer_ui.py
@@ -2414,7 +2414,11 @@ class VideoRemixer(TabBase):
                 shutil.move(downsample_scene_path, self.state.scenes_path)
                 Mtqdm().update_bar(bar)
 
-        shutil.rmtree(working_path)
+        try:
+            shutil.rmtree(working_path)
+        except OSError as error:
+            self.log(f"Error removing path '{working_path}' ignored: {error}")
+
         self.invalidate_split_scene_cache()
         return gr.update(value=format_markdown("Kept scenes replaced with cleaned versions"))
 

--- a/tabs/video_remixer_ui.py
+++ b/tabs/video_remixer_ui.py
@@ -2271,7 +2271,7 @@ class VideoRemixer(TabBase):
     def next_minute_702(self, scene_index, split_percent):
         return self.compute_advance_702(scene_index, split_percent, True, by_minute=True)
 
-    def export_project_703(self, new_project_path, new_project_name):
+    def export_project_703(self, new_project_path : str, new_project_name : str):
         empty_args = [gr.update(visible=False), gr.update(visible=False)]
         if not new_project_path:
             return gr.update(value=format_markdown("Please enter a Project Path for the new project", "warning")), *empty_args
@@ -2284,6 +2284,7 @@ class VideoRemixer(TabBase):
         if not kept_scenes:
             return gr.update(value=format_markdown("No kept scenes were found", "warning")), *empty_args
 
+        new_project_name = new_project_name.strip()
         full_new_project_path = os.path.join(new_project_path, new_project_name)
         try:
             create_directory(full_new_project_path)

--- a/tabs/video_remixer_ui.py
+++ b/tabs/video_remixer_ui.py
@@ -2551,6 +2551,8 @@ class VideoRemixer(TabBase):
         try:
             new_scene_name = self.merge_scenes(first_scene_index, last_scene_index)
             message = f"Scenes merged into new scene {new_scene_name}"
+            self.invalidate_split_scene_cache()
+
             return gr.update(selected=self.TAB_CHOOSE_SCENES), \
                 format_markdown(message), \
                 *self.scene_chooser_details(self.state.current_scene)
@@ -2641,6 +2643,7 @@ class VideoRemixer(TabBase):
 
             self.state.current_scene = return_to_scene_index
             self.log("Saving project after consolidating scenes")
+            self.invalidate_split_scene_cache()
 
             return gr.update(selected=self.TAB_CHOOSE_SCENES), \
                 format_markdown(report), \

--- a/video_remixer.py
+++ b/video_remixer.py
@@ -946,6 +946,9 @@ class VideoRemixerState():
                 self.clips_path])
             self.clips = []
 
+    def clean_remix_audio(self):
+        clean_directories([self.audio_clips_path])
+
     RESIZE_PATH = "SCENES-RC"
     RESYNTH_PATH = "SCENES-RE"
     INFLATE_PATH = "SCENES-IN"


### PR DESCRIPTION
Some minor lingering issues:
- Invalidate the split scene cache when using the Remix Extra _Merge Scenes_ features. Otherwise, Scene Chooser will show blank data after use until changing to a new scene
- Invalidate processed audio clips if _Split Scene_ is used and processed content has also been split. Otherwise, the processed audio clips become out of sync with the split processed content.
- Clean whitespace from the start/end of the entered project name when exporting a project
- Ignore errors deleting the working folder when using the _Cleanse Scenes_ feature

