### PR TITLE
Video Remixer: Choose whether to tile for Real-ESRGAN based on image size

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -130,7 +130,7 @@ remixer_settings:
   scale_type_down: "area"
   source_audio_crf: 28
   thumb_scale: 0.5
-  use_tiling: False
+  use_tiling_over: 921600
 restoration_settings:
   create_gif: True
   create_zip: True

--- a/tabs/video_remixer_ui.py
+++ b/tabs/video_remixer_ui.py
@@ -258,6 +258,9 @@ class VideoRemixer(TabBase):
                                 with gr.Row():
                                     set_scene_label = gr.Textbox(placeholder="Scene Label", max_lines=1, show_label=False, min_width=80, container=False)
                                     save_scene_label = gr.Button(value="Set", size="sm", scale=0, min_width=80)
+                                with gr.Row():
+                                    auto_label_scenes = gr.Button(value="Auto Label Scenes", size="sm", min_width=80)
+                                    reset_scene_labels = gr.Button(value="Reset Scene Labels", size="sm", min_width=80)
                             with gr.Accordion(label="Danger Zone", open=False):
                                 with gr.Row():
                                     keep_all_button = gr.Button(value="Keep All Scenes",
@@ -898,6 +901,13 @@ class VideoRemixer(TabBase):
         save_scene_label.click(self.save_scene_label, inputs=[scene_index, set_scene_label],
                             outputs=[scene_index, scene_name, scene_image, scene_state,
                                      scene_info, set_scene_label])
+
+        auto_label_scenes.click(self.auto_label_scenes,
+                                outputs=[scene_index, scene_name, scene_image, scene_state,
+                                         scene_info, set_scene_label])
+        reset_scene_labels.click(self.reset_scene_labels,
+                                outputs=[scene_index, scene_name, scene_image, scene_state,
+                                        scene_info, set_scene_label])
 
         keep_all_button.click(self.keep_all_scenes, show_progress=True,
                             inputs=[scene_index, scene_name],
@@ -1541,6 +1551,19 @@ class VideoRemixer(TabBase):
             self.state.clear_scene_label(scene_index)
             self.log("saving project after clearing scene label")
             self.state.save()
+        return self.scene_chooser_details(self.state.current_scene)
+
+    def auto_label_scenes(self):
+        num_scenes = len(self.state.scene_names)
+        num_width = len(str(num_scenes))
+        for scene_index in range(len(self.state.scene_names)):
+            label = str(scene_index).zfill(num_width)
+            formatted_label = f"[{label}]"
+            self.state.set_scene_label(scene_index, formatted_label)
+        return self.scene_chooser_details(self.state.current_scene)
+
+    def reset_scene_labels(self):
+        self.state.clear_all_scene_labels()
         return self.scene_chooser_details(self.state.current_scene)
 
     def keep_all_scenes(self, scene_index, scene_name):

--- a/video_remixer.py
+++ b/video_remixer.py
@@ -718,6 +718,10 @@ class VideoRemixerState():
         if scene_name in self.scene_labels:
             del self.scene_labels[scene_name]
 
+    def clear_all_scene_labels(self):
+        for scene_index in range(len(self.scene_names)):
+            self.clear_scene_label(scene_index)
+
     def keep_all_scenes(self):
         self.scene_states = {scene_name : "Keep" for scene_name in self.scene_names}
 

--- a/video_remixer.py
+++ b/video_remixer.py
@@ -1654,6 +1654,9 @@ class VideoRemixerState():
                             if endpoint != -1:
                                 label = label[endpoint + 1:]
 
+                        # trim whitespace
+                        label = label.strip()
+
                         # FFmpeg needs the colons escaped
                         label = label.replace(":", "\:")
                         if draw_box:

--- a/video_remixer.py
+++ b/video_remixer.py
@@ -1646,7 +1646,13 @@ class VideoRemixerState():
                 use_custom_video_options = custom_video_options
                 if use_custom_video_options.find("<LABEL>") != -1:
                     try:
-                        label = labels[index]
+                        label : str = labels[index]
+
+                        # remove the sorting mark if present
+                        if label.startswith("["):
+                            endpoint = label.find("]")
+                            if endpoint != -1:
+                                label = label[endpoint + 1:]
 
                         # FFmpeg needs the colons escaped
                         label = label.replace(":", "\:")
@@ -1705,7 +1711,7 @@ class VideoRemixerState():
     def assembly_list(self, clip_filepaths : list) -> list:
         """Get list clips to assemble in order.
         'clip_filepaths' is expected to be full path and filename to the remix clips, corresponding to the list of kept scenes.
-        If there are labeled scenes, they are arranged first in sorted order, followed by non-nolabeled scenes."""
+        If there are labeled scenes, they are arranged first in sorted order, followed by non-labeled scenes."""
         if not self.scene_labels:
             return clip_filepaths
 

--- a/video_remixer.py
+++ b/video_remixer.py
@@ -1260,8 +1260,12 @@ class VideoRemixerState():
         model_name = realesrgan_settings["model_name"]
         gpu_ids = realesrgan_settings["gpu_ids"]
         fp32 = realesrgan_settings["fp32"]
-        use_tiling = remixer_settings["use_tiling"]
-        if use_tiling:
+
+        # determine if cropped image size is above memory threshold requiring tiling
+        use_tiling_over = remixer_settings["use_tiling_over"]
+        size = self.crop_w * self.crop_h
+
+        if size > use_tiling_over:
             tiling = realesrgan_settings["tiling"]
             tile_pad = realesrgan_settings["tile_pad"]
         else:


### PR DESCRIPTION
## Alert the following config option changes:

Old:
```yaml
remixer_settings:
  use_tiling: False
```

New:
```yaml
remixer_settings:
  use_tiling_over: 921600
```

Base whether to use tiling with Real-ESRGAN on the crop frame size. This allows it to handle larger and smaller frame sizes without having to change the tiling option and restart the application. The default is set to use tiling if the image if larger than 1280x720.

Example: In the case of my NVIDIA RTX 3090 I must use tiling with 1920x1080 images, but 1280x720 do not require tiling.
