### PR TITLE
Misc fixes

### DIFF
--- a/tabs/video_remixer_ui.py
+++ b/tabs/video_remixer_ui.py
@@ -249,10 +249,10 @@ class VideoRemixer(TabBase):
                         with gr.Row():
                                 split_scene_button = gr.Button(
                                     value="Split Scene " + SimpleIcons.AXE,
-                                    variant="secondary")
+                                    variant="secondary", elem_id="highlightbutton")
                                 choose_range_button = gr.Button(
                                     value="Choose Scene Range " + SimpleIcons.HEART_HANDS,
-                                    variant="secondary")
+                                    variant="secondary", elem_id="highlightbutton")
                         with gr.Row(variant="panel", equal_height=False):
                             with gr.Accordion(label="Properties", open=False):
                                 with gr.Row():
@@ -1872,6 +1872,7 @@ class VideoRemixer(TabBase):
 
     ### SAVE REMIX EVENT HANDLERS
 
+    # TODO move to state
     def prepare_save_remix(self, output_filepath : str):
         if not output_filepath:
             raise ValueError("Enter a path for the remixed video to proceed")
@@ -1906,6 +1907,7 @@ class VideoRemixer(TabBase):
         self.state.clean_remix_content(purge_from="video_clips")
         return global_options, kept_scenes
 
+    # TODO move to state
     def save_remix(self, global_options, kept_scenes):
         self.log(f"about to create video clips")
         self.state.create_video_clips(self.log, kept_scenes, global_options)

--- a/tabs/video_remixer_ui.py
+++ b/tabs/video_remixer_ui.py
@@ -1449,8 +1449,10 @@ class VideoRemixer(TabBase):
                 self.state.save()
                 self.log(f"FFmpeg command: {ffcmd}")
 
-            self.state.scenes_path = os.path.join(self.state.project_path, "SCENES")
-            self.state.dropped_scenes_path = os.path.join(self.state.project_path, "DROPPED_SCENES")
+            self.state.scenes_path = os.path.join(self.state.project_path,
+                                                  VideoRemixerState.SCENES_PATH)
+            self.state.dropped_scenes_path = os.path.join(self.state.project_path,
+                                                          VideoRemixerState.DROPPED_SCENES_PATH)
             self.log(f"creating scenes directory {self.state.scenes_path}")
             create_directory(self.state.scenes_path)
             self.log(f"creating dropped scenes directory {self.state.dropped_scenes_path}")

--- a/video_remixer.py
+++ b/video_remixer.py
@@ -1045,8 +1045,8 @@ class VideoRemixerState():
                 log_fn(f"Planned skip of splitting processed content path {path}: path not found")
 
         if processed_content_split:
-            self.log("invalidating processed audio content after splitting")
-            self.state.clean_remix_audio()
+            log_fn("invalidating processed audio content after splitting")
+            self.clean_remix_audio()
 
         return f"Scene split into new scenes {new_lower_scene_name} and {new_upper_scene_name}"
 

--- a/video_remixer.py
+++ b/video_remixer.py
@@ -980,9 +980,9 @@ class VideoRemixerState():
 
         # this may fail, so copy the original scene and project file to the purged content directory
         scene_path = os.path.join(self.scenes_path, scene_name)
-        purge_path = self.purge_paths([scene_path], keep_original=True, additional_path=self.SCENES_PATH)
-        if purge_path:
-            self.copy_project_file(purge_path)
+        purge_root = self.purge_paths([scene_path], keep_original=True, additional_path=self.SCENES_PATH)
+        if purge_root:
+            self.copy_project_file(purge_root)
 
         try:
             self.split_scene_content(self.scenes_path,
@@ -1037,6 +1037,13 @@ class VideoRemixerState():
             if path and os.path.exists(path):
                 dirs = get_directories(path)
                 if scene_name in dirs:
+
+                    # this may fail, so copy the processed content to the purged content directory
+                    processed_path = os.path.join(path, scene_name)
+                    _, last_path, _ = split_filepath(path)
+                    purge_root = self.purge_paths([processed_path], purged_path=purge_root,
+                                            keep_original=True, additional_path=last_path)
+
                     try:
                         processed_content_split = True
                         self.split_processed_content(path,
@@ -1660,10 +1667,10 @@ class VideoRemixerState():
             content_path = os.path.join(path, scene_name)
             if os.path.exists(content_path):
                 purge_dirs.append(content_path)
-        purge_path = self.purge_paths(purge_dirs)
+        purge_root = self.purge_paths(purge_dirs)
         removed += purge_dirs
-        if purge_path:
-            self.copy_project_file(purge_path)
+        if purge_root:
+            self.copy_project_file(purge_root)
 
         if self.audio_clips_path:
             self.audio_clips = sorted(get_files(self.audio_clips_path))

--- a/webui_utils/file_utils.py
+++ b/webui_utils/file_utils.py
@@ -78,6 +78,18 @@ def duplicate_directory(source_dir, dest_dir):
     shutil.copytree(source_dir, dest_dir, copy_function=_copy, dirs_exist_ok=True)
     Mtqdm().leave_bar(_duplicate_directory_progress)
 
+def directory_populated(path : str, files_only=False):
+    """Returns True if the directory exists and has contents"""
+    if not is_safe_path(path):
+        raise ValueError("'path' must be a legal path")
+    if os.path.exists(path):
+        iter = os.scandir(path)
+        if files_only:
+            return any([item.is_file() for item in iter])
+        elif next(iter, False):
+            return True
+    return False
+
 def _get_files(path : str):
     entries = glob.glob(path)
     files = []


### PR DESCRIPTION
Video Remixer:
- fix a crash when splitting a scene, during splitting of processed content
- ensure project file matches purged content that's revertable
- make drop processed scene safer, saving the processed content in case of error
- on reprocessing a remix, purge rather than delete the previously processed content along with the `project.yaml` file so the project can be reverted
- ensure `project.yaml` is preseved in the right state in other cases of purging content
- ensure saved scene splitter purged content is labeled as to the original directory for easier recover if there's an error

_These are fixes toward a future_ Revert Project _feature to support_ Undo