### PR TITLE
Video Remixer: fixing subtle issue opening ported older projects

### DIFF
--- a/tabs/video_remixer_ui.py
+++ b/tabs/video_remixer_ui.py
@@ -2452,6 +2452,13 @@ class VideoRemixer(TabBase):
         self.log(f"creating downsample directory {working_path}")
         create_directory(downsample_path)
 
+        # the native size of the on-disk PNG frames is needed
+        # older project.yaml files won't have this data
+        try:
+            self.state.enhance_video_info(self.log, ignore_errors=False)
+        except ValueError as error:
+            return gr.update(value=format_markdown(f"Error: {error}", "error"))
+
         content_width = self.state.video_details["source_width"]
         content_height = self.state.video_details["source_height"]
         scale_type = self.config.remixer_settings["scale_type_down"]

--- a/tabs/video_remixer_ui.py
+++ b/tabs/video_remixer_ui.py
@@ -175,7 +175,7 @@ class VideoRemixer(TabBase):
                             crop_h = gr.Number(label="Crop Height")
                         with gr.Accordion(label="More Settings", open=False):
                             with gr.Row():
-                                crop_offset_x = gr.Number(label="Crop X Ofset", value=-1, info="Set to -1 for auto-centering")
+                                crop_offset_x = gr.Number(label="Crop X Offset", value=-1, info="Set to -1 for auto-centering")
                                 crop_offset_y = gr.Number(label="Crop Y Offset", value=-1, info="Set to -1 for auto-centering")
 
                 message_box1 = gr.Markdown(value=format_markdown(self.TAB1_DEFAULT_MESSAGE))

--- a/video_remixer.py
+++ b/video_remixer.py
@@ -439,7 +439,7 @@ class VideoRemixerState():
     # this is intended to be called after source frames have been rendered
     def enhance_video_info(self, log_fn, ignore_errors=True):
         """Get the actual dimensions of the PNG frame files"""
-        if self.scene_names:
+        if self.scene_names and not self.video_details.get("source_width", None):
             self.uncompile_scenes()
             first_scene_name = self.scene_names[0]
             first_scene_path = os.path.join(self.scenes_path, first_scene_name)
@@ -1948,8 +1948,12 @@ class VideoRemixerState():
                         state.source_audio = state.source_video
                 except AttributeError:
                     state.source_audio = state.source_video
+
                 # new source video properties
-                state.enhance_video_info(log_fn)
+                # doing this now causes a problem with ported projecs
+                # since the portability handling comes later
+                # state.enhance_video_info(log_fn)
+
                 # new crop offsets
                 try:
                     if state.crop_offset_x == None or state.crop_offset_y == None:


### PR DESCRIPTION
Don't check for on-disk frames in order to enhance source video info with on-disk source frame width and height data on loading a project
- If the project has been ported (copied) to another location from a slow I/O location like a HDD, on loading, the software was looking at the source frames in the original slow location to fill in missing source frame data
- Because the particular project being opened had two enormous scenes with around 75K frames each, just the gathering of the set of on-disk files was taking a long time and made the software appear frozen

The only feature relying on this feature is the _Cleanse Scenes_ feature, which needs the on-disk size of the PNG frames. 
- For newer projects, this information is already included in the `video_details` section of the project
- Code has been added to the Cleanse Scenes feature to ensure this information is available when needed

