### PR TITLE
Video Remixer: Enhance labeled scene support

### DIFF
--- a/guide/video_remixer_choose.md
+++ b/guide/video_remixer_choose.md
@@ -1,14 +1,62 @@
 **Video Remixer Scene Chooser** - Step through scenes choosing which to keep
 
-## Important Action Buttons
-The Green buttons:
-- Set _Keep_ or _Drop_ status for a scene
+## Main Action Buttons (Green)
+_Keep Scene | Next_ and _Drop Scene | Next_
+- Set the _Next_ or _Drop_ Status, then
+- **Save the project**, then
 - Advance to the next scene
-- Save the project
 
-The _Keep_ and _Drop_ radio buttons
-- Set _Keep_ or _Drop_ status for a scene
-- Save the project
+## Action Radio Buttons
+- Set the _Next_ or _Drop_ Status, then
+- **Save the project**
+
+## When Done Choosing Scenes
+Click the _Done Choosing Scenes_ button when all _Keep_ or _Drop_ selections have been made
+- This will save your choices and take you to the _Compile Scenes_ tab
+
+## Scene Navigation Buttons (Orange)
+_Prev Scene_ and _Next Scene_
+- Go to the previous or next scene
+
+## Other Navigation Buttons
+_Prev Keep_ and _Next Keep_
+- Go to the previous or next scene marked **_Keep_**
+
+_First Scene_ and _Last Scene_
+- Go to the first or last scene in the project
+
+## Shortcut Buttons (Purple)
+_Split Scene_
+- Opens the _Scene Splitter_ tab to scrub through a scene and optionally split it
+
+_Choose Scene Range_
+- Opens the _Choose Scene Range_ tab to set a series of scenes to _Keep_ or _Drop_
+
+## Properties Accordion
+_Scene Label_
+- Enter a scene label and click _Set_ to save it with the scene
+- _Tip:_ Use the < and > buttons to navigate to labeled scenes
+
+### About Scene Labels
+- Labels can be used to add a scene title
+  - The entered scene title will appear in the video when using the _Labeled Remix_ feature
+  - The entered title will also be used as the based for the scene remix clip, making it easier to reuse individual clips
+- Labels can be used to rearrange scene order in the remix video
+  - When a label starts with a value inside parentheses, the value will be used to arrange the clips in sorted order
+  - _Tip:_ use the _Auto Label Scenes_ button to automatically add a sorting mark to each scene
+- Labels can be used to mark a scene for 2X or 4X audio slow motion
+  - **NOTE** the main video must use 2X Inflation for this feature to work
+  - Use the _Add 2X Audio Slo Mo_ or _Add 4X Audio Slo Mo_ buttons to add a _processing hint_ to the scene label
+
+_Auto Label Scenes_
+- Automatically adds a sorting mark to each scene
+
+_Reset Scene Labels_
+- Clears the contents of all scene labels
+
+_Add 2X Audio Slo Mo_ and _Add 4X Audio Slo Mo_
+- Add a _processing hint_ to the scene label to enabled 2X or 4X audio slow motion processing
+- **NOTE** the main video must use 2X Inflation for this feature to work
 
 The _Keep All Scenes_ and _Drop All Scenes_ buttons (inside the _Danger Zone_ accordion)
 - **Destructively** _Keep_ or _Drop_ all scenes (there is no undo)
@@ -17,16 +65,19 @@ The _Keep All Scenes_ and _Drop All Scenes_ buttons (inside the _Danger Zone_ ac
 The _Split Scene_ and _Drop Processed Scene_ buttons (inside the _Danger Zone_ accordion)
 - Shortcuts that take you to the corresponding _Remix Extra_ tabs with pre-filled scene IDs
 
-The remaining buttons are navigation-related, except for:
+## Danger Zone Accordion
 
-Click the _Done Choosing Scenes_ button when all _Keep_ or _Drop_ selections have been made
-- This will save your choices and take you to the _Compile Scenes_ tab
+_Keep All Scenes_ and _Drop All Scenes_
+- Sets all sets to _Keep_ or _Drop_
 
-Other Buttons
-- _< Prev Scene_ and _Next Scene >_ - step through all scenes
-- _< Prev Keep_ and _Next Keep >_ - step through only kept scenes
-- _<< First Scene_ and _Last Scene >>_ - jump to the first or last scene
-- _Danger Zone_ - expands the accordion to reveal various rare-use buttons
+_Invert Scene Choices_
+- Changes all scene keep/drop statues to the opposite state
+- _Tips:_
+  - Use this feature, then use the _Next Keep_ button to navigate through all dropped scenes
+  - Use this feature, then create a _Marked_ remix video, to watch and check or accidentally left out footage
+
+_Drop Processed Scene_
+- Opens the _Drop Processed Scenes_ tab to drop a scene, including its processed content, to save the remix video without that the dropped scene, avoiding reprocessing the whole video
 
 ## Important
 - `ffmpeg.exe` must be available on the system path

--- a/tabs/video_remixer_ui.py
+++ b/tabs/video_remixer_ui.py
@@ -263,6 +263,9 @@ class VideoRemixer(TabBase):
                                 with gr.Row():
                                     auto_label_scenes = gr.Button(value="Auto Label Scenes", size="sm", min_width=80)
                                     reset_scene_labels = gr.Button(value="Reset Scene Labels", size="sm", min_width=80)
+                                with gr.Row():
+                                    add_2x_slomo = gr.Button(value="Add 2X Audio Slo Mo", size="sm", min_width=80, elem_id="highlightbutton")
+                                    add_4x_slomo = gr.Button(value="Add 4X Audio Slo Mo", size="sm", min_width=80, elem_id="highlightbutton")
                             with gr.Accordion(label="Danger Zone", open=False):
                                 with gr.Row():
                                     keep_all_button = gr.Button(value="Keep All Scenes",
@@ -935,6 +938,14 @@ class VideoRemixer(TabBase):
         reset_scene_labels.click(self.reset_scene_labels,
                                 outputs=[scene_index, scene_name, scene_image, scene_state,
                                         scene_info, set_scene_label])
+
+        add_2x_slomo.click(self.add_2x_slomo, inputs=scene_index,
+                            outputs=[scene_index, scene_name, scene_image, scene_state,
+                                     scene_info, set_scene_label])
+
+        add_4x_slomo.click(self.add_4x_slomo, inputs=scene_index,
+                            outputs=[scene_index, scene_name, scene_image, scene_state,
+                                     scene_info, set_scene_label])
 
         keep_all_button.click(self.keep_all_scenes, show_progress=True,
                             inputs=[scene_index, scene_name],
@@ -1678,6 +1689,24 @@ class VideoRemixer(TabBase):
 
     def reset_scene_labels(self):
         self.state.clear_all_scene_labels()
+        return self.scene_chooser_details(self.state.current_scene)
+
+    def add_slomo(self, scene_index, slomo_hint):
+        scene_name = self.state.scene_names[scene_index]
+        scene_label = self.state.scene_labels.get(scene_name) or ""
+        # TODO later if adding other hint types, might want to overwrite only what changed here
+        sort_mark, _, title = self.state.split_label(scene_label)
+        new_label = self.state.compose_label(sort_mark, slomo_hint, title)
+        self.state.set_scene_label(scene_index, new_label)
+        self.log("saving project after adding slomo hint")
+        self.state.save()
+
+    def add_2x_slomo(self, scene_index):
+        self.add_slomo(scene_index, "I:4A")
+        return self.scene_chooser_details(self.state.current_scene)
+
+    def add_4x_slomo(self, scene_index):
+        self.add_slomo(scene_index, "I:8A")
         return self.scene_chooser_details(self.state.current_scene)
 
     def keep_all_scenes(self, scene_index, scene_name):

--- a/tabs/video_remixer_ui.py
+++ b/tabs/video_remixer_ui.py
@@ -1945,7 +1945,7 @@ class VideoRemixer(TabBase):
         self.state.save()
 
         self.log("about to create scene clips")
-        self.state.create_scene_clips(kept_scenes, global_options)
+        self.state.create_scene_clips(self.log, kept_scenes, global_options)
         self.log("saving project after creating scene clips")
         self.state.save()
 

--- a/tabs/video_remixer_ui.py
+++ b/tabs/video_remixer_ui.py
@@ -677,7 +677,7 @@ class VideoRemixer(TabBase):
                                 gr.Markdown(
                         "**_Delete source PNG frame files, thumbnails and dropped scenes_**")
                                 with gr.Row():
-                                    delete_source_711 = gr.Checkbox(
+                                    delete_source_711 = gr.Checkbox(value=True,
                                         label="Remove Source Video Frames")
                                     with gr.Column(variant="compact"):
                                         gr.Markdown(

--- a/tabs/video_remixer_ui.py
+++ b/tabs/video_remixer_ui.py
@@ -1953,7 +1953,7 @@ class VideoRemixer(TabBase):
             return gr.update(value="No processed video clips were found", visible=True)
 
         self.log("about to create remix viedeo")
-        ffcmd = self.state.create_remix_video(global_options, self.state.output_filepath)
+        ffcmd = self.state.create_remix_video(self.log, global_options, self.state.output_filepath)
         self.log(f"FFmpeg command: {ffcmd}")
         self.log("saving project after creating remix video")
         self.state.save()
@@ -1965,7 +1965,7 @@ class VideoRemixer(TabBase):
                           custom_video_options,
                           custom_audio_options,
                           draw_text_options=None,
-                          labeled_scenes_first=True):
+                          use_scene_sorting=True):
         _, _, output_ext = split_filepath(output_filepath)
         output_ext = output_ext[1:]
 
@@ -1988,8 +1988,8 @@ class VideoRemixer(TabBase):
             raise ValueError("No processed video clips were found")
 
         self.log("about to create remix viedeo")
-        ffcmd = self.state.create_remix_video(global_options, output_filepath,
-                                              labeled_scenes_first=labeled_scenes_first)
+        ffcmd = self.state.create_remix_video(self.log, global_options, output_filepath,
+                                              use_scene_sorting=use_scene_sorting)
         self.log(f"FFmpeg command: {ffcmd}")
         self.log("saving project after creating remix video")
         self.state.save()
@@ -2143,8 +2143,10 @@ class VideoRemixer(TabBase):
 
             try:
                 self.save_custom_remix(output_filepath, global_options, kept_scenes,
-                                    labeled_video_options, labeled_audio_options, draw_text_options, labeled_scenes_first=False)
-                return gr.update(value=format_markdown(f"Remixed labeled video {output_filepath} is complete.", "highlight"))
+                                       labeled_video_options, labeled_audio_options,
+                                       draw_text_options, use_scene_sorting=True)
+                return format_markdown(
+                    f"Remixed labeled video {output_filepath} is complete.", "highlight")
             except FFRuntimeError as error:
                 return gr.update(value=format_markdown(f"Error: {error}.", "error"))
 

--- a/tabs/video_remixer_ui.py
+++ b/tabs/video_remixer_ui.py
@@ -1666,8 +1666,13 @@ class VideoRemixer(TabBase):
         num_scenes = len(self.state.scene_names)
         num_width = len(str(num_scenes))
         for scene_index in range(len(self.state.scene_names)):
-            label = str(scene_index).zfill(num_width)
-            formatted_label = f"({label})"
+            scene_name = self.state.scene_names[scene_index]
+            scene_label = self.state.scene_labels.get(scene_name)
+            hint_mark, title = None, None
+            if scene_label:
+                _, hint_mark, title = self.state.split_label(scene_label)
+            sort_mark = str(scene_index).zfill(num_width)
+            formatted_label = self.state.compose_label(sort_mark, hint_mark, title)
             self.state.set_scene_label(scene_index, formatted_label)
         return self.scene_chooser_details(self.state.current_scene)
 

--- a/video_remixer.py
+++ b/video_remixer.py
@@ -726,6 +726,18 @@ class VideoRemixerState():
         except Exception:
             return None, None, None
 
+    def compose_label(self, sort_mark, hint_mark, title):
+        composed = []
+        if sort_mark:
+            composed.append(f"({sort_mark})")
+        if hint_mark:
+            composed.append(f"{{{hint_mark}}}")
+        if title:
+            if(len(composed)):
+                composed.append(" ")
+            composed.append(title)
+        return "".join(composed)
+
     def split_hint(self, hint : str):
         """Splits a processing hint string such as 'a:1,B:22,C:3c3' into a dict"""
         hints = hint.split(",")

--- a/webui_utils/file_utils.py
+++ b/webui_utils/file_utils.py
@@ -1,5 +1,6 @@
 """Functions for dealing with files"""
 import os
+import re
 import shutil
 import glob
 from zipfile import ZipFile
@@ -332,3 +333,19 @@ def check_for_name_clash(file_list, check_base_filename, check_file_type):
         if file_type == check_file_type and filename.startswith(check_base_filename):
             raise ValueError(
                 f"Existing files were found with the base filename {check_base_filename}")
+
+def simple_sanitize_filename(filename, default_filename=None):
+    """Given an arbitrary string, produce a safe filename
+       Uses the default_filename if a safe filename cannot be produced
+       Raises ValueError if default_filename is not provided
+    """
+    # Keep only alphanumeric chars and spaces, and convert all space sequences into underscores
+    safe_name = re.sub(r' +',
+                       '_',
+                       re.sub(r'[^A-Za-z0-9 ]+',
+                              '',
+                              filename)) or default_filename
+    if safe_name:
+        return safe_name
+    raise ValueError(
+        f"simple_sanitize_filename(): unable to produce safe filename from input string {filename}")


### PR DESCRIPTION
Enhance use and support for Video Remixer scene labels
- Ensure sorting marks* are respected and not part of label titles
- Ensure hinting marks** are respected and not part of label titles
- Change scene sorting to be based solely on sorting marks
- Implement primitive processing hints*** for now for marking a scene for audio slow motion
- Adds buttons to add the appropriate processing hints for 2X and 4X audio slow motion

*Sorting Marks (optional)
- When setting a scene label, preface the scene title with a sortable value inside parentheses
- Ex: `(a) First Scene`, `(b) Second Scene`

*Hinting Marks (optional)
- When setting a scene label, preface the scene title with proper hinting values inside curly braces
  - The hinting mark should come immediately after the optional sorting mark
- Ex 1: Make one scene in an otherwise 2X inflated video have 2X Audio Slow Motion
  - `{I:4A} Two Times Slo Mo!`
  - Explanation: 
    - `I` signals an _Inflation_ processing hint
    - `4` signals _4X_ Inflation
    - `A` signals _Audio_ slow motion 
    - Of the 4X inflated scenes, 2X goes into matching the base 2X inflation rate, and 2X goes into 0.50 motion slowdown with audio pitch adjusted to match

- Ex 2: Make one scene in an otherwise 2X inflated video have 4X Audio Slow Motion
  - `{I:8A} Four Times Slo Mo!`
  - Explanation: 
    - `I` signals an _Inflation_ processing hint
    - `8` signals _8X_ Inflation
    - `A` signals _Audio_ slow motion 
    - Of the 8X inflated scenes, 2X goes into matching the base 2X inflation rate, and 4X goes into 0.25 motion slowdown with audio pitch adjusted to match

***Processing Hints
- The current support is limited to enabling 2X or 4X audio inflation only on an otherwise 2X inflated video
  - Support will be added to enabled/disable Inflation on a per-scene basis, and not require the main processing to have Inflation enabled. Other types of processing hints are planned.
