### PR TITLE
Video Remixer: new feature: Video Blender project from Scene

### DIFF
--- a/create_ui.py
+++ b/create_ui.py
@@ -39,6 +39,14 @@ from tabs.video_assembler_ui import VideoAssembler
 from tabs.transpose_png_files_ui import TransposePngFiles
 from tabs.enhance_frames_ui import EnhanceFrames
 
+APP_TAB_INTERPOLATE_FRAMES=0
+APP_TAB_INTERPOLATE_VIDEO=1
+APP_TAB_FILM_RESTORATION=2
+APP_TAB_VIDEO_RENOVATION=3
+APP_TAB_VIDEO_BLENDER=4
+APP_TAB_VIDEO_REMIXER=5
+APP_TAB_TOOLS=6
+
 def create_ui(config : SimpleConfig,
               engine : InterpolateEngine,
               log : SimpleLog,
@@ -60,61 +68,66 @@ def create_ui(config : SimpleConfig,
         if config.user_interface["show_header"]:
             app_header.render()
 
-        with gr.Tab("Interpolate Frames"):
-            FrameInterpolation(config, engine, log.log).render_tab()
-            FrameSearch(config, engine, log.log).render_tab()
+        with gr.Tabs() as main_tabs:
+            with gr.Tab("Interpolate Frames", id=APP_TAB_INTERPOLATE_FRAMES):
+                FrameInterpolation(config, engine, log.log).render_tab()
+                FrameSearch(config, engine, log.log).render_tab()
 
-        with gr.Tab("Interpolate Video"):
-            VideoInflation(config, engine, log.log).render_tab()
-            ResynthesizeVideo(config, engine, log.log).render_tab()
+            with gr.Tab("Interpolate Video", id=APP_TAB_INTERPOLATE_VIDEO):
+                VideoInflation(config, engine, log.log).render_tab()
+                ResynthesizeVideo(config, engine, log.log).render_tab()
 
-        with gr.Tab("Film Restoration"):
-            FrameRestoration(config, engine, log.log).render_tab()
-            UpscaleFrames(config, engine, log.log).render_tab()
+            with gr.Tab("Film Restoration", id=APP_TAB_FILM_RESTORATION):
+                FrameRestoration(config, engine, log.log).render_tab()
+                UpscaleFrames(config, engine, log.log).render_tab()
 
-        with gr.Tab("Video Renovation"):
-            with gr.Tab("Deduplication"):
-                gr.HTML(SimpleIcons.SCISSORS + "Detect & Replace Duplicate Frames",
+            with gr.Tab("Video Renovation", id=APP_TAB_VIDEO_RENOVATION):
+                with gr.Tab("Deduplication"):
+                    gr.HTML(SimpleIcons.SCISSORS + "Detect & Replace Duplicate Frames",
+                            elem_id="tabheading")
+                    DuplicateFramesReport(config, engine, log.log).render_tab()
+                    DuplicateTuning(config, engine, log.log).render_tab()
+                    DedupeFrames(config, engine, log.log).render_tab()
+                    AutofillFrames(config, engine, log.log).render_tab()
+
+                with gr.Tab("Split & Merge"):
+                    gr.HTML(SimpleIcons.SPLIT_MERGE_SYMBOL +
+                            "Split, Merge & Process PNG Frame Groups",
+                            elem_id="tabheading")
+                    SplitFrames(config, engine, log.log).render_tab()
+                    MergeFrames(config, engine, log.log).render_tab()
+                    SplitScenes(config, engine, log.log).render_tab()
+                    SliceVideo(config, engine, log.log).render_tab()
+                    StripScenes(config, engine, log.log).render_tab()
+
+            with gr.Tab("Video Blender", id=APP_TAB_VIDEO_BLENDER):
+                VideoBlender(config, engine, log.log).render_tab()
+
+            with gr.Tab(SimpleIcons.SPOTLIGHT_SYMBOL + "Video Remixer", id=APP_TAB_VIDEO_REMIXER):
+                VideoRemixer(config, engine, log.log).render_tab()
+
+            with gr.Tab(SimpleIcons.LABCOAT + "Tools", id=APP_TAB_TOOLS):
+                VideoDetails(config, engine, log.log).render_tab()
+                ResequenceFiles(config, engine, log.log).render_tab()
+                ResizeFrames(config, engine, log.log).render_tab()
+                with gr.Tab("File Conversion"):
+                    gr.HTML(SimpleIcons.HAMMER_WRENCH +
+                        "Tools for common video file conversion tasks",
                         elem_id="tabheading")
-                DuplicateFramesReport(config, engine, log.log).render_tab()
-                DuplicateTuning(config, engine, log.log).render_tab()
-                DedupeFrames(config, engine, log.log).render_tab()
-                AutofillFrames(config, engine, log.log).render_tab()
-
-            with gr.Tab("Split & Merge"):
-                gr.HTML(SimpleIcons.SPLIT_MERGE_SYMBOL +
-                        "Split, Merge & Process PNG Frame Groups",
-                        elem_id="tabheading")
-                SplitFrames(config, engine, log.log).render_tab()
-                MergeFrames(config, engine, log.log).render_tab()
-                SplitScenes(config, engine, log.log).render_tab()
-                SliceVideo(config, engine, log.log).render_tab()
-                StripScenes(config, engine, log.log).render_tab()
-        VideoBlender(config, engine, log.log).render_tab()
-        VideoRemixer(config, engine, log.log).render_tab()
-
-        with gr.Tab(SimpleIcons.LABCOAT + "Tools"):
-            VideoDetails(config, engine, log.log).render_tab()
-            ResequenceFiles(config, engine, log.log).render_tab()
-            ResizeFrames(config, engine, log.log).render_tab()
-            with gr.Tab("File Conversion"):
-                gr.HTML(SimpleIcons.HAMMER_WRENCH +
-                    "Tools for common video file conversion tasks",
-                    elem_id="tabheading")
-                MP4toPNG(config, engine, log.log).render_tab()
-                PNGtoMP4(config, engine, log.log).render_tab()
-                GIFtoPNG(config, engine, log.log).render_tab()
-                PNGtoGIF(config, engine, log.log).render_tab()
-                TransposePngFiles(config, engine, log.log).render_tab()
-                SimplifyPngFiles(config, engine, log.log).render_tab()
-                VideoAssembler(config, engine, log.log).render_tab()
-            ChangeFPS(config, engine, log.log).render_tab()
-            EnhanceFrames(config, engine, log.log).render_tab()
-            GIFtoMP4(config, engine, log.log).render_tab()
-            with gr.Tab(SimpleIcons.GEAR + "Application"):
-                LogViewer(config, engine, log.log, log).render_tab()
-                Resources(config, engine, log.log).render_tab()
-                Options(config, engine, log.log, restart_fn).render_tab()
+                    MP4toPNG(config, engine, log.log).render_tab()
+                    PNGtoMP4(config, engine, log.log).render_tab()
+                    GIFtoPNG(config, engine, log.log).render_tab()
+                    PNGtoGIF(config, engine, log.log).render_tab()
+                    TransposePngFiles(config, engine, log.log).render_tab()
+                    SimplifyPngFiles(config, engine, log.log).render_tab()
+                    VideoAssembler(config, engine, log.log).render_tab()
+                ChangeFPS(config, engine, log.log).render_tab()
+                EnhanceFrames(config, engine, log.log).render_tab()
+                GIFtoMP4(config, engine, log.log).render_tab()
+                with gr.Tab(SimpleIcons.GEAR + "Application"):
+                    LogViewer(config, engine, log.log, log).render_tab()
+                    Resources(config, engine, log.log).render_tab()
+                    Options(config, engine, log.log, restart_fn).render_tab()
 
         if config.user_interface["show_header"]:
             app_footer.render()

--- a/create_ui.py
+++ b/create_ui.py
@@ -101,10 +101,11 @@ def create_ui(config : SimpleConfig,
                     StripScenes(config, engine, log.log).render_tab()
 
             with gr.Tab("Video Blender", id=APP_TAB_VIDEO_BLENDER):
-                VideoBlender(config, engine, log.log).render_tab()
+                video_blender = VideoBlender(config, engine, log.log)
+                video_blender.render_tab()
 
             with gr.Tab(SimpleIcons.SPOTLIGHT_SYMBOL + "Video Remixer", id=APP_TAB_VIDEO_REMIXER):
-                VideoRemixer(config, engine, log.log).render_tab()
+                VideoRemixer(config, engine, log.log, main_tabs, video_blender).render_tab()
 
             with gr.Tab(SimpleIcons.LABCOAT + "Tools", id=APP_TAB_TOOLS):
                 VideoDetails(config, engine, log.log).render_tab()

--- a/tabs/video_blender_ui.py
+++ b/tabs/video_blender_ui.py
@@ -659,14 +659,24 @@ class VideoBlender(TabBase):
 
             if step2_enabled:
                 # If repair frames were synthesized, there are now two extra frames in the
-                # source set not present in the repair set: # the outermost frames.
-                # Set aside frame #0 from the source set so the sets can # remain in sync
+                # source set not present in the repair set: the outermost frames.
+                # Copy the first and last frames from the source set to the repair set
+                # to keep frames aligned
                 source_files = sorted(get_files(source_frames_path, "png"))
-                frame0_file = source_files[0]
-                _, filename, ext = split_filepath(frame0_file)
-                set_aside_path = os.path.join(new_project_path, f"{filename}-(removed for sync){ext}")
-                self.log(f"setting aside {frame0_file} as {set_aside_path}")
-                os.replace(frame0_file, set_aside_path)
+                num_files = len(source_files)
+                lower_outer_frame = source_files[0]
+                upper_outer_frame = source_files[-1]
+                num_width = len(str(num_files))
+                lower_frame = 0
+                upper_frame = num_files
+                lower_filename = f"repair_frame{str(lower_frame).zfill(num_width)}.png"
+                upper_filename = f"repair_frame{str(upper_frame).zfill(num_width)}.png"
+                lower_filepath = os.path.join(resynth_frames_path, lower_filename)
+                upper_filepath = os.path.join(resynth_frames_path, upper_filename)
+                self.log(f"duplicating source frame {lower_outer_frame} to {lower_filepath} for frame syncing")
+                shutil.copy(lower_outer_frame, lower_filepath)
+                self.log(f"duplicating source frame {upper_outer_frame} to {upper_filepath} for frame syncing")
+                shutil.copy(upper_outer_frame, upper_filepath)
 
             if self.config.blender_settings["clean_frames"]:
                 self.log(f"cleaning source files in {source_frames_path}")

--- a/tabs/video_blender_ui.py
+++ b/tabs/video_blender_ui.py
@@ -32,6 +32,24 @@ class VideoBlender(TabBase):
         self.video_blender_state = None
         self.video_blender_projects = VideoBlenderProjects(self.config.
             blender_settings["projects_file"])
+        self.video_blender_tabs = None
+        self.new_project_name = None
+        self.new_project_path = None
+        self.new_project_frame_rate = None
+        self.step1_enabled = None
+        self.step1_input = None
+        self.step2_enabled = None
+        self.step2_input = None
+        self.step3_enabled = None
+        self.step3_input = None
+        self.step4_enabled = None
+
+    TAB_PROJECT_SETTINGS = 0
+    TAB_FRAME_CHOOSER = 1
+    TAB_FRAME_FIXER = 2
+    TAB_VIDEO_PREVIEW = 3
+    TAB_NEW_PROJECT = 4
+    TAB_RESET_PROJECT = 5
 
     def render_tab(self):
         """Render tab into UI"""
@@ -40,9 +58,10 @@ class VideoBlender(TabBase):
         max_frame_rate = self.config.blender_settings["max_frame_rate"]
         # with gr.Tab("Video Blender"):
         with gr.Tabs() as tabs_video_blender:
+            self.video_blender_tabs = tabs_video_blender
 
             ### PROJECT SETTINGS
-            with gr.Tab(SimpleIcons.NOTEBOOK + "Project Settings", id=0):
+            with gr.Tab(SimpleIcons.NOTEBOOK + "Project Settings", id=self.TAB_PROJECT_SETTINGS):
                 with gr.Row():
                     with gr.Column(scale=3, variant="compact"):
                         with gr.Row():
@@ -74,7 +93,7 @@ class VideoBlender(TabBase):
                     WebuiTips.video_blender_project_settings.render()
 
             ### FRAME CHOOSER
-            with gr.Tab(SimpleIcons.CONTROLS + "Frame Chooser", id=1):
+            with gr.Tab(SimpleIcons.CONTROLS + "Frame Chooser", id=self.TAB_FRAME_CHOOSER):
                 with gr.Row():
                     with gr.Column():
                         output_prev_frame_vb = gr.Image(label="Previous Frame",
@@ -138,7 +157,7 @@ class VideoBlender(TabBase):
                         WebuiTips.video_blender_frame_chooser.render()
 
             ### FRAME FIXER
-            with gr.Tab(SimpleIcons.HAMMER + "Frame Fixer", id=2):
+            with gr.Tab(SimpleIcons.HAMMER + "Frame Fixer", id=self.TAB_FRAME_FIXER):
                 with gr.Row():
                     with gr.Column():
                         with gr.Row():
@@ -166,7 +185,7 @@ class VideoBlender(TabBase):
                     WebuiTips.video_blender_frame_fixer.render()
 
             ### VIDEO PREVIEW
-            with gr.Tab(SimpleIcons.TELEVISION + "Video Preview", id=3):
+            with gr.Tab(SimpleIcons.TELEVISION + "Video Preview", id=self.TAB_VIDEO_PREVIEW):
                 with gr.Row():
                     gr.Column(scale=1)
                     with gr.Column():
@@ -183,7 +202,7 @@ class VideoBlender(TabBase):
                     WebuiTips.video_blender_video_preview.render()
 
             ### NEW PROJECT
-            with gr.Tab(SimpleIcons.SEEDLING + "New Project", id=4):
+            with gr.Tab(SimpleIcons.SEEDLING + "New Project", id=self.TAB_NEW_PROJECT):
                 with gr.Row():
                     with gr.Column(variant="compact"):
                         gr.HTML("Define New Project")
@@ -240,7 +259,7 @@ class VideoBlender(TabBase):
                     WebuiTips.video_blender_new_project.render()
 
             ### RESET PROJECT
-            with gr.Tab(SimpleIcons.RECYCLE + "Reset Project", id=5):
+            with gr.Tab(SimpleIcons.RECYCLE + "Reset Project", id=self.TAB_RESET_PROJECT):
                 with gr.Row():
                     choices = self.video_blender_projects.get_project_names()
                     reset_project_dropdown = gr.Dropdown(label=SimpleIcons.PROP_SYMBOL +
@@ -350,6 +369,18 @@ class VideoBlender(TabBase):
                 step1_input, step2_enabled, step2_input, step3_enabled, step3_input, step4_enabled,
                 new_project_frame_rate],
             show_progress=False)
+
+        self.video_blender_tabs = tabs_video_blender
+        self.new_project_name = new_project_name
+        self.new_project_path = new_project_path
+        self.new_project_frame_rate = new_project_frame_rate
+        self.step1_enabled = step1_enabled
+        self.step1_input = step1_input
+        self.step2_enabled = step2_enabled
+        self.step2_input = step2_input
+        self.step3_enabled = step3_enabled
+        self.step3_input = step3_input
+        self.step4_enabled = step4_enabled
 
     def video_blender_load(self, project_path, frames_path1, frames_path2, main_path, fps):
         """Open Project button handler"""

--- a/tabs/video_blender_ui.py
+++ b/tabs/video_blender_ui.py
@@ -38,219 +38,219 @@ class VideoBlender(TabBase):
         skip_frames = self.config.blender_settings["skip_frames"]
         frame_rate = self.config.blender_settings["frame_rate"]
         max_frame_rate = self.config.blender_settings["max_frame_rate"]
-        with gr.Tab("Video Blender"):
-            with gr.Tabs() as tabs_video_blender:
+        # with gr.Tab("Video Blender"):
+        with gr.Tabs() as tabs_video_blender:
 
-                ### PROJECT SETTINGS
-                with gr.Tab(SimpleIcons.NOTEBOOK + "Project Settings", id=0):
-                    with gr.Row():
-                        with gr.Column(scale=3, variant="compact"):
+            ### PROJECT SETTINGS
+            with gr.Tab(SimpleIcons.NOTEBOOK + "Project Settings", id=0):
+                with gr.Row():
+                    with gr.Column(scale=3, variant="compact"):
+                        with gr.Row():
+                            input_project_name_vb = gr.Textbox(label="Project Name")
+                    with gr.Column(scale=3, variant="compact", elem_id="mainhighlightdim"):
+                        with gr.Row():
+                            choices = self.video_blender_projects.get_project_names()
+                            projects_dropdown_vb = gr.Dropdown(label=SimpleIcons.PROP_SYMBOL +
+                                " Saved Projects", choices=choices, value=choices[0])
+                            save_project_button_vb = gr.Button(SimpleIcons.PROP_SYMBOL +
+                                " Save", scale=0)
+                with gr.Row():
+                    input_main_path = gr.Textbox(label="Project Main Path",
+                                                    placeholder="Root path for the project")
+                    input_project_frame_rate = gr.Slider(value=frame_rate, minimum=1,
+                                        maximum=max_frame_rate, step=0.01, label="Frame Rate")
+                with gr.Row():
+                    input_project_path_vb = gr.Textbox(label="Project Frames Path",
+                        placeholder="Path to frame PNG files for video being restored")
+                with gr.Row():
+                    input_path1_vb = gr.Textbox(label="Original / Video #1 Frames Path",
+                        placeholder="Path to original or video #1 PNG files")
+                with gr.Row():
+                    input_path2_vb = gr.Textbox(label="Alternate / Video #2 Frames Path",
+                        placeholder="Path to alternate or video #2 PNG files")
+                load_button_vb = gr.Button("Open Video Blender Project " +
+                    SimpleIcons.ROCKET, variant="primary")
+                with gr.Accordion(SimpleIcons.TIPS_SYMBOL + " Guide", open=False):
+                    WebuiTips.video_blender_project_settings.render()
+
+            ### FRAME CHOOSER
+            with gr.Tab(SimpleIcons.CONTROLS + "Frame Chooser", id=1):
+                with gr.Row():
+                    with gr.Column():
+                        output_prev_frame_vb = gr.Image(label="Previous Frame",
+                            interactive=False, type="filepath", elem_id="sideimage", height=300)
+                    with gr.Column():
+                        output_curr_frame_vb = gr.Image(show_label=False,
+                            interactive=False, type="filepath", elem_id="actionimage", height=300)
+                    with gr.Column():
+                        output_next_frame_vb = gr.Image(label="Next Frame",
+                            interactive=False, type="filepath", elem_id="sideimage", height=300)
+                with gr.Row():
+                    with gr.Column():
+                        gr.Row()
+                        with gr.Row(variant="panel", elem_id="highlightbutton"):
+                            fix_frames_count = gr.Number(label="FIX ADJACENT DAMAGED FRAMES: " +
+                                SimpleIcons.ONE + " Go to the first damaged frame " +
+                                SimpleIcons.TWO + " Set count of damaged frames " +
+                                SimpleIcons.THREE + " Click Go To Frame Fixer", value=0,
+                                precision=0)
                             with gr.Row():
-                                input_project_name_vb = gr.Textbox(label="Project Name")
-                        with gr.Column(scale=3, variant="compact", elem_id="mainhighlightdim"):
-                            with gr.Row():
-                                choices = self.video_blender_projects.get_project_names()
-                                projects_dropdown_vb = gr.Dropdown(label=SimpleIcons.PROP_SYMBOL +
-                                    " Saved Projects", choices=choices, value=choices[0])
-                                save_project_button_vb = gr.Button(SimpleIcons.PROP_SYMBOL +
-                                    " Save", scale=0)
-                    with gr.Row():
-                        input_main_path = gr.Textbox(label="Project Main Path",
-                                                     placeholder="Root path for the project")
-                        input_project_frame_rate = gr.Slider(value=frame_rate, minimum=1,
-                                            maximum=max_frame_rate, step=0.01, label="Frame Rate")
-                    with gr.Row():
-                        input_project_path_vb = gr.Textbox(label="Project Frames Path",
-                            placeholder="Path to frame PNG files for video being restored")
-                    with gr.Row():
-                        input_path1_vb = gr.Textbox(label="Original / Video #1 Frames Path",
-                            placeholder="Path to original or video #1 PNG files")
-                    with gr.Row():
-                        input_path2_vb = gr.Textbox(label="Alternate / Video #2 Frames Path",
-                            placeholder="Path to alternate or video #2 PNG files")
-                    load_button_vb = gr.Button("Open Video Blender Project " +
-                        SimpleIcons.ROCKET, variant="primary")
+                                fix_frames_last_before = gr.Number(
+                                    label="Last Frame Before Damage", value=0, precision=0,
+                                    interactive=False)
+                                fix_frames_first_after = gr.Number(
+                                    label="First Frame After Damage", value=0, precision=0,
+                                    interactive=False)
+                            fix_frames_button_vb = gr.Button("Go To " + SimpleIcons.HAMMER
+                                                                + " Frame Fixer")
+                        with gr.Row():
+                            preview_video_vb = gr.Button("Go To "  + SimpleIcons.TELEVISION
+                                                            + " Video Preview")
+
+                    with gr.Column():
+                        with gr.Tabs():
+                            with gr.Tab(label="Repair / Path 2 Frame"):
+                                output_img_path2_vb = gr.Image(show_label=False,
+                                    interactive=False, type="filepath", height=300)
+                            with gr.Tab(label="Original / Path 1 Frame"):
+                                output_img_path1_vb = gr.Image(show_label=False,
+                                    interactive=False, type="filepath", height=300)
+
+                    with gr.Column():
+                        gr.Row()
+                        use_path_1_button_vb = gr.Button("Use Path 1 Frame | Next >",
+                            variant="primary", elem_id="actionbutton")
+                        use_path_2_button_vb = gr.Button("Use Path 2 Frame | Next >",
+                            variant="primary", elem_id="actionbutton")
+                        with gr.Row():
+                            prev_frame_button_vb = gr.Button("< Prev Frame",
+                                variant="primary")
+                            next_frame_button_vb = gr.Button("Next Frame >",
+                                variant="primary")
+                        with gr.Row():
+                            prev_xframes_button_vb = gr.Button(f"<< {skip_frames}")
+                            next_xframes_button_vb = gr.Button(f"{skip_frames} >>")
+                        input_text_frame_vb = gr.Number(value=0, precision=0,
+                            label="Frame Number")
+
+                if self.config.user_interface["show_header"]:
                     with gr.Accordion(SimpleIcons.TIPS_SYMBOL + " Guide", open=False):
-                        WebuiTips.video_blender_project_settings.render()
+                        WebuiTips.video_blender_frame_chooser.render()
 
-                ### FRAME CHOOSER
-                with gr.Tab(SimpleIcons.CONTROLS + "Frame Chooser", id=1):
-                    with gr.Row():
-                        with gr.Column():
-                            output_prev_frame_vb = gr.Image(label="Previous Frame",
-                                interactive=False, type="filepath", elem_id="sideimage", height=300)
-                        with gr.Column():
-                            output_curr_frame_vb = gr.Image(show_label=False,
-                                interactive=False, type="filepath", elem_id="actionimage", height=300)
-                        with gr.Column():
-                            output_next_frame_vb = gr.Image(label="Next Frame",
-                                interactive=False, type="filepath", elem_id="sideimage", height=300)
-                    with gr.Row():
-                        with gr.Column():
-                            gr.Row()
-                            with gr.Row(variant="panel", elem_id="highlightbutton"):
-                                fix_frames_count = gr.Number(label="FIX ADJACENT DAMAGED FRAMES: " +
-                                    SimpleIcons.ONE + " Go to the first damaged frame " +
-                                    SimpleIcons.TWO + " Set count of damaged frames " +
-                                    SimpleIcons.THREE + " Click Go To Frame Fixer", value=0,
-                                    precision=0)
+            ### FRAME FIXER
+            with gr.Tab(SimpleIcons.HAMMER + "Frame Fixer", id=2):
+                with gr.Row():
+                    with gr.Column():
+                        with gr.Row():
+                            project_path_ff = gr.Text(label="Video Blender Project Path",
+                                placeholder="Path to video frame PNG files")
+                        with gr.Row():
+                            input_clean_before_ff = gr.Number(
+                                label="Last clean frame BEFORE damaged ones", value=0,
+                                precision=0)
+                            input_clean_after_ff = gr.Number(
+                                label="First clean frame AFTER damaged ones", value=0,
+                                precision=0)
+                        with gr.Row():
+                            preview_button_ff = gr.Button(value="Preview Fixed Frames",
+                                variant="primary", elem_id="highlightbutton")
+                    with gr.Column():
+                        preview_image_ff = gr.Image(type="filepath",
+                            label="Fixed Frames Preview", interactive=False,
+                            elem_id="highlightoutput", height=300)
+                        fixed_path_ff = gr.Text(label="Path to Restored Frames",
+                            interactive=False)
+                        use_fixed_button_ff = gr.Button(value="Apply Fixed Frames",
+                            elem_id="actionbutton")
+                with gr.Accordion(SimpleIcons.TIPS_SYMBOL + " Guide", open=False):
+                    WebuiTips.video_blender_frame_fixer.render()
+
+            ### VIDEO PREVIEW
+            with gr.Tab(SimpleIcons.TELEVISION + "Video Preview", id=3):
+                with gr.Row():
+                    gr.Column(scale=1)
+                    with gr.Column():
+                        video_preview_vb = gr.Video(label="Preview", interactive=False,
+                            include_audio=False, width=800, container=True, scale=8)
+                    gr.Column(scale=1)
+                preview_path_vb = gr.Textbox(max_lines=1, label="Path to PNG Sequence",
+                    placeholder="Path on this server to the PNG files to be converted")
+                with gr.Row():
+                    render_video_vb = gr.Button("Render Video", variant="primary")
+                    input_frame_rate_vb = gr.Slider(value=frame_rate, minimum=1,
+                                        maximum=max_frame_rate, step=0.01, label="Frame Rate")
+                with gr.Accordion(SimpleIcons.TIPS_SYMBOL + " Guide", open=False):
+                    WebuiTips.video_blender_video_preview.render()
+
+            ### NEW PROJECT
+            with gr.Tab(SimpleIcons.SEEDLING + "New Project", id=4):
+                with gr.Row():
+                    with gr.Column(variant="compact"):
+                        gr.HTML("Define New Project")
+                        with gr.Row(variant="panel"):
+                            with gr.Column(scale=1):
+                                new_project_name = gr.Textbox(max_lines=1,
+                                    label="New Project Name",
+                                    placeholder="Name for the new project")
+                            with gr.Column(scale=12):
+                                new_project_path = gr.Textbox(max_lines=1,
+                                    label="New Project Path",
+                                    placeholder="Path on this server for the new project")
+                            with gr.Column(scale=1):
+                                new_project_frame_rate = gr.Slider(value=frame_rate, minimum=1,
+                                        maximum=max_frame_rate, step=0.01, label="Frame Rate")
+                with gr.Row():
+                    with gr.Column(variant="compact"):
+                        gr.HTML("Check Applicable Setup Steps")
+                        with gr.Row(variant="panel"):
+                            with gr.Column(scale=1):
+                                step1_enabled = gr.Checkbox(value=True, label=SimpleIcons.ONE +
+                                                            " Split MP4 to PNG Frames Set")
+                            with gr.Column(scale=12):
                                 with gr.Row():
-                                    fix_frames_last_before = gr.Number(
-                                        label="Last Frame Before Damage", value=0, precision=0,
-                                        interactive=False)
-                                    fix_frames_first_after = gr.Number(
-                                        label="First Frame After Damage", value=0, precision=0,
-                                        interactive=False)
-                                fix_frames_button_vb = gr.Button("Go To " + SimpleIcons.HAMMER
-                                                                 + " Frame Fixer")
-                            with gr.Row():
-                                preview_video_vb = gr.Button("Go To "  + SimpleIcons.TELEVISION
-                                                             + " Video Preview")
+                                    step1_input = gr.Textbox(max_lines=1, interactive=True,
+                                        label="MP4 Path",
+                                        placeholder="Path on this server to the source MP4 file")
+                        with gr.Row(variant="panel"):
+                            with gr.Column(scale=1):
+                                step2_enabled = gr.Checkbox(value=True, label=SimpleIcons.TWO +
+                                                            " Resynthesize Repair Frames Set")
+                            with gr.Column(scale=12):
+                                step2_input = gr.Textbox(max_lines=1, interactive=False,
+                                    label="n/a",
+                                placeholder="Repair frames set will be automatically created")
+                        with gr.Row(variant="panel"):
+                            with gr.Column(scale=1):
+                                step3_enabled = gr.Checkbox(value=True, label=SimpleIcons.THREE
+                                                            + " Init Restored Set from Source")
+                            with gr.Column(scale=12):
+                                step3_input = gr.Textbox(max_lines=1, interactive=False,
+                                    label="n/a",
+                                placeholder="Restored frames set will be automatically created")
+                        with gr.Row(variant="panel"):
+                            with gr.Column(scale=1):
+                                step4_enabled = gr.Checkbox(value=True, label=SimpleIcons.FOUR +
+                                                            " Sync Frame Numbers Across Sets")
+                            with gr.Column(scale=12):
+                                gr.Textbox(visible=False)
+                gr.Markdown("*Progress can be tracked in the console*")
+                new_project_button = gr.Button("Create New Project " + SimpleIcons.SLOW_SYMBOL,
+                                                variant="primary")
+                with gr.Accordion(SimpleIcons.TIPS_SYMBOL + " Guide", open=False):
+                    WebuiTips.video_blender_new_project.render()
 
-                        with gr.Column():
-                            with gr.Tabs():
-                                with gr.Tab(label="Repair / Path 2 Frame"):
-                                    output_img_path2_vb = gr.Image(show_label=False,
-                                        interactive=False, type="filepath", height=300)
-                                with gr.Tab(label="Original / Path 1 Frame"):
-                                    output_img_path1_vb = gr.Image(show_label=False,
-                                        interactive=False, type="filepath", height=300)
-
-                        with gr.Column():
-                            gr.Row()
-                            use_path_1_button_vb = gr.Button("Use Path 1 Frame | Next >",
-                                variant="primary", elem_id="actionbutton")
-                            use_path_2_button_vb = gr.Button("Use Path 2 Frame | Next >",
-                                variant="primary", elem_id="actionbutton")
-                            with gr.Row():
-                                prev_frame_button_vb = gr.Button("< Prev Frame",
-                                    variant="primary")
-                                next_frame_button_vb = gr.Button("Next Frame >",
-                                    variant="primary")
-                            with gr.Row():
-                                prev_xframes_button_vb = gr.Button(f"<< {skip_frames}")
-                                next_xframes_button_vb = gr.Button(f"{skip_frames} >>")
-                            input_text_frame_vb = gr.Number(value=0, precision=0,
-                                label="Frame Number")
-
-                    if self.config.user_interface["show_header"]:
-                        with gr.Accordion(SimpleIcons.TIPS_SYMBOL + " Guide", open=False):
-                            WebuiTips.video_blender_frame_chooser.render()
-
-                ### FRAME FIXER
-                with gr.Tab(SimpleIcons.HAMMER + "Frame Fixer", id=2):
-                    with gr.Row():
-                        with gr.Column():
-                            with gr.Row():
-                                project_path_ff = gr.Text(label="Video Blender Project Path",
-                                    placeholder="Path to video frame PNG files")
-                            with gr.Row():
-                                input_clean_before_ff = gr.Number(
-                                    label="Last clean frame BEFORE damaged ones", value=0,
-                                    precision=0)
-                                input_clean_after_ff = gr.Number(
-                                    label="First clean frame AFTER damaged ones", value=0,
-                                    precision=0)
-                            with gr.Row():
-                                preview_button_ff = gr.Button(value="Preview Fixed Frames",
-                                    variant="primary", elem_id="highlightbutton")
-                        with gr.Column():
-                            preview_image_ff = gr.Image(type="filepath",
-                                label="Fixed Frames Preview", interactive=False,
-                                elem_id="highlightoutput", height=300)
-                            fixed_path_ff = gr.Text(label="Path to Restored Frames",
-                                interactive=False)
-                            use_fixed_button_ff = gr.Button(value="Apply Fixed Frames",
-                                elem_id="actionbutton")
-                    with gr.Accordion(SimpleIcons.TIPS_SYMBOL + " Guide", open=False):
-                        WebuiTips.video_blender_frame_fixer.render()
-
-                ### VIDEO PREVIEW
-                with gr.Tab(SimpleIcons.TELEVISION + "Video Preview", id=3):
-                    with gr.Row():
-                        gr.Column(scale=1)
-                        with gr.Column():
-                            video_preview_vb = gr.Video(label="Preview", interactive=False,
-                                include_audio=False, width=800, container=True, scale=8)
-                        gr.Column(scale=1)
-                    preview_path_vb = gr.Textbox(max_lines=1, label="Path to PNG Sequence",
-                        placeholder="Path on this server to the PNG files to be converted")
-                    with gr.Row():
-                        render_video_vb = gr.Button("Render Video", variant="primary")
-                        input_frame_rate_vb = gr.Slider(value=frame_rate, minimum=1,
-                                            maximum=max_frame_rate, step=0.01, label="Frame Rate")
-                    with gr.Accordion(SimpleIcons.TIPS_SYMBOL + " Guide", open=False):
-                        WebuiTips.video_blender_video_preview.render()
-
-                ### NEW PROJECT
-                with gr.Tab(SimpleIcons.SEEDLING + "New Project", id=4):
-                    with gr.Row():
-                        with gr.Column(variant="compact"):
-                            gr.HTML("Define New Project")
-                            with gr.Row(variant="panel"):
-                                with gr.Column(scale=1):
-                                    new_project_name = gr.Textbox(max_lines=1,
-                                        label="New Project Name",
-                                        placeholder="Name for the new project")
-                                with gr.Column(scale=12):
-                                    new_project_path = gr.Textbox(max_lines=1,
-                                        label="New Project Path",
-                                        placeholder="Path on this server for the new project")
-                                with gr.Column(scale=1):
-                                    new_project_frame_rate = gr.Slider(value=frame_rate, minimum=1,
-                                            maximum=max_frame_rate, step=0.01, label="Frame Rate")
-                    with gr.Row():
-                        with gr.Column(variant="compact"):
-                            gr.HTML("Check Applicable Setup Steps")
-                            with gr.Row(variant="panel"):
-                                with gr.Column(scale=1):
-                                    step1_enabled = gr.Checkbox(value=True, label=SimpleIcons.ONE +
-                                                                " Split MP4 to PNG Frames Set")
-                                with gr.Column(scale=12):
-                                    with gr.Row():
-                                        step1_input = gr.Textbox(max_lines=1, interactive=True,
-                                            label="MP4 Path",
-                                            placeholder="Path on this server to the source MP4 file")
-                            with gr.Row(variant="panel"):
-                                with gr.Column(scale=1):
-                                    step2_enabled = gr.Checkbox(value=True, label=SimpleIcons.TWO +
-                                                                " Resynthesize Repair Frames Set")
-                                with gr.Column(scale=12):
-                                    step2_input = gr.Textbox(max_lines=1, interactive=False,
-                                        label="n/a",
-                                    placeholder="Repair frames set will be automatically created")
-                            with gr.Row(variant="panel"):
-                                with gr.Column(scale=1):
-                                    step3_enabled = gr.Checkbox(value=True, label=SimpleIcons.THREE
-                                                                + " Init Restored Set from Source")
-                                with gr.Column(scale=12):
-                                    step3_input = gr.Textbox(max_lines=1, interactive=False,
-                                        label="n/a",
-                                    placeholder="Restored frames set will be automatically created")
-                            with gr.Row(variant="panel"):
-                                with gr.Column(scale=1):
-                                    step4_enabled = gr.Checkbox(value=True, label=SimpleIcons.FOUR +
-                                                                " Sync Frame Numbers Across Sets")
-                                with gr.Column(scale=12):
-                                    gr.Textbox(visible=False)
-                    gr.Markdown("*Progress can be tracked in the console*")
-                    new_project_button = gr.Button("Create New Project " + SimpleIcons.SLOW_SYMBOL,
-                                                   variant="primary")
-                    with gr.Accordion(SimpleIcons.TIPS_SYMBOL + " Guide", open=False):
-                        WebuiTips.video_blender_new_project.render()
-
-                ### RESET PROJECT
-                with gr.Tab(SimpleIcons.RECYCLE + "Reset Project", id=5):
-                    with gr.Row():
-                        choices = self.video_blender_projects.get_project_names()
-                        reset_project_dropdown = gr.Dropdown(label=SimpleIcons.PROP_SYMBOL +
-                            " Projects", choices=choices, value=choices[0])
-                    gr.Markdown(
-                "*Reset Project uses the New Project tab to selectively revert parts of a project*")
-                    with gr.Row():
-                        reset_project_button = gr.Button("Reset Project", variant="primary")
-                    with gr.Accordion(SimpleIcons.TIPS_SYMBOL + " Guide", open=False):
-                        WebuiTips.video_blender_reset_project.render()
+            ### RESET PROJECT
+            with gr.Tab(SimpleIcons.RECYCLE + "Reset Project", id=5):
+                with gr.Row():
+                    choices = self.video_blender_projects.get_project_names()
+                    reset_project_dropdown = gr.Dropdown(label=SimpleIcons.PROP_SYMBOL +
+                        " Projects", choices=choices, value=choices[0])
+                gr.Markdown(
+            "*Reset Project uses the New Project tab to selectively revert parts of a project*")
+                with gr.Row():
+                    reset_project_button = gr.Button("Reset Project", variant="primary")
+                with gr.Accordion(SimpleIcons.TIPS_SYMBOL + " Guide", open=False):
+                    WebuiTips.video_blender_reset_project.render()
 
         projects_dropdown_vb.change(self.video_blender_choose_project,
             inputs=[projects_dropdown_vb],

--- a/tabs/video_remixer_ui.py
+++ b/tabs/video_remixer_ui.py
@@ -19,14 +19,19 @@ from webui_utils.mtqdm import Mtqdm
 from webui_utils.session import Session
 from ffmpy import FFRuntimeError
 from resequence_files import ResequenceFiles
+from .video_blender_ui import VideoBlender
 
 class VideoRemixer(TabBase):
     """Encapsulates UI elements and events for the Video Remixer Feature"""
     def __init__(self,
                  config : SimpleConfig,
                  engine : InterpolateEngine,
-                 log_fn : Callable):
+                 log_fn : Callable,
+                 main_tabs : any,
+                 video_blender : VideoBlender):
         TabBase.__init__(self, config, engine, log_fn)
+        self.main_tabs = main_tabs
+        self.video_blender = video_blender
         self.new_project()
 
     # TODO this only runs at app start-up
@@ -51,6 +56,7 @@ class VideoRemixer(TabBase):
     TAB_EXTRA_CLEANSE_SCENES = 4
     TAB_EXTRA_MANAGE_STORAGE = 5
     TAB_EXTRA_MERGE_RANGE = 6
+    TAB_EXTRA_VIDEO_BLEND_SCENE = 7
 
     TAB00_DEFAULT_MESSAGE = "Click New Project to: Inspect Video and Count Frames (can take a minute or more)"
     TAB01_DEFAULT_MESSAGE = "Click Open Project to: Resume Editing an Existing Project"
@@ -530,6 +536,19 @@ class VideoRemixer(TabBase):
                         cleanse_button704 = gr.Button(
                         "Cleanse Scenes " + SimpleIcons.SLOW_SYMBOL, variant="stop", scale=0)
 
+                    # EXPORT TO VIDEO BLENDER
+                    with gr.Tab(SimpleIcons.MICROSCOPE + " Video Blend Scene",
+                                id=self.TAB_EXTRA_VIDEO_BLEND_SCENE):
+                        gr.Markdown(
+                    "**_Create a Video Blender project for advanced scene restoration_**")
+                        scene_id_707 = gr.Number(value=-1, label="Scene Index")
+                        with gr.Row():
+                            message_box707 = gr.Markdown(
+                                format_markdown(
+                "Click Video Blend Scene to: Create a Video Blender project for the scene"))
+                        export_button707 = gr.Button(
+                    "Video Blend Scene " + SimpleIcons.SLOW_SYMBOL, variant="stop", scale=0)
+
                     # DROP PROCESSED SCENE
                     with gr.Tab(SimpleIcons.BROKEN_HEART + " Drop Processed Scene",
                                 id=self.TAB_EXTRA_DROP_PROCESSED):
@@ -993,6 +1012,22 @@ class VideoRemixer(TabBase):
                                outputs=[tabs_video_remixer, message_box706, scene_index,
                                         scene_name, scene_image, scene_state, scene_info,
                                         set_scene_label])
+
+        export_button707.click(self.export_button707,
+                               inputs=scene_id_707,
+                               outputs=[message_box707,
+                                        self.main_tabs,
+                                        self.video_blender.video_blender_tabs,
+                                        self.video_blender.new_project_name,
+                                        self.video_blender.new_project_path,
+                                        self.video_blender.new_project_frame_rate,
+                                        self.video_blender.step1_enabled,
+                                        self.video_blender.step1_input,
+                                        self.video_blender.step2_enabled,
+                                        self.video_blender.step2_input,
+                                        self.video_blender.step3_enabled,
+                                        self.video_blender.step3_input,
+                                        self.video_blender.step4_enabled])
 
         delete_button710.click(self.delete_button710,
                                inputs=delete_purged_710,
@@ -2671,6 +2706,35 @@ class VideoRemixer(TabBase):
                 *self.scene_chooser_details(self.state.current_scene)
         else:
             return gr.update(selected=self.TAB_REMIX_EXTRA), format_markdown(report), *empty_args
+
+    APP_TAB_VIDEO_BLENDER=4
+
+    def export_button707(self, scene_index):
+        return format_markdown("testing"), \
+            gr.update(selected=self.APP_TAB_VIDEO_BLENDER), \
+            gr.update(selected=VideoBlender.TAB_NEW_PROJECT), \
+            "new project name", \
+            "new project path", \
+            12.34, \
+            False, \
+            "existing frames path", \
+            True, \
+            None, \
+            True, \
+            None, \
+            True
+        #                        outputs=[message_box707,
+        #                                 self.video_blender.video_blender_tabs,
+        #                                 self.video_blender.new_project_name,
+        #                                 self.video_blender.new_project_path,
+        #                                 self.video_blender.new_project_frame_rate,
+        #                                 self.video_blender.step_1_enabled,
+        #                                 self.video_blender.step_1_input,
+        #                                 self.video_blender.step_2_enabled,
+        #                                 self.video_blender.step_2_input,
+        #                                 self.video_blender.step_3_enabled,
+        #                                 self.video_blender.step_3_input,
+        #                                 self.video_blender.step_4_enabled])
 
     def delete_button710(self, delete_purged):
         if delete_purged:

--- a/tabs/video_remixer_ui.py
+++ b/tabs/video_remixer_ui.py
@@ -2727,9 +2727,15 @@ class VideoRemixer(TabBase):
         _, filename, _ = split_filepath(self.state.project_path)
         scene_name = self.state.scene_names[scene_index]
         vb_project_name = f"{filename} {scene_name}"
-        vb_project_path = os.path.join(self.state.project_path, vb_project_name)
-        scene_path = os.path.join(self.state.scenes_path, scene_name)
+        vb_project_path_name = f"vb_project {scene_name}"
+        vb_project_path = os.path.join(self.state.project_path, vb_project_path_name)
+        self.log(f"creating video blender project directory {vb_project_path}")
         create_directory(vb_project_path)
+
+        scene_path = os.path.join(self.state.scenes_path, scene_name)
+        original_frames_path = os.path.join(vb_project_path, "original_frames")
+        self.log(f"duplicating files from {scene_path} to {original_frames_path}")
+        duplicate_directory(scene_path, original_frames_path)
 
         return format_markdown("testing"), \
             gr.update(selected=self.APP_TAB_VIDEO_BLENDER), \
@@ -2738,11 +2744,11 @@ class VideoRemixer(TabBase):
             vb_project_path, \
             self.state.project_fps, \
             False, \
+            original_frames_path, \
+            True, \
+            None, \
+            False, \
             scene_path, \
-            True, \
-            None, \
-            True, \
-            None, \
             True
 
     def delete_button710(self, delete_purged):

--- a/tabs/video_remixer_ui.py
+++ b/tabs/video_remixer_ui.py
@@ -2711,17 +2711,21 @@ class VideoRemixer(TabBase):
     APP_TAB_VIDEO_REMIXER=5
 
     def export_button707(self, scene_index):
-        empty_args = self.empty_args(12)
+        empty_args = self.empty_args(10)
         num_scenes = len(self.state.scene_names)
         last_scene = num_scenes - 1
 
         if not isinstance(scene_index, (int, float)):
             return gr.update(value=format_markdown(f"Please enter a Scene Index to get started", "warning")), \
+                gr.update(selected=self.APP_TAB_VIDEO_REMIXER), \
+                gr.update(selected=VideoBlender.TAB_NEW_PROJECT), \
                 *empty_args
 
         scene_index = int(scene_index)
         if scene_index < 0 or scene_index > last_scene:
             return gr.update(value=format_markdown(f"Please enter a Scene Index from 0 to {last_scene}", "warning")), \
+                gr.update(selected=self.APP_TAB_VIDEO_REMIXER), \
+                gr.update(selected=VideoBlender.TAB_NEW_PROJECT), \
                 *empty_args
 
         _, filename, _ = split_filepath(self.state.project_path)

--- a/tabs/video_remixer_ui.py
+++ b/tabs/video_remixer_ui.py
@@ -19,7 +19,7 @@ from webui_utils.mtqdm import Mtqdm
 from webui_utils.session import Session
 from ffmpy import FFRuntimeError
 from resequence_files import ResequenceFiles
-from . import video_blender_ui as VideoBlender
+from .video_blender_ui import VideoBlender
 
 class VideoRemixer(TabBase):
     """Encapsulates UI elements and events for the Video Remixer Feature"""
@@ -2710,6 +2710,12 @@ class VideoRemixer(TabBase):
     APP_TAB_VIDEO_BLENDER=4
 
     def export_button707(self, scene_index):
+
+
+
+        # _, filename, _ = split_filepath(self.state.project_filepath)
+        # project_name =
+
         return format_markdown("testing"), \
             gr.update(selected=self.APP_TAB_VIDEO_BLENDER), \
             gr.update(selected=VideoBlender.TAB_NEW_PROJECT), \

--- a/tabs/video_remixer_ui.py
+++ b/tabs/video_remixer_ui.py
@@ -2741,7 +2741,7 @@ class VideoRemixer(TabBase):
         self.log(f"duplicating files from {scene_path} to {original_frames_path}")
         duplicate_directory(scene_path, original_frames_path)
 
-        return format_markdown("testing"), \
+        return format_markdown(f"Ready to continue on Video Blender New Project tab"), \
             gr.update(selected=self.APP_TAB_VIDEO_BLENDER), \
             gr.update(selected=VideoBlender.TAB_NEW_PROJECT), \
             vb_project_name, \

--- a/tabs/video_remixer_ui.py
+++ b/tabs/video_remixer_ui.py
@@ -19,7 +19,7 @@ from webui_utils.mtqdm import Mtqdm
 from webui_utils.session import Session
 from ffmpy import FFRuntimeError
 from resequence_files import ResequenceFiles
-from .video_blender_ui import VideoBlender
+from . import video_blender_ui as VideoBlender
 
 class VideoRemixer(TabBase):
     """Encapsulates UI elements and events for the Video Remixer Feature"""

--- a/tabs/video_remixer_ui.py
+++ b/tabs/video_remixer_ui.py
@@ -2708,39 +2708,42 @@ class VideoRemixer(TabBase):
             return gr.update(selected=self.TAB_REMIX_EXTRA), format_markdown(report), *empty_args
 
     APP_TAB_VIDEO_BLENDER=4
+    APP_TAB_VIDEO_REMIXER=5
 
     def export_button707(self, scene_index):
+        empty_args = self.empty_args(12)
+        num_scenes = len(self.state.scene_names)
+        last_scene = num_scenes - 1
 
+        if not isinstance(scene_index, (int, float)):
+            return gr.update(value=format_markdown(f"Please enter a Scene Index to get started", "warning")), \
+                *empty_args
 
+        scene_index = int(scene_index)
+        if scene_index < 0 or scene_index > last_scene:
+            return gr.update(value=format_markdown(f"Please enter a Scene Index from 0 to {last_scene}", "warning")), \
+                *empty_args
 
-        # _, filename, _ = split_filepath(self.state.project_filepath)
-        # project_name =
+        _, filename, _ = split_filepath(self.state.project_path)
+        scene_name = self.state.scene_names[scene_index]
+        vb_project_name = f"{filename} {scene_name}"
+        vb_project_path = os.path.join(self.state.project_path, vb_project_name)
+        scene_path = os.path.join(self.state.scenes_path, scene_name)
+        create_directory(vb_project_path)
 
         return format_markdown("testing"), \
             gr.update(selected=self.APP_TAB_VIDEO_BLENDER), \
             gr.update(selected=VideoBlender.TAB_NEW_PROJECT), \
-            "new project name", \
-            "new project path", \
-            12.34, \
+            vb_project_name, \
+            vb_project_path, \
+            self.state.project_fps, \
             False, \
-            "existing frames path", \
+            scene_path, \
             True, \
             None, \
             True, \
             None, \
             True
-        #                        outputs=[message_box707,
-        #                                 self.video_blender.video_blender_tabs,
-        #                                 self.video_blender.new_project_name,
-        #                                 self.video_blender.new_project_path,
-        #                                 self.video_blender.new_project_frame_rate,
-        #                                 self.video_blender.step_1_enabled,
-        #                                 self.video_blender.step_1_input,
-        #                                 self.video_blender.step_2_enabled,
-        #                                 self.video_blender.step_2_input,
-        #                                 self.video_blender.step_3_enabled,
-        #                                 self.video_blender.step_3_input,
-        #                                 self.video_blender.step_4_enabled])
 
     def delete_button710(self, delete_purged):
         if delete_purged:

--- a/tabs/video_remixer_ui.py
+++ b/tabs/video_remixer_ui.py
@@ -547,7 +547,7 @@ class VideoRemixer(TabBase):
                                 format_markdown(
                 "Click Video Blend Scene to: Create a Video Blender project for the scene"))
                         export_button707 = gr.Button(
-                    "Video Blend Scene " + SimpleIcons.SLOW_SYMBOL, variant="stop", scale=0)
+                    "Video Blend Scene", variant="stop", scale=0)
 
                     # DROP PROCESSED SCENE
                     with gr.Tab(SimpleIcons.BROKEN_HEART + " Drop Processed Scene",


### PR DESCRIPTION
A new Remix Extra tab _Video Blend Scene_
- Sets up a _Video Blender_ project directory for the scene within the Video Remixer project folder
- Duplicates the selected scene's frames as the Video Blender _original frame set_
- Takes user to the Video Blender _New Project_ tab with all settings in place to create a video blender project
- Once created the project will have a set of _Resynthesized_ frames for individual frame repair
- Video Blender's _Frame Fixer_ can be used to fix a series' of damaged frames
- The _restore frame set_ is set as the Video Remixer _Scene_ directory, so all frame repairs are immediately available in the Video Remixer project
