### PR TITLE
Video Remixer: Minor fixes for recent additions

### DIFF
--- a/video_remixer.py
+++ b/video_remixer.py
@@ -2102,8 +2102,8 @@ class VideoRemixerState():
                     if scene_label:
                         _, _, title = self.split_label(scene_label)
                         new_filename = simple_sanitize_filename(title)
-                        path, _, ext = split_filepath(kept_clip_filepath)
-                        new_filepath = os.path.join(path, new_filename + ext)
+                        path, filename, ext = split_filepath(kept_clip_filepath)
+                        new_filepath = os.path.join(path, f"{new_filename}_{filename}" + ext)
                         log_fn(f"renaming clip {kept_clip_filepath} to {new_filepath}")
                         os.replace(kept_clip_filepath, new_filepath)
                         kept_clip_filepath = new_filepath

--- a/video_remixer.py
+++ b/video_remixer.py
@@ -1888,8 +1888,8 @@ class VideoRemixerState():
                                     pass
                                 elif "2" in inflation_hint:
                                     # TODO re-enable inflation
-                                    # force_inflate_by = "2X"
-                                    pass
+                                    log_fn("force 2X inflation")
+                                    force_inflate_by = "2X"
                                 elif "4" in inflation_hint:
                                     log_fn("force 4X inflation")
                                     force_inflate_by = "4X"
@@ -2050,9 +2050,7 @@ class VideoRemixerState():
                                     pass
                                 elif "2" in inflation_hint:
                                     # TODO re-enable inflation
-                                    # force_inflate_by = "2X"
-                                    # for now don't affect the inflation amount
-                                    pass
+                                    force_inflate_by = "2X"
                                 elif "4" in inflation_hint:
                                     force_inflate_by = "4X"
                                 elif "8" in inflation_hint:


### PR DESCRIPTION
- support hint for 2X inflation in addition to the existing 4X and 8X
- prevent filename clash when naming remix clips that have titles               