### PR TITLE
Fix: Use parentheses instead of brackets for the sorting mark

### DIFF
--- a/tabs/video_remixer_ui.py
+++ b/tabs/video_remixer_ui.py
@@ -1558,7 +1558,7 @@ class VideoRemixer(TabBase):
         num_width = len(str(num_scenes))
         for scene_index in range(len(self.state.scene_names)):
             label = str(scene_index).zfill(num_width)
-            formatted_label = f"[{label}]"
+            formatted_label = f"({label})"
             self.state.set_scene_label(scene_index, formatted_label)
         return self.scene_chooser_details(self.state.current_scene)
 

--- a/video_remixer.py
+++ b/video_remixer.py
@@ -1653,8 +1653,8 @@ class VideoRemixerState():
                         label : str = labels[index]
 
                         # remove the sorting mark if present
-                        if label.startswith("["):
-                            endpoint = label.find("]")
+                        if label.startswith("("):
+                            endpoint = label.find(")")
                             if endpoint != -1:
                                 label = label[endpoint + 1:]
 


### PR DESCRIPTION
The use of square brackets for the sorting mark conflicts with the marked video labeling