### PR TITLE
Video Remixer: Fix labeling regression

### DIFF
--- a/tabs/video_remixer_ui.py
+++ b/tabs/video_remixer_ui.py
@@ -1807,12 +1807,7 @@ class VideoRemixer(TabBase):
             draw_text_options["marked_position"] = self.config.remixer_settings["marked_position"]
 
             # account for upscaling
-            upscale_factor = 1
-            if self.state.upscale:
-                if self.state.upscale_option == "2X":
-                    upscale_factor = 2
-                elif self.state.upscale_option == "4X":
-                    upscale_factor = 4
+            upscale_factor = self.state.upscale_factor_from_options()
             draw_text_options["crop_width"] = self.state.crop_w * upscale_factor
             draw_text_options["crop_height"] = self.state.crop_h * upscale_factor
 
@@ -1881,12 +1876,7 @@ class VideoRemixer(TabBase):
             draw_text_options["marked_position"] = label_position
 
             # account for upscaling
-            upscale_factor = 1
-            if self.state.upscale:
-                if self.state.upscale_option == "2X":
-                    upscale_factor = 2
-                elif self.state.upscale_option == "4X":
-                    upscale_factor = 4
+            upscale_factor = self.state.upscale_factor_from_options()
             draw_text_options["crop_width"] = self.state.crop_w * upscale_factor
             draw_text_options["crop_height"] = self.state.crop_h * upscale_factor
 


### PR DESCRIPTION
Labels were coming out oversized when any upscale option was set other than 1X even if not using upscaling.