### PR TITLE
Gradio cleanup

### DIFF
--- a/tabs/dedupe_report_ui.py
+++ b/tabs/dedupe_report_ui.py
@@ -73,11 +73,12 @@ class DuplicateFramesReport(TabBase):
                 info_file = os.path.join(output_path, output_basename + str(run_index) + ".txt")
                 with open(info_file, "w", encoding="UTF-8") as file:
                     file.write(report)
-                return gr.update(value=[info_file], visible=True), gr.update(value=report,
-                                                                             visible=True)
+                return gr.update(value=[info_file], visible=True), \
+                       gr.update(value=report, visible=True)
 
             except RuntimeError as error:
                 message = \
 f"""Error creating report:
 {error}"""
-                return gr.update(value=None, visible=False), gr.update(value=message, visible=True)
+                return gr.update(value=None, visible=False), \
+                       gr.update(value=message, visible=True)

--- a/tabs/dedupe_tuning_ui.py
+++ b/tabs/dedupe_tuning_ui.py
@@ -92,17 +92,17 @@ class DuplicateTuning(TabBase):
                     suppress_output=True)
                 report = str(tuning_data)
                 return gr.update(value=[output_filepath], visible=True), \
-                    gr.update(value=output_filepath, visible=True), \
-                    gr.update(value=None, visible=False)
+                       gr.update(value=output_filepath, visible=True), \
+                       gr.update(value=None, visible=False)
 
             except RuntimeError as error:
                 message = str(error)
                 return gr.update(value=None, visible=False),\
-                    gr.update(value=None, visible=False), \
-                    gr.update(value=message, visible=True)
+                       gr.update(value=None, visible=False), \
+                       gr.update(value=message, visible=True)
         else:
             message =\
             "To proceed, ensure: an input path was entered, threshold max > min, threshold step > 0"
             return gr.update(value=None, visible=False),\
-                gr.update(value=None, visible=False), \
-                gr.update(value=message, visible=True)
+                   gr.update(value=None, visible=False), \
+                   gr.update(value=message, visible=True)

--- a/tabs/frame_interpolation_ui.py
+++ b/tabs/frame_interpolation_ui.py
@@ -23,7 +23,8 @@ class FrameInterpolation(TabBase):
                     log_fn : Callable):
         TabBase.__init__(self, config, engine, log_fn)
 
-    DEFAULT_MESSAGE = "Click Interpolate to: Create interpolated frames and show an animated preview"
+    DEFAULT_MESSAGE = \
+        "Click Interpolate to: Create interpolated frames and show an animated preview"
 
     def render_tab(self):
         """Render tab into UI"""
@@ -33,8 +34,10 @@ class FrameInterpolation(TabBase):
                 + " see an animation of result and download the new frames", elem_id="tabheading")
             with gr.Row():
                 with gr.Column():
-                    img1_input = gr.Image(type="filepath", label="Before Frame", tool=None, height=250)
-                    img2_input = gr.Image(type="filepath", label="After Frame", tool=None, height=250)
+                    img1_input = gr.Image(type="filepath", label="Before Frame", tool=None,
+                                          height=250)
+                    img2_input = gr.Image(type="filepath", label="After Frame", tool=None,
+                                          height=250)
                     with gr.Row():
                         splits_input = gr.Slider(value=1, minimum=1, maximum=max_splits,
                             step=1, label="Split Count")
@@ -97,6 +100,6 @@ class FrameInterpolation(TabBase):
                 output_paths)
             downloads.append(info_file)
 
-        return gr.update(value=preview_gif), \
+        return preview_gif, \
             gr.update(value=downloads, visible=True), \
-            gr.update(value=format_markdown(self.DEFAULT_MESSAGE))
+            format_markdown(self.DEFAULT_MESSAGE)

--- a/tabs/frame_interpolation_ui.py
+++ b/tabs/frame_interpolation_ui.py
@@ -64,8 +64,8 @@ class FrameInterpolation(TabBase):
         """Interpolate button handler"""
 
         if not img_before_file or not img_after_file:
-            return None, None, gr.update(value=format_markdown(
-                "Please choose a Before Frame and After Frame to begin", "warning"))
+            return None, None, format_markdown(
+                "Please choose a Before Frame and After Frame to begin", "warning")
 
         interpolater = Interpolate(self.engine.model, self.log_fn)
         use_time_step = self.config.engine_settings["use_time_step"]

--- a/tabs/frame_restoration_ui.py
+++ b/tabs/frame_restoration_ui.py
@@ -8,7 +8,8 @@ from webui_utils.image_utils import create_gif
 from webui_utils.file_utils import create_zip, create_directory
 from webui_utils.ui_utils import create_report
 from webui_utils.auto_increment import AutoIncrementDirectory
-from webui_utils.simple_utils import restored_frame_fractions, restored_frame_predictions, format_markdown
+from webui_utils.simple_utils import restored_frame_fractions, restored_frame_predictions, \
+    format_markdown
 from webui_utils.ui_utils import update_info_fr
 from webui_tips import WebuiTips
 from interpolate_engine import InterpolateEngine
@@ -89,8 +90,8 @@ class FrameRestoration(TabBase):
         """Restore Frames button handler"""
 
         if not img_before_file or not img_after_file:
-            return None, None, gr.update(value=format_markdown(
-                "Please choose a Before Frame and After Frame to begin", "warning"))
+            return None, None, format_markdown(
+                "Please choose a Before Frame and After Frame to begin", "warning")
 
         interpolater = Interpolate(self.engine.model, self.log)
         target_interpolater = TargetInterpolate(interpolater, self.log)
@@ -129,6 +130,6 @@ class FrameRestoration(TabBase):
             downloads.append(info_file)
 
         message = f"Restored frames saved to {os.path.abspath(output_path)}"
-        return gr.Image.update(value=preview_gif), \
-            gr.File.update(value=downloads, visible=True), \
-            gr.update(value=format_markdown(message))
+        return preview_gif, \
+            gr.update(value=downloads, visible=True), \
+            format_markdown(message)

--- a/tabs/frame_search_ui.py
+++ b/tabs/frame_search_ui.py
@@ -21,7 +21,8 @@ class FrameSearch(TabBase):
                     log_fn : Callable):
         TabBase.__init__(self, config, engine, log_fn)
 
-    DEFAULT_MESSAGE = "Click Search to: Create a frame at the requested moment (can take from seconds to minutes)"
+    DEFAULT_MESSAGE = \
+        "Click Search to: Create a frame at the requested moment (can take from seconds to minutes)"
 
     def render_tab(self):
         """Render tab into UI"""
@@ -33,15 +34,17 @@ class FrameSearch(TabBase):
                 elem_id="tabheading")
             with gr.Row():
                 with gr.Column():
-                    img1_input = gr.Image(type="filepath", label="Before Frame", tool=None, height=250)
-                    img2_input = gr.Image(type="filepath", label="After Frame", tool=None, height=250)
+                    img1_input = gr.Image(type="filepath", label="Before Frame", tool=None,
+                                          height=250)
+                    img2_input = gr.Image(type="filepath", label="After Frame", tool=None,
+                                          height=250)
                     with gr.Row():
                         splits_input = gr.Slider(value=default_splits, minimum=1,
                                             maximum=max_splits, step=1, label="Search Precision")
-                        min_input_text = gr.Text(placeholder="0.0-1.0",
-                            label="Lower Bound")
-                        max_input_text = gr.Text(placeholder="0.0-1.0",
-                            label="Upper Bound")
+                        min_input_text = gr.Text(placeholder="0.0-1.0", label="Lower Bound",
+                                                 max_lines=1)
+                        max_input_text = gr.Text(placeholder="0.0-1.0", label="Upper Bound",
+                                                 max_lines=1)
                 with gr.Column():
                     img_output = gr.Image(type="filepath", label="Found Frame",
                         interactive=False, elem_id="mainoutput", height=250)
@@ -74,11 +77,13 @@ class FrameSearch(TabBase):
             max_target = float(max_target)
         except ValueError:
             return None, None, gr.update(value=format_markdown(
-                "Please enter a Lower Bound and Upper Bound between 0.0 and 1.0 to begin", "warning"))
+                "Please enter a Lower Bound and Upper Bound between 0.0 and 1.0 to begin",
+                "warning"))
 
         if min_target < 0.0 or min_target > 1.0 or max_target < 0.0 or max_target > 1.0:
             return None, None, gr.update(value=format_markdown(
-                "Please enter a Lower Bound and Upper Bound between 0.0 and 1.0 to begin", "warning"))
+                "Please enter a Lower Bound and Upper Bound between 0.0 and 1.0 to begin",
+                "warning"))
 
         base_output_path = self.config.directories["output_search"]
         use_time_step = self.config.engine_settings["use_time_step"]
@@ -103,6 +108,7 @@ class FrameSearch(TabBase):
             target_interpolater.split_frames(img_before_file, img_after_file, num_splits,
                 float(min_target), float(max_target), output_path, output_basename)
             output_paths = target_interpolater.output_paths
-        return gr.update(value=output_paths[0]), \
+
+        return output_paths[0], \
             gr.update(value=output_paths, visible=True), \
-            gr.update(value=format_markdown(self.DEFAULT_MESSAGE))
+            format_markdown(self.DEFAULT_MESSAGE)

--- a/tabs/frame_search_ui.py
+++ b/tabs/frame_search_ui.py
@@ -70,20 +70,20 @@ class FrameSearch(TabBase):
         """Search button handler"""
 
         if not img_before_file or not img_after_file:
-            return None, None, gr.update(value=format_markdown(
-                "Please choose a Before Frame and After Frame to begin", "warning"))
+            return None, None, format_markdown(
+                "Please choose a Before Frame and After Frame to begin", "warning")
         try:
             min_target = float(min_target)
             max_target = float(max_target)
         except ValueError:
-            return None, None, gr.update(value=format_markdown(
+            return None, None, format_markdown(
                 "Please enter a Lower Bound and Upper Bound between 0.0 and 1.0 to begin",
-                "warning"))
+                "warning")
 
         if min_target < 0.0 or min_target > 1.0 or max_target < 0.0 or max_target > 1.0:
-            return None, None, gr.update(value=format_markdown(
+            return None, None, format_markdown(
                 "Please enter a Lower Bound and Upper Bound between 0.0 and 1.0 to begin",
-                "warning"))
+                "warning")
 
         base_output_path = self.config.directories["output_search"]
         use_time_step = self.config.engine_settings["use_time_step"]

--- a/tabs/resynthesize_video_ui.py
+++ b/tabs/resynthesize_video_ui.py
@@ -5,7 +5,8 @@ import gradio as gr
 from webui_utils.simple_config import SimpleConfig
 from webui_utils.simple_icons import SimpleIcons
 from webui_utils.simple_utils import format_markdown
-from webui_utils.file_utils import create_directory, get_files, get_directories, is_safe_path, remove_directories
+from webui_utils.file_utils import create_directory, get_files, get_directories, is_safe_path, \
+    remove_directories
 from webui_utils.auto_increment import AutoIncrementDirectory
 from webui_utils.mtqdm import Mtqdm
 from webui_tips import WebuiTips
@@ -25,7 +26,8 @@ class ResynthesizeVideo(TabBase):
         TabBase.__init__(self, config, engine, log_fn)
 
     DEFAULT_MESSAGE_SINGLE = "Click Resynthesize Video to: Create interpolated replacement frames"
-    DEFAULT_MESSAGE_BATCH = "Click Resynthesize Batch to: Create interpolated replacement frames for each batch directory"
+    DEFAULT_MESSAGE_BATCH = \
+    "Click Resynthesize Batch to: Create interpolated replacement frames for each batch directory"
 
     def render_tab(self):
         """Render tab into UI"""
@@ -40,7 +42,7 @@ class ResynthesizeVideo(TabBase):
                 with gr.Tab(label="Individual Path"):
                     with gr.Row():
                         input_path_text = gr.Text(max_lines=1, label="Input Path",
-                            placeholder="Path on this server to the frame PNG files to resynthesize")
+                        placeholder="Path on this server to the frame PNG files to resynthesize")
                         output_path_text = gr.Text(max_lines=1, label="Output Path",
                             placeholder="Where to place the resynthesized PNG frames",
                             info="Leave blank to use default path")
@@ -74,19 +76,16 @@ class ResynthesizeVideo(TabBase):
     def resynthesize_batch(self, input_path : str, output_path : str | None, resynth_type : str):
         """Resynthesize Video button handler"""
         if not input_path:
-            return gr.update(value=format_markdown(
-                "Please enter an input path to begin", "warning"))
+            return format_markdown("Please enter an input path to begin", "warning")
         if not os.path.exists(input_path):
-            return gr.update(value=format_markdown(
-                f"The input path {input_path} was not found", "error"))
+            return format_markdown(f"The input path {input_path} was not found", "error")
         if not is_safe_path(input_path):
-            return gr.update(value=format_markdown(
-                f"The input path {input_path} is not valid", "error"))
+            return format_markdown(f"The input path {input_path} is not valid", "error")
 
         group_names = get_directories(input_path)
         if not group_names:
-            return gr.update(value=format_markdown(
-                f"No directories were found at the input path {input_path}", "error"))
+            return format_markdown(f"No directories were found at the input path {input_path}",
+                                   "error")
 
         self.log(f"beginning batch ResynthesizeVideo processing with input_path={input_path}" +\
                     f" output_path={output_path}")
@@ -94,8 +93,7 @@ class ResynthesizeVideo(TabBase):
 
         if output_path:
             if not is_safe_path(output_path):
-                return gr.update(value=format_markdown(
-                    f"The output path {output_path} is not valid", "error"))
+                return format_markdown(f"The output path {output_path} is not valid", "error")
             self.log(f"creating group output path {output_path}")
             create_directory(output_path)
         else:
@@ -108,16 +106,17 @@ class ResynthesizeVideo(TabBase):
                 group_input_path = os.path.join(input_path, group_name)
                 group_output_path = os.path.join(output_path, group_name)
                 try:
-                    self.resynthesize_video(group_input_path, group_output_path, resynth_type=resynth_type, interactive=False)
+                    self.resynthesize_video(group_input_path, group_output_path,
+                                            resynth_type=resynth_type, interactive=False)
                 except ValueError as error:
                     errors.append(f"Error handling directory {group_name}: " + str(error))
                 Mtqdm().update_bar(bar)
         if errors:
             message = "\r\n".join(errors)
-            return gr.update(value=format_markdown(message, "error"))
+            return format_markdown(message, "error")
         else:
             message = f"Batch processed resynthesized frames saved to {os.path.abspath(output_path)}"
-            return gr.update(value=format_markdown(message))
+            return format_markdown(message)
 
     def one_pass_resynthesis(self, input_path, output_path, output_basename, engine):
         file_list = sorted(get_files(input_path, extension="png"))
@@ -125,7 +124,8 @@ class ResynthesizeVideo(TabBase):
         engine.interpolate_series(file_list, output_path, 1, "interframe", offset=2)
 
         self.log(f"auto-resequencing recreated frames at {output_path}")
-        ResequenceFiles(output_path, "png", "resynthesized_frame", 1, 1, 1, 0, -1, True, self.log).resequence()
+        ResequenceFiles(output_path, "png", "resynthesized_frame", 1, 1, 1, 0, -1, True,
+                        self.log).resequence()
 
     def two_pass_resynthesis(self, input_path, output_path, output_basename, engine):
         interframes_path1 = os.path.join(output_path, "interframes-pass1")
@@ -169,23 +169,24 @@ class ResynthesizeVideo(TabBase):
             Mtqdm().update_bar(bar)
             remove_directories([interframes_path1, interframes_path2, interframes_path3])
 
-    def resynthesize_video(self, input_path : str, output_path : str | None, resynth_type : str, interactive : bool=True):
+    def resynthesize_video(self, input_path : str, output_path : str | None, resynth_type : str,
+                           interactive : bool=True):
         """Resynthesize Video button handler"""
         if not input_path:
             if interactive:
-                return gr.update(value=format_markdown("Please enter an input path to begin", "warning"))
+                return format_markdown("Please enter an input path to begin", "warning")
             else:
                 raise ValueError(f"The input path is empty")
         if not os.path.exists(input_path):
             message = f"The input path {input_path} was not found"
             if interactive:
-                return gr.update(value=format_markdown(message, "error"))
+                return format_markdown(message, "error")
             else:
                 raise ValueError(message)
         if not is_safe_path(input_path):
             message = f"The input path {input_path} is not valid"
             if interactive:
-                return gr.update(value=format_markdown(message, "error"))
+                return format_markdown(message, "error")
             else:
                 raise ValueError(message)
 
@@ -193,7 +194,7 @@ class ResynthesizeVideo(TabBase):
             if not is_safe_path(output_path):
                 message = f"The output path {output_path} is not valid"
                 if interactive:
-                    return gr.update(value=format_markdown(message, "error"))
+                    return format_markdown(message, "error")
                 else:
                     raise ValueError(f"The output path {input_path} is not valid")
             self.log(f"creating output path {output_path}")
@@ -215,6 +216,6 @@ class ResynthesizeVideo(TabBase):
 
         message = f"Resynthesized frames saved to {os.path.abspath(output_path)}"
         if interactive:
-            return gr.update(value=format_markdown(message))
+            return format_markdown(message)
         else:
             self.log(message)

--- a/tabs/split_scenes_ui.py
+++ b/tabs/split_scenes_ui.py
@@ -49,7 +49,9 @@ class SplitScenes(TabBase):
                                                    variant="primary")
             with gr.Accordion(SimpleIcons.TIPS_SYMBOL + " Guide", open=False):
                 WebuiTips.split_scenes.render()
+
         split_scenes.click(self.split_scenes, inputs=[input_path, output_path, scene_threshold])
+
         split_breaks.click(self.split_breaks, inputs=[input_path, output_path, break_duration,
                                                       break_ratio])
 

--- a/tabs/upscale_frames_ui.py
+++ b/tabs/upscale_frames_ui.py
@@ -6,7 +6,6 @@ from webui_utils.simple_config import SimpleConfig
 from webui_utils.simple_icons import SimpleIcons
 from webui_utils.simple_utils import format_markdown
 from webui_utils.file_utils import create_directory, get_files, get_directories, is_safe_path
-# from webui_utils.ui_utils import update_splits_info
 from webui_utils.mtqdm import Mtqdm
 from webui_tips import WebuiTips
 from upscale_series import UpscaleSeries
@@ -21,7 +20,8 @@ class UpscaleFrames(TabBase):
         TabBase.__init__(self, config, engine, log_fn)
 
     DEFAULT_MESSAGE_SINGLE = "Click Upscale Frames to: Create cleansed and enlarged frames"
-    DEFAULT_MESSAGE_BATCH = "Click Upscale Batch to: Create cleansed and enlarged frames for each batch directory"
+    DEFAULT_MESSAGE_BATCH = \
+        "Click Upscale Batch to: Create cleansed and enlarged frames for each batch directory"
 
     def render_tab(self):
         """Render tab into UI"""
@@ -78,22 +78,18 @@ class UpscaleFrames(TabBase):
                        use_tiling : str):
         """Upscale Frames button handler"""
         if not input_path or not output_path:
-            return gr.update(value=format_markdown(
-                "Please enter an input path and output path to begin", "warning"))
+            return format_markdown("Please enter an input path and output path to begin", "warning")
         if not os.path.exists(input_path):
-            return gr.update(value=format_markdown(
-                f"The input path {input_path} was not found", "error"))
+            return format_markdown(f"The input path {input_path} was not found", "error")
         if not is_safe_path(input_path):
-            return gr.update(value=format_markdown(
-                f"The input path {input_path} is not valid", "error"))
+            return format_markdown(f"The input path {input_path} is not valid", "error")
         if not is_safe_path(output_path):
-            return gr.update(value=format_markdown(
-                f"The output path {output_path} is not valid", "error"))
+            return format_markdown(f"The output path {output_path} is not valid", "error")
 
         group_names = get_directories(input_path)
         if not group_names:
-            return gr.update(value=format_markdown(
-                f"No directories were found at the input path {input_path}", "error"))
+            return format_markdown(f"No directories were found at the input path {input_path}",
+                                   "error")
 
         self.log(f"beginning batch UpscaleFrames processing with input_path={input_path}" +\
                     f" output_path={output_path}")
@@ -119,10 +115,10 @@ class UpscaleFrames(TabBase):
                 Mtqdm().update_bar(bar)
         if errors:
             message = "\r\n".join(errors)
-            return gr.update(value=format_markdown(message, "error"))
+            return format_markdown(message, "error")
         else:
             message = f"Batch processed upscaled frames saved to {os.path.abspath(output_path)}"
-            return gr.update(value=format_markdown(message))
+            return format_markdown(message)
 
     def upscale_frames(self,
                        input_path : str,
@@ -133,19 +129,19 @@ class UpscaleFrames(TabBase):
         """Upscale Frames button handler"""
         if not input_path:
             if interactive:
-                return gr.update(value=format_markdown("Please enter an input path to begin", "warning"))
+                return format_markdown("Please enter an input path to begin", "warning")
             else:
                 raise ValueError(f"The input path is empty")
         if not os.path.exists(input_path):
             message = f"The input path {input_path} was not found"
             if interactive:
-                return gr.update(value=format_markdown(message, "error"))
+                return format_markdown(message, "error")
             else:
                 raise ValueError(message)
         if not is_safe_path(input_path):
             message = f"The input path {input_path} is not valid"
             if interactive:
-                return gr.update(value=format_markdown(message, "error"))
+                return format_markdown(message, "error")
             else:
                 raise ValueError(message)
 
@@ -165,7 +161,7 @@ class UpscaleFrames(TabBase):
             if not is_safe_path(output_path):
                 message = f"The output path {output_path} is not valid"
                 if interactive:
-                    return gr.update(value=format_markdown(message, "error"))
+                    return format_markdown(message, "error")
                 else:
                     raise ValueError(f"The output path {input_path} is not valid")
             self.log(f"creating output path {output_path}")
@@ -202,6 +198,6 @@ class UpscaleFrames(TabBase):
 
         message = f"Upscaled frames saved to {os.path.abspath(output_path)}"
         if interactive:
-            return gr.update(value=format_markdown(message))
+            return format_markdown(message)
         else:
             self.log(message)

--- a/tabs/video_assembler_ui.py
+++ b/tabs/video_assembler_ui.py
@@ -54,14 +54,16 @@ class VideoAssembler(TabBase):
     def assemble_batch(self, input_path : str):
         """Clean Batch button handler"""
         if not input_path:
-            return gr.update(value=format_markdown("Enter a path to directories of video clips on this server to get started", "warning"))
+            return format_markdown(
+                "Enter a path to directories of video clips on this server to get started",
+                "warning")
 
         if not os.path.exists(input_path):
-            return gr.update(value=format_markdown(f"Input path {input_path} was not found", "error"))
+            return format_markdown(f"Input path {input_path} was not found", "error")
 
         path_names = sorted(get_directories(input_path))
         if not path_names:
-            return gr.update(value=format_markdown(f"Input path {input_path} does not contain video clip directories", "error"))
+            return format_markdown(f"Input path {input_path} does not contain video clip directories", "error")
 
         self.log(f"beginning batch combine video clips processing with input_path={input_path}")
         self.log(f"found {len(path_names)} groups to process")
@@ -88,33 +90,35 @@ class VideoAssembler(TabBase):
                 try:
                     self.assemble_clips(clips_input_path, output_filepath, interactive=False)
                 except ValueError as error:
-                    return gr.update(value=format_markdown(f"Error: {str(error)}", "error"))
+                    return format_markdown(f"Error: {str(error)}", "error")
 
                 Mtqdm().update_bar(bar)
         if warnings:
             warnings = "\r\n".join(warnings)
-            return gr.update(value=format_markdown(warnings, "warning"))
+            return format_markdown(warnings, "warning")
         else:
-            return gr.update(value=format_markdown(self.DEFAULT_MESSAGE_BATCH))
+            return format_markdown(self.DEFAULT_MESSAGE_BATCH)
 
     def assemble_clips(self, input_path : str, output_filepath : str="", interactive=True):
         """Assemble Video button handler"""
         if not input_path:
             if interactive:
-                return gr.update(value=format_markdown("Enter a path to video clips on this server to get started", "warning"))
+                return format_markdown("Enter a path to video clips on this server to get started",
+                                       "warning")
             else:
                 raise ValueError("'input_path' must be provided")
 
         if not os.path.exists(input_path):
             if interactive:
-                return gr.update(value=format_markdown(f"Input path {input_path} was not found", "error"))
+                return format_markdown(f"Input path {input_path} was not found", "error")
             else:
                 raise ValueError(f"input_path {input_path} not found")
 
         paths = sorted(get_files(input_path))
         if not paths:
             if interactive:
-                return gr.update(value=format_markdown(f"Input path {input_path} does not contain video clips", "error"))
+                return format_markdown(f"Input path {input_path} does not contain video clips",
+                                       "error")
             else:
                 raise ValueError(f"input_path {input_path} is empty")
 
@@ -131,7 +135,7 @@ class VideoAssembler(TabBase):
                                     global_options=global_options)
             except ValueError as error:
                 if interactive:
-                    return gr.update(value=format_markdown(f"Error: {str(error)}", "error"))
+                    return format_markdown(f"Error: {str(error)}", "error")
                 else:
                     raise error
 
@@ -139,4 +143,4 @@ class VideoAssembler(TabBase):
             Mtqdm().update_bar(bar)
 
         if interactive:
-            return gr.update(value=format_markdown(self.DEFAULT_MESSAGE_SINGLE))
+            return format_markdown(self.DEFAULT_MESSAGE_SINGLE)

--- a/tabs/video_blender_ui.py
+++ b/tabs/video_blender_ui.py
@@ -161,8 +161,9 @@ class VideoBlender(TabBase):
                 with gr.Row():
                     with gr.Column():
                         with gr.Row():
-                            project_path_ff = gr.Text(label="Video Blender Project Path",
-                                placeholder="Path to video frame PNG files")
+                            project_path_ff = gr.Textbox(label="Video Blender Project Path",
+                                                        max_lines=1,
+                                                        placeholder="Path to video frame PNG files")
                         with gr.Row():
                             input_clean_before_ff = gr.Number(
                                 label="Last clean frame BEFORE damaged ones", value=0,
@@ -177,8 +178,8 @@ class VideoBlender(TabBase):
                         preview_image_ff = gr.Image(type="filepath",
                             label="Fixed Frames Preview", interactive=False,
                             elem_id="highlightoutput", height=300)
-                        fixed_path_ff = gr.Text(label="Path to Restored Frames",
-                            interactive=False)
+                        fixed_path_ff = gr.Textbox(label="Path to Restored Frames", max_lines=1,
+                                                   interactive=False)
                         use_fixed_button_ff = gr.Button(value="Apply Fixed Frames",
                             elem_id="actionbutton")
                 with gr.Accordion(SimpleIcons.TIPS_SYMBOL + " Guide", open=False):

--- a/tabs/video_blender_ui.py
+++ b/tabs/video_blender_ui.py
@@ -274,11 +274,13 @@ class VideoBlender(TabBase):
             outputs=[input_project_name, input_project_path, input_path1,
                 input_path2, input_main_path, input_project_frame_rate],
             show_progress=False)
+
         save_project_button.click(self.video_blender_save_project,
             inputs=[input_project_name, input_project_path, input_path1, input_path2,
                     input_main_path, input_project_frame_rate],
             outputs=[projects_dropdown, reset_project_dropdown],
             show_progress=False)
+
         load_button.click(self.video_blender_load,
             inputs=[input_project_path, input_path1, input_path2, input_main_path,
                 input_project_frame_rate],
@@ -286,81 +288,100 @@ class VideoBlender(TabBase):
                 output_prev_frame, output_curr_frame, output_next_frame,
                 output_img_path2, fix_frames_count],
             show_progress=False)
+
         prev_frame_button.click(self.video_blender_prev_frame,
             inputs=[input_text_frame],
             outputs=[input_text_frame, output_img_path1, output_prev_frame,
                 output_curr_frame, output_next_frame, output_img_path2, fix_frames_count],
             show_progress=False)
+
         next_frame_button.click(self.video_blender_next_frame,
             inputs=[input_text_frame],
             outputs=[input_text_frame, output_img_path1, output_prev_frame,
                 output_curr_frame, output_next_frame, output_img_path2, fix_frames_count],
             show_progress=False)
+
         input_text_frame.submit(self.video_blender_goto_frame,
             inputs=[input_text_frame],
             outputs=[input_text_frame, output_img_path1, output_prev_frame,
                 output_curr_frame, output_next_frame, output_img_path2, fix_frames_count],
             show_progress=False)
+
         input_text_frame.change(self.video_blender_goto_frame2,
             inputs=[input_text_frame],
             outputs=[output_img_path1, output_prev_frame,
                 output_curr_frame, output_next_frame, output_img_path2, fix_frames_count],
             show_progress=False)
+
         use_path_1_button.click(self.video_blender_use_path1,
             inputs=[input_text_frame],
             outputs=[input_text_frame, output_img_path1, output_prev_frame,
                 output_curr_frame, output_next_frame, output_img_path2, fix_frames_count],
             show_progress=False)
+
         use_path_2_button.click(self.video_blender_use_path2,
             inputs=[input_text_frame],
             outputs=[input_text_frame, output_img_path1, output_prev_frame,
                 output_curr_frame, output_next_frame, output_img_path2, fix_frames_count],
             show_progress=False)
+
         prev_xframes_button.click(self.video_blender_skip_prev,
             inputs=[input_text_frame],
             outputs=[input_text_frame, output_img_path1, output_prev_frame,
                 output_curr_frame, output_next_frame, output_img_path2, fix_frames_count],
             show_progress=False)
+
         next_xframes_button.click(self.video_blender_skip_next,
             inputs=[input_text_frame],
             outputs=[input_text_frame, output_img_path1, output_prev_frame,
                 output_curr_frame, output_next_frame, output_img_path2, fix_frames_count],
             show_progress=False)
+
         preview_video.click(self.video_blender_preview_video,
             inputs=input_project_path, outputs=[tabs_video_blender, preview_path])
+
         fix_frames_count.change(self.video_blender_compute_fix_frames,
                                 inputs=[input_text_frame, fix_frames_count],
                                 outputs=[fix_frames_last_before, fix_frames_first_after,
                                          fix_frames_count],
                                 show_progress=False)
+
         fix_frames_button.click(self.video_blender_fix_frames,
             inputs=[input_project_path, fix_frames_count, fix_frames_last_before,
                     fix_frames_first_after],
             outputs=[tabs_video_blender, project_path_ff, input_clean_before_ff,
                 input_clean_after_ff, fixed_path_ff])
+
         preview_button_ff.click(self.video_blender_preview_fixed,
             inputs=[project_path_ff, input_clean_before_ff, input_clean_after_ff],
             outputs=[preview_image_ff, fixed_path_ff])
+
         use_fixed_button_ff.click(self.video_blender_use_fixed,
             inputs=[project_path_ff, fixed_path_ff, input_clean_before_ff],
             outputs=[tabs_video_blender, fixed_path_ff, input_text_frame, output_img_path1,
                 output_prev_frame,output_curr_frame, output_next_frame,
                 output_img_path2, fix_frames_count, preview_image_ff, fixed_path_ff])
+
         render_video.click(self.video_blender_render_preview,
             inputs=[preview_path, input_frame_rate], outputs=[video_preview])
-        step1_enabled.change(self.video_blender_new_project_ui_switch,
+
+        step1_enabled.change(self.video_blender_new_project_ui_switch_1,
             inputs=[step1_enabled, step2_enabled, step3_enabled, step4_enabled],
             outputs=[step1_input, step2_input, step3_input], show_progress=False)
-        step2_enabled.change(self.video_blender_new_project_ui_switch,
+
+        step2_enabled.change(self.video_blender_new_project_ui_switch_2,
             inputs=[step1_enabled, step2_enabled, step3_enabled, step4_enabled],
             outputs=[step1_input, step2_input, step3_input], show_progress=False)
-        step3_enabled.change(self.video_blender_new_project_ui_switch,
+
+        step3_enabled.change(self.video_blender_new_project_ui_switch_3,
             inputs=[step1_enabled, step2_enabled, step3_enabled, step4_enabled],
             outputs=[step1_input, step2_input, step3_input], show_progress=False)
+
         new_project_button.click(self.video_blender_new_project,
             inputs=[new_project_name, new_project_path, step1_enabled, step2_enabled, step3_enabled,
                 step4_enabled, step1_input, step2_input, step3_input, new_project_frame_rate],
             outputs=[projects_dropdown, reset_project_dropdown], show_progress=False)
+
         reset_project_button.click(self.video_blender_reset_project,
             inputs=reset_project_dropdown,
             outputs=[tabs_video_blender, new_project_name, new_project_path, step1_enabled,
@@ -566,7 +587,35 @@ class VideoBlender(TabBase):
                 crf=QUALITY_SMALLER_SIZE, global_options=global_options)
             return output_filepath
 
-    def video_blender_new_project_ui_switch(self,
+    def video_blender_new_project_ui_switch_1(self,
+                                            step1_enabled,
+                                            step2_enabled,
+                                            step3_enabled,
+                                            step4_enabled):
+        return self.video_blender_new_project_ui_switch_shared(step1_enabled,
+                                                               step2_enabled,
+                                                               step3_enabled,
+                                                               step4_enabled)
+    def video_blender_new_project_ui_switch_2(self,
+                                            step1_enabled,
+                                            step2_enabled,
+                                            step3_enabled,
+                                            step4_enabled):
+        return self.video_blender_new_project_ui_switch_shared(step1_enabled,
+                                                               step2_enabled,
+                                                               step3_enabled,
+                                                               step4_enabled)
+    def video_blender_new_project_ui_switch_3(self,
+                                            step1_enabled,
+                                            step2_enabled,
+                                            step3_enabled,
+                                            step4_enabled):
+        return self.video_blender_new_project_ui_switch_shared(step1_enabled,
+                                                               step2_enabled,
+                                                               step3_enabled,
+                                                               step4_enabled)
+
+    def video_blender_new_project_ui_switch_shared(self,
                                             step1_enabled,
                                             step2_enabled,
                                             step3_enabled,

--- a/tabs/video_blender_ui.py
+++ b/tabs/video_blender_ui.py
@@ -7,7 +7,7 @@ from webui_utils.simple_config import SimpleConfig
 from webui_utils.simple_icons import SimpleIcons
 from webui_utils.image_utils import create_gif
 from webui_utils.file_utils import get_files, create_directory, locate_frame_file, \
-    duplicate_directory, split_filepath
+    duplicate_directory
 from webui_utils.auto_increment import AutoIncrementDirectory, AutoIncrementFilename
 from webui_utils.video_utils import PNGtoMP4, QUALITY_SMALLER_SIZE, MP4toPNG
 from webui_tips import WebuiTips
@@ -30,8 +30,8 @@ class VideoBlender(TabBase):
                     log_fn : Callable):
         TabBase.__init__(self, config, engine, log_fn)
         self.video_blender_state = None
-        self.video_blender_projects = VideoBlenderProjects(self.config.
-            blender_settings["projects_file"])
+        self.video_blender_projects = VideoBlenderProjects(
+            self.config.blender_settings["projects_file"])
         self.video_blender_tabs = None
         self.new_project_name = None
         self.new_project_path = None
@@ -65,7 +65,7 @@ class VideoBlender(TabBase):
                 with gr.Row():
                     with gr.Column(scale=3, variant="compact"):
                         with gr.Row():
-                            input_project_name_vb = gr.Textbox(label="Project Name")
+                            input_project_name_vb = gr.Textbox(label="Project Name", max_lines=1)
                     with gr.Column(scale=3, variant="compact", elem_id="mainhighlightdim"):
                         with gr.Row():
                             choices = self.video_blender_projects.get_project_names()
@@ -74,19 +74,19 @@ class VideoBlender(TabBase):
                             save_project_button_vb = gr.Button(SimpleIcons.PROP_SYMBOL +
                                 " Save", scale=0)
                 with gr.Row():
-                    input_main_path = gr.Textbox(label="Project Main Path",
+                    input_main_path = gr.Textbox(label="Project Main Path", max_lines=1,
                                                     placeholder="Root path for the project")
                     input_project_frame_rate = gr.Slider(value=frame_rate, minimum=1,
                                         maximum=max_frame_rate, step=0.01, label="Frame Rate")
                 with gr.Row():
-                    input_project_path_vb = gr.Textbox(label="Project Frames Path",
+                    input_project_path_vb = gr.Textbox(label="Project Frames Path", max_lines=1,
                         placeholder="Path to frame PNG files for video being restored")
                 with gr.Row():
                     input_path1_vb = gr.Textbox(label="Original / Video #1 Frames Path",
-                        placeholder="Path to original or video #1 PNG files")
+                                max_lines=1, placeholder="Path to original or video #1 PNG files")
                 with gr.Row():
                     input_path2_vb = gr.Textbox(label="Alternate / Video #2 Frames Path",
-                        placeholder="Path to alternate or video #2 PNG files")
+                                max_lines=1, placeholder="Path to alternate or video #2 PNG files")
                 load_button_vb = gr.Button("Open Video Blender Project " +
                     SimpleIcons.ROCKET, variant="primary")
                 with gr.Accordion(SimpleIcons.TIPS_SYMBOL + " Guide", open=False):
@@ -192,7 +192,7 @@ class VideoBlender(TabBase):
                         video_preview_vb = gr.Video(label="Preview", interactive=False,
                             include_audio=False, width=800, container=True, scale=8)
                     gr.Column(scale=1)
-                preview_path_vb = gr.Textbox(max_lines=1, label="Path to PNG Sequence",
+                preview_path_vb = gr.Textbox(label="Path to PNG Sequence", max_lines=1,
                     placeholder="Path on this server to the PNG files to be converted")
                 with gr.Row():
                     render_video_vb = gr.Button("Render Video", variant="primary")
@@ -208,12 +208,10 @@ class VideoBlender(TabBase):
                         gr.HTML("Define New Project")
                         with gr.Row(variant="panel"):
                             with gr.Column(scale=1):
-                                new_project_name = gr.Textbox(max_lines=1,
-                                    label="New Project Name",
+                                new_project_name = gr.Textbox(label="New Project Name", max_lines=1,
                                     placeholder="Name for the new project")
                             with gr.Column(scale=12):
-                                new_project_path = gr.Textbox(max_lines=1,
-                                    label="New Project Path",
+                                new_project_path = gr.Textbox(label="New Project Path", max_lines=1,
                                     placeholder="Path on this server for the new project")
                             with gr.Column(scale=1):
                                 new_project_frame_rate = gr.Slider(value=frame_rate, minimum=1,
@@ -223,35 +221,35 @@ class VideoBlender(TabBase):
                         gr.HTML("Check Applicable Setup Steps")
                         with gr.Row(variant="panel"):
                             with gr.Column(scale=1):
-                                step1_enabled = gr.Checkbox(value=True, label=SimpleIcons.ONE +
-                                                            " Split MP4 to PNG Frames Set")
+                                step1_enabled = gr.Checkbox(value=True,
+                                            label=SimpleIcons.ONE + " Split MP4 to PNG Frames Set")
                             with gr.Column(scale=12):
                                 with gr.Row():
-                                    step1_input = gr.Textbox(max_lines=1, interactive=True,
-                                        label="MP4 Path",
+                                    step1_input = gr.Textbox(label="MP4 Path", max_lines=1,
+                                        interactive=True,
                                         placeholder="Path on this server to the source MP4 file")
                         with gr.Row(variant="panel"):
                             with gr.Column(scale=1):
-                                step2_enabled = gr.Checkbox(value=True, label=SimpleIcons.TWO +
-                                                            " Resynthesize Repair Frames Set")
+                                step2_enabled = gr.Checkbox(value=True,
+                                        label=SimpleIcons.TWO + " Resynthesize Repair Frames Set")
                             with gr.Column(scale=12):
-                                step2_input = gr.Textbox(max_lines=1, interactive=False,
-                                    label="n/a",
-                                placeholder="Repair frames set will be automatically created")
+                                step2_input = gr.Textbox(label="n/a", max_lines=1,
+                                    interactive=False,
+                                    placeholder="Repair frames set will be automatically created")
                         with gr.Row(variant="panel"):
                             with gr.Column(scale=1):
-                                step3_enabled = gr.Checkbox(value=True, label=SimpleIcons.THREE
-                                                            + " Init Restored Set from Source")
+                                step3_enabled = gr.Checkbox(value=True,
+                                        label=SimpleIcons.THREE + " Init Restored Set from Source")
                             with gr.Column(scale=12):
-                                step3_input = gr.Textbox(max_lines=1, interactive=False,
-                                    label="n/a",
-                                placeholder="Restored frames set will be automatically created")
+                                step3_input = gr.Textbox(label="n/a", max_lines=1,
+                                    interactive=False,
+                                    placeholder="Restored frames set will be automatically created")
                         with gr.Row(variant="panel"):
                             with gr.Column(scale=1):
-                                step4_enabled = gr.Checkbox(value=True, label=SimpleIcons.FOUR +
-                                                            " Sync Frame Numbers Across Sets")
+                                step4_enabled = gr.Checkbox(value=True,
+                                        label=SimpleIcons.FOUR + " Sync Frame Numbers Across Sets")
                             with gr.Column(scale=12):
-                                gr.Textbox(visible=False)
+                                gr.Textbox(visible=False, max_lines=1)
                 gr.Markdown("*Progress can be tracked in the console*")
                 new_project_button = gr.Button("Create New Project " + SimpleIcons.SLOW_SYMBOL,
                                                 variant="primary")
@@ -704,9 +702,11 @@ class VideoBlender(TabBase):
                 upper_filename = f"repair_frame{str(upper_frame).zfill(num_width)}.png"
                 lower_filepath = os.path.join(resynth_frames_path, lower_filename)
                 upper_filepath = os.path.join(resynth_frames_path, upper_filename)
-                self.log(f"duplicating source frame {lower_outer_frame} to {lower_filepath} for frame syncing")
+                self.log(
+            f"duplicating source frame {lower_outer_frame} to {lower_filepath} for frame syncing")
                 shutil.copy(lower_outer_frame, lower_filepath)
-                self.log(f"duplicating source frame {upper_outer_frame} to {upper_filepath} for frame syncing")
+                self.log(
+            f"duplicating source frame {upper_outer_frame} to {upper_filepath} for frame syncing")
                 shutil.copy(upper_outer_frame, upper_filepath)
 
             if self.config.blender_settings["clean_frames"]:

--- a/tabs/video_blender_ui.py
+++ b/tabs/video_blender_ui.py
@@ -65,13 +65,13 @@ class VideoBlender(TabBase):
                 with gr.Row():
                     with gr.Column(scale=3, variant="compact"):
                         with gr.Row():
-                            input_project_name_vb = gr.Textbox(label="Project Name", max_lines=1)
+                            input_project_name = gr.Textbox(label="Project Name", max_lines=1)
                     with gr.Column(scale=3, variant="compact", elem_id="mainhighlightdim"):
                         with gr.Row():
                             choices = self.video_blender_projects.get_project_names()
-                            projects_dropdown_vb = gr.Dropdown(label=SimpleIcons.PROP_SYMBOL +
+                            projects_dropdown = gr.Dropdown(label=SimpleIcons.PROP_SYMBOL +
                                 " Saved Projects", choices=choices, value=choices[0])
-                            save_project_button_vb = gr.Button(SimpleIcons.PROP_SYMBOL +
+                            save_project_button = gr.Button(SimpleIcons.PROP_SYMBOL +
                                 " Save", scale=0)
                 with gr.Row():
                     input_main_path = gr.Textbox(label="Project Main Path", max_lines=1,
@@ -79,15 +79,15 @@ class VideoBlender(TabBase):
                     input_project_frame_rate = gr.Slider(value=frame_rate, minimum=1,
                                         maximum=max_frame_rate, step=0.01, label="Frame Rate")
                 with gr.Row():
-                    input_project_path_vb = gr.Textbox(label="Project Frames Path", max_lines=1,
+                    input_project_path = gr.Textbox(label="Project Frames Path", max_lines=1,
                         placeholder="Path to frame PNG files for video being restored")
                 with gr.Row():
-                    input_path1_vb = gr.Textbox(label="Original / Video #1 Frames Path",
+                    input_path1 = gr.Textbox(label="Original / Video #1 Frames Path",
                                 max_lines=1, placeholder="Path to original or video #1 PNG files")
                 with gr.Row():
-                    input_path2_vb = gr.Textbox(label="Alternate / Video #2 Frames Path",
+                    input_path2 = gr.Textbox(label="Alternate / Video #2 Frames Path",
                                 max_lines=1, placeholder="Path to alternate or video #2 PNG files")
-                load_button_vb = gr.Button("Open Video Blender Project " +
+                load_button = gr.Button("Open Video Blender Project " +
                     SimpleIcons.ROCKET, variant="primary")
                 with gr.Accordion(SimpleIcons.TIPS_SYMBOL + " Guide", open=False):
                     WebuiTips.video_blender_project_settings.render()
@@ -96,13 +96,13 @@ class VideoBlender(TabBase):
             with gr.Tab(SimpleIcons.CONTROLS + "Frame Chooser", id=self.TAB_FRAME_CHOOSER):
                 with gr.Row():
                     with gr.Column():
-                        output_prev_frame_vb = gr.Image(label="Previous Frame",
+                        output_prev_frame = gr.Image(label="Previous Frame",
                             interactive=False, type="filepath", elem_id="sideimage", height=300)
                     with gr.Column():
-                        output_curr_frame_vb = gr.Image(show_label=False,
+                        output_curr_frame = gr.Image(show_label=False,
                             interactive=False, type="filepath", elem_id="actionimage", height=300)
                     with gr.Column():
-                        output_next_frame_vb = gr.Image(label="Next Frame",
+                        output_next_frame = gr.Image(label="Next Frame",
                             interactive=False, type="filepath", elem_id="sideimage", height=300)
                 with gr.Row():
                     with gr.Column():
@@ -120,36 +120,36 @@ class VideoBlender(TabBase):
                                 fix_frames_first_after = gr.Number(
                                     label="First Frame After Damage", value=0, precision=0,
                                     interactive=False)
-                            fix_frames_button_vb = gr.Button("Go To " + SimpleIcons.HAMMER
+                            fix_frames_button = gr.Button("Go To " + SimpleIcons.HAMMER
                                                                 + " Frame Fixer")
                         with gr.Row():
-                            preview_video_vb = gr.Button("Go To "  + SimpleIcons.TELEVISION
+                            preview_video = gr.Button("Go To "  + SimpleIcons.TELEVISION
                                                             + " Video Preview")
 
                     with gr.Column():
                         with gr.Tabs():
                             with gr.Tab(label="Repair / Path 2 Frame"):
-                                output_img_path2_vb = gr.Image(show_label=False,
+                                output_img_path2 = gr.Image(show_label=False,
                                     interactive=False, type="filepath", height=300)
                             with gr.Tab(label="Original / Path 1 Frame"):
-                                output_img_path1_vb = gr.Image(show_label=False,
+                                output_img_path1 = gr.Image(show_label=False,
                                     interactive=False, type="filepath", height=300)
 
                     with gr.Column():
                         gr.Row()
-                        use_path_1_button_vb = gr.Button("Use Path 1 Frame | Next >",
+                        use_path_1_button = gr.Button("Use Path 1 Frame | Next >",
                             variant="primary", elem_id="actionbutton")
-                        use_path_2_button_vb = gr.Button("Use Path 2 Frame | Next >",
+                        use_path_2_button = gr.Button("Use Path 2 Frame | Next >",
                             variant="primary", elem_id="actionbutton")
                         with gr.Row():
-                            prev_frame_button_vb = gr.Button("< Prev Frame",
+                            prev_frame_button = gr.Button("< Prev Frame",
                                 variant="primary")
-                            next_frame_button_vb = gr.Button("Next Frame >",
+                            next_frame_button = gr.Button("Next Frame >",
                                 variant="primary")
                         with gr.Row():
-                            prev_xframes_button_vb = gr.Button(f"<< {skip_frames}")
-                            next_xframes_button_vb = gr.Button(f"{skip_frames} >>")
-                        input_text_frame_vb = gr.Number(value=0, precision=0,
+                            prev_xframes_button = gr.Button(f"<< {skip_frames}")
+                            next_xframes_button = gr.Button(f"{skip_frames} >>")
+                        input_text_frame = gr.Number(value=0, precision=0,
                             label="Frame Number")
 
                 if self.config.user_interface["show_header"]:
@@ -189,14 +189,14 @@ class VideoBlender(TabBase):
                 with gr.Row():
                     gr.Column(scale=1)
                     with gr.Column():
-                        video_preview_vb = gr.Video(label="Preview", interactive=False,
+                        video_preview = gr.Video(label="Preview", interactive=False,
                             include_audio=False, width=800, container=True, scale=8)
                     gr.Column(scale=1)
-                preview_path_vb = gr.Textbox(label="Path to PNG Sequence", max_lines=1,
+                preview_path = gr.Textbox(label="Path to PNG Sequence", max_lines=1,
                     placeholder="Path on this server to the PNG files to be converted")
                 with gr.Row():
-                    render_video_vb = gr.Button("Render Video", variant="primary")
-                    input_frame_rate_vb = gr.Slider(value=frame_rate, minimum=1,
+                    render_video = gr.Button("Render Video", variant="primary")
+                    input_frame_rate = gr.Slider(value=frame_rate, minimum=1,
                                         maximum=max_frame_rate, step=0.01, label="Frame Rate")
                 with gr.Accordion(SimpleIcons.TIPS_SYMBOL + " Guide", open=False):
                     WebuiTips.video_blender_video_preview.render()
@@ -269,72 +269,72 @@ class VideoBlender(TabBase):
                 with gr.Accordion(SimpleIcons.TIPS_SYMBOL + " Guide", open=False):
                     WebuiTips.video_blender_reset_project.render()
 
-        projects_dropdown_vb.change(self.video_blender_choose_project,
-            inputs=[projects_dropdown_vb],
-            outputs=[input_project_name_vb, input_project_path_vb, input_path1_vb,
-                input_path2_vb, input_main_path, input_project_frame_rate],
+        projects_dropdown.change(self.video_blender_choose_project,
+            inputs=[projects_dropdown],
+            outputs=[input_project_name, input_project_path, input_path1,
+                input_path2, input_main_path, input_project_frame_rate],
             show_progress=False)
-        save_project_button_vb.click(self.video_blender_save_project,
-            inputs=[input_project_name_vb, input_project_path_vb, input_path1_vb, input_path2_vb,
+        save_project_button.click(self.video_blender_save_project,
+            inputs=[input_project_name, input_project_path, input_path1, input_path2,
                     input_main_path, input_project_frame_rate],
-            outputs=[projects_dropdown_vb, reset_project_dropdown],
+            outputs=[projects_dropdown, reset_project_dropdown],
             show_progress=False)
-        load_button_vb.click(self.video_blender_load,
-            inputs=[input_project_path_vb, input_path1_vb, input_path2_vb, input_main_path,
+        load_button.click(self.video_blender_load,
+            inputs=[input_project_path, input_path1, input_path2, input_main_path,
                 input_project_frame_rate],
-            outputs=[tabs_video_blender, input_text_frame_vb, output_img_path1_vb,
-                output_prev_frame_vb, output_curr_frame_vb, output_next_frame_vb,
-                output_img_path2_vb, fix_frames_count],
+            outputs=[tabs_video_blender, input_text_frame, output_img_path1,
+                output_prev_frame, output_curr_frame, output_next_frame,
+                output_img_path2, fix_frames_count],
             show_progress=False)
-        prev_frame_button_vb.click(self.video_blender_prev_frame,
-            inputs=[input_text_frame_vb],
-            outputs=[input_text_frame_vb, output_img_path1_vb, output_prev_frame_vb,
-                output_curr_frame_vb, output_next_frame_vb, output_img_path2_vb, fix_frames_count],
+        prev_frame_button.click(self.video_blender_prev_frame,
+            inputs=[input_text_frame],
+            outputs=[input_text_frame, output_img_path1, output_prev_frame,
+                output_curr_frame, output_next_frame, output_img_path2, fix_frames_count],
             show_progress=False)
-        next_frame_button_vb.click(self.video_blender_next_frame,
-            inputs=[input_text_frame_vb],
-            outputs=[input_text_frame_vb, output_img_path1_vb, output_prev_frame_vb,
-                output_curr_frame_vb, output_next_frame_vb, output_img_path2_vb, fix_frames_count],
+        next_frame_button.click(self.video_blender_next_frame,
+            inputs=[input_text_frame],
+            outputs=[input_text_frame, output_img_path1, output_prev_frame,
+                output_curr_frame, output_next_frame, output_img_path2, fix_frames_count],
             show_progress=False)
-        input_text_frame_vb.submit(self.video_blender_goto_frame,
-            inputs=[input_text_frame_vb],
-            outputs=[input_text_frame_vb, output_img_path1_vb, output_prev_frame_vb,
-                output_curr_frame_vb, output_next_frame_vb, output_img_path2_vb, fix_frames_count],
+        input_text_frame.submit(self.video_blender_goto_frame,
+            inputs=[input_text_frame],
+            outputs=[input_text_frame, output_img_path1, output_prev_frame,
+                output_curr_frame, output_next_frame, output_img_path2, fix_frames_count],
             show_progress=False)
-        input_text_frame_vb.change(self.video_blender_goto_frame2,
-            inputs=[input_text_frame_vb],
-            outputs=[output_img_path1_vb, output_prev_frame_vb,
-                output_curr_frame_vb, output_next_frame_vb, output_img_path2_vb, fix_frames_count],
+        input_text_frame.change(self.video_blender_goto_frame2,
+            inputs=[input_text_frame],
+            outputs=[output_img_path1, output_prev_frame,
+                output_curr_frame, output_next_frame, output_img_path2, fix_frames_count],
             show_progress=False)
-        use_path_1_button_vb.click(self.video_blender_use_path1,
-            inputs=[input_text_frame_vb],
-            outputs=[input_text_frame_vb, output_img_path1_vb, output_prev_frame_vb,
-                output_curr_frame_vb, output_next_frame_vb, output_img_path2_vb, fix_frames_count],
+        use_path_1_button.click(self.video_blender_use_path1,
+            inputs=[input_text_frame],
+            outputs=[input_text_frame, output_img_path1, output_prev_frame,
+                output_curr_frame, output_next_frame, output_img_path2, fix_frames_count],
             show_progress=False)
-        use_path_2_button_vb.click(self.video_blender_use_path2,
-            inputs=[input_text_frame_vb],
-            outputs=[input_text_frame_vb, output_img_path1_vb, output_prev_frame_vb,
-                output_curr_frame_vb, output_next_frame_vb, output_img_path2_vb, fix_frames_count],
+        use_path_2_button.click(self.video_blender_use_path2,
+            inputs=[input_text_frame],
+            outputs=[input_text_frame, output_img_path1, output_prev_frame,
+                output_curr_frame, output_next_frame, output_img_path2, fix_frames_count],
             show_progress=False)
-        prev_xframes_button_vb.click(self.video_blender_skip_prev,
-            inputs=[input_text_frame_vb],
-            outputs=[input_text_frame_vb, output_img_path1_vb, output_prev_frame_vb,
-                output_curr_frame_vb, output_next_frame_vb, output_img_path2_vb, fix_frames_count],
+        prev_xframes_button.click(self.video_blender_skip_prev,
+            inputs=[input_text_frame],
+            outputs=[input_text_frame, output_img_path1, output_prev_frame,
+                output_curr_frame, output_next_frame, output_img_path2, fix_frames_count],
             show_progress=False)
-        next_xframes_button_vb.click(self.video_blender_skip_next,
-            inputs=[input_text_frame_vb],
-            outputs=[input_text_frame_vb, output_img_path1_vb, output_prev_frame_vb,
-                output_curr_frame_vb, output_next_frame_vb, output_img_path2_vb, fix_frames_count],
+        next_xframes_button.click(self.video_blender_skip_next,
+            inputs=[input_text_frame],
+            outputs=[input_text_frame, output_img_path1, output_prev_frame,
+                output_curr_frame, output_next_frame, output_img_path2, fix_frames_count],
             show_progress=False)
-        preview_video_vb.click(self.video_blender_preview_video,
-            inputs=input_project_path_vb, outputs=[tabs_video_blender, preview_path_vb])
+        preview_video.click(self.video_blender_preview_video,
+            inputs=input_project_path, outputs=[tabs_video_blender, preview_path])
         fix_frames_count.change(self.video_blender_compute_fix_frames,
-                                inputs=[input_text_frame_vb, fix_frames_count],
+                                inputs=[input_text_frame, fix_frames_count],
                                 outputs=[fix_frames_last_before, fix_frames_first_after,
                                          fix_frames_count],
                                 show_progress=False)
-        fix_frames_button_vb.click(self.video_blender_fix_frames,
-            inputs=[input_project_path_vb, fix_frames_count, fix_frames_last_before,
+        fix_frames_button.click(self.video_blender_fix_frames,
+            inputs=[input_project_path, fix_frames_count, fix_frames_last_before,
                     fix_frames_first_after],
             outputs=[tabs_video_blender, project_path_ff, input_clean_before_ff,
                 input_clean_after_ff, fixed_path_ff])
@@ -343,11 +343,11 @@ class VideoBlender(TabBase):
             outputs=[preview_image_ff, fixed_path_ff])
         use_fixed_button_ff.click(self.video_blender_use_fixed,
             inputs=[project_path_ff, fixed_path_ff, input_clean_before_ff],
-            outputs=[tabs_video_blender, fixed_path_ff, input_text_frame_vb, output_img_path1_vb,
-                output_prev_frame_vb,output_curr_frame_vb, output_next_frame_vb,
-                output_img_path2_vb, fix_frames_count, preview_image_ff, fixed_path_ff])
-        render_video_vb.click(self.video_blender_render_preview,
-            inputs=[preview_path_vb, input_frame_rate_vb], outputs=[video_preview_vb])
+            outputs=[tabs_video_blender, fixed_path_ff, input_text_frame, output_img_path1,
+                output_prev_frame,output_curr_frame, output_next_frame,
+                output_img_path2, fix_frames_count, preview_image_ff, fixed_path_ff])
+        render_video.click(self.video_blender_render_preview,
+            inputs=[preview_path, input_frame_rate], outputs=[video_preview])
         step1_enabled.change(self.video_blender_new_project_ui_switch,
             inputs=[step1_enabled, step2_enabled, step3_enabled, step4_enabled],
             outputs=[step1_input, step2_input, step3_input], show_progress=False)
@@ -360,7 +360,7 @@ class VideoBlender(TabBase):
         new_project_button.click(self.video_blender_new_project,
             inputs=[new_project_name, new_project_path, step1_enabled, step2_enabled, step3_enabled,
                 step4_enabled, step1_input, step2_input, step3_input, new_project_frame_rate],
-            outputs=[projects_dropdown_vb, reset_project_dropdown], show_progress=False)
+            outputs=[projects_dropdown, reset_project_dropdown], show_progress=False)
         reset_project_button.click(self.video_blender_reset_project,
             inputs=reset_project_dropdown,
             outputs=[tabs_video_blender, new_project_name, new_project_path, step1_enabled,

--- a/tabs/video_details_ui.py
+++ b/tabs/video_details_ui.py
@@ -66,7 +66,7 @@ class VideoDetails(TabBase):
                     report.append(separator)
                     report.append("Console output:")
                     report.append(error_data["console_output"])
-                    return gr.update(value="\r\n".join(report)), None, None, None, None, None
+                    return "\r\n".join(report), None, None, None, None, None
 
                 format = {}
                 format_data = data["format"]
@@ -143,14 +143,13 @@ class VideoDetails(TabBase):
                     report.append(separator)
                 report.append("More media file details availale in the Log Viewer")
 
-                return gr.update(value="\r\n".join(report)),\
+                return "\r\n".join(report),\
                                  video_summary.get("frame_rate"),\
                                  video_summary.get("duration"),\
                                  video_summary.get("dimensions"),\
                                  video_summary.get("frame_count"),\
                                  video_summary.get("file_size")
             else:
-                return gr.update(value=f"media file {input_path} not found"), None, None, None,\
-                                                                            None, None
+                return f"media file {input_path} not found", None, None, None, None, None
         else:
-            return gr.update(value="media file path must be supplied"), None, None, None, None, None
+            return "media file path must be supplied", None, None, None, None, None

--- a/tabs/video_inflation_ui.py
+++ b/tabs/video_inflation_ui.py
@@ -24,8 +24,10 @@ class VideoInflation(TabBase):
                     log_fn : Callable):
         TabBase.__init__(self, config, engine, log_fn)
 
-    DEFAULT_MESSAGE_SINGLE = "Click Inflate Video to: Insert the specified number of interpolated frames"
-    DEFAULT_MESSAGE_BATCH = "Click Inflate Batch to: Insert the specified number of interpolated frames for each batch directory"
+    DEFAULT_MESSAGE_SINGLE = \
+        "Click Inflate Video to: Insert the specified number of interpolated frames"
+    DEFAULT_MESSAGE_BATCH = \
+"Click Inflate Batch to: Insert the specified number of interpolated frames for each batch directory"
 
     def render_tab(self):
         """Render tab into UI"""
@@ -77,19 +79,16 @@ class VideoInflation(TabBase):
     def batch_inflation(self, input_path : str, output_path : str | None, num_splits : float):
         """Inflate Video button handler"""
         if not input_path:
-            return gr.update(value=format_markdown(
-                "Please enter an input path to begin", "warning"))
+            return format_markdown("Please enter an input path to begin", "warning")
         if not os.path.exists(input_path):
-            return gr.update(value=format_markdown(
-                f"The input path {input_path} was not found", "error"))
+            return format_markdown(f"The input path {input_path} was not found", "error")
         if not is_safe_path(input_path):
-            return gr.update(value=format_markdown(
-                f"The input path {input_path} is not valid", "error"))
+            return format_markdown(f"The input path {input_path} is not valid", "error")
 
         group_names = get_directories(input_path)
         if not group_names:
-            return gr.update(value=format_markdown(
-                f"No directories were found at the input path {input_path}", "error"))
+            return format_markdown(f"No directories were found at the input path {input_path}",
+                                   "error")
 
         self.log(f"beginning batch VideoInflation processing with input_path={input_path}" +\
                     f" output_path={output_path}")
@@ -97,8 +96,7 @@ class VideoInflation(TabBase):
 
         if output_path:
             if not is_safe_path(output_path):
-                return gr.update(value=format_markdown(
-                    f"The output path {output_path} is not valid", "error"))
+                return format_markdown(f"The output path {output_path} is not valid", "error")
             self.log(f"creating group output path {output_path}")
             create_directory(output_path)
         else:
@@ -111,34 +109,36 @@ class VideoInflation(TabBase):
                 group_input_path = os.path.join(input_path, group_name)
                 group_output_path = os.path.join(output_path, group_name)
                 try:
-                    self.video_inflation(group_input_path, group_output_path, num_splits, interactive=False)
+                    self.video_inflation(group_input_path, group_output_path, num_splits,
+                                         interactive=False)
                 except ValueError as error:
                     errors.append(f"Error handling directory {group_name}: " + str(error))
                 Mtqdm().update_bar(bar)
         if errors:
             message = "\r\n".join(errors)
-            return gr.update(value=format_markdown(message, "error"))
+            return format_markdown(message, "error")
         else:
             message = f"Batch processed inflated frames saved to {os.path.abspath(output_path)}"
-            return gr.update(value=format_markdown(message))
+            return format_markdown(message)
 
-    def video_inflation(self, input_path : str, output_path : str | None, num_splits : float, interactive : bool=True):
+    def video_inflation(self, input_path : str, output_path : str | None, num_splits : float,
+                        interactive : bool=True):
         """Inflate Video button handler"""
         if not input_path:
             if interactive:
-                return gr.update(value=format_markdown("Please enter an input path to begin", "warning"))
+                return format_markdown("Please enter an input path to begin", "warning")
             else:
                 raise ValueError(f"The input path is empty")
         if not os.path.exists(input_path):
             message = f"The input path {input_path} was not found"
             if interactive:
-                return gr.update(value=format_markdown(message, "error"))
+                return format_markdown(message, "error")
             else:
                 raise ValueError(message)
         if not is_safe_path(input_path):
             message = f"The input path {input_path} is not valid"
             if interactive:
-                return gr.update(value=format_markdown(message, "error"))
+                return format_markdown(message, "error")
             else:
                 raise ValueError(message)
 
@@ -146,7 +146,7 @@ class VideoInflation(TabBase):
             if not is_safe_path(output_path):
                 message = f"The output path {output_path} is not valid"
                 if interactive:
-                    return gr.update(value=format_markdown(message, "error"))
+                    return format_markdown(message, "error")
                 else:
                     raise ValueError(f"The output path {input_path} is not valid")
             self.log(f"creating output path {output_path}")
@@ -168,6 +168,6 @@ class VideoInflation(TabBase):
 
         message = f"Inflated frames saved to {os.path.abspath(output_path)}"
         if interactive:
-            return gr.update(value=format_markdown(message))
+            return format_markdown(message)
         else:
             self.log(message)

--- a/tabs/video_remixer_ui.py
+++ b/tabs/video_remixer_ui.py
@@ -916,11 +916,11 @@ class VideoRemixer(TabBase):
         choose_range_button.click(self.choose_range_shortcut, inputs=scene_index,
             outputs=[tabs_video_remixer, tabs_remix_extra, first_scene_id_701, last_scene_id_701])
 
-        set_scene_label.submit(self.save_scene_label, inputs=[scene_index, set_scene_label],
+        set_scene_label.submit(self.submit_scene_label, inputs=[scene_index, set_scene_label],
                             outputs=[scene_index, scene_name, scene_image, scene_state,
                                      scene_info, set_scene_label])
 
-        save_scene_label.click(self.save_scene_label, inputs=[scene_index, set_scene_label],
+        save_scene_label.click(self.click_scene_label, inputs=[scene_index, set_scene_label],
                             outputs=[scene_index, scene_name, scene_image, scene_state,
                                      scene_info, set_scene_label])
 
@@ -937,6 +937,7 @@ class VideoRemixer(TabBase):
         auto_label_scenes.click(self.auto_label_scenes,
                                 outputs=[scene_index, scene_name, scene_image, scene_state,
                                          scene_info, set_scene_label])
+
         reset_scene_labels.click(self.reset_scene_labels,
                                 outputs=[scene_index, scene_name, scene_image, scene_state,
                                         scene_info, set_scene_label])
@@ -994,19 +995,19 @@ class VideoRemixer(TabBase):
                             inputs=[output_filepath, quality_slider],
                            outputs=message_box60)
 
-        back_button60.click(self.back_button6, outputs=tabs_video_remixer)
+        back_button60.click(self.back_button60, outputs=tabs_video_remixer)
 
         next_button61.click(self.next_button61,
                         inputs=[custom_video_options, custom_audio_options, output_filepath_custom],
                         outputs=message_box61)
 
-        back_button61.click(self.back_button6, outputs=tabs_video_remixer)
+        back_button61.click(self.back_button61, outputs=tabs_video_remixer)
 
         next_button62.click(self.next_button62,
                         inputs=[marked_video_options, marked_audio_options, output_filepath_marked],
                         outputs=message_box62)
 
-        back_button62.click(self.back_button6, outputs=tabs_video_remixer)
+        back_button62.click(self.back_button62, outputs=tabs_video_remixer)
 
         next_button63.click(self.next_button63,
                         inputs=[label_text, label_font_size, label_font_color, label_font_file,
@@ -1014,7 +1015,7 @@ class VideoRemixer(TabBase):
                                 output_filepath_labeled, quality_slider_labeled],
                         outputs=message_box63)
 
-        back_button63.click(self.back_button6, outputs=tabs_video_remixer)
+        back_button63.click(self.back_button63, outputs=tabs_video_remixer)
 
         drop_button700.click(self.drop_button700, inputs=scene_id_700, outputs=message_box700)
 
@@ -1024,13 +1025,10 @@ class VideoRemixer(TabBase):
                                         scene_name, scene_image, scene_state, scene_info,
                                         set_scene_label])
 
-        scene_id_702.change(self.preview_button702, inputs=[scene_id_702, split_percent_702],
+        scene_id_702.change(self.update_preview_scene_id, inputs=[scene_id_702, split_percent_702],
                                 outputs=[preview_image702, scene_info_702], show_progress=False)
 
-        split_percent_702.change(self.preview_button702, inputs=[scene_id_702, split_percent_702],
-                                outputs=[preview_image702, scene_info_702], show_progress=False)
-
-        split_percent_702.change(self.preview_button702, inputs=[scene_id_702, split_percent_702],
+        split_percent_702.change(self.update_preview_split_percent, inputs=[scene_id_702, split_percent_702],
                                 outputs=[preview_image702, scene_info_702], show_progress=False)
 
         goto_0_702.click(self.goto_0_702, outputs=split_percent_702, show_progress=False)
@@ -1057,10 +1055,12 @@ class VideoRemixer(TabBase):
         next_second_702.click(self.next_second_702, inputs=[scene_id_702, split_percent_702],
                                 outputs=split_percent_702, show_progress=False)
 
+        # TODO
         go_to_s_button702.click(self.go_to_s_button702,
                                 inputs=[scene_id_702, split_percent_702, go_to_s_702],
                                 outputs=split_percent_702, show_progress=False)
 
+        # TODO
         go_to_s_702.submit(self.go_to_s_button702,
                                 inputs=[scene_id_702, split_percent_702, go_to_s_702],
                                 outputs=split_percent_702, show_progress=False)
@@ -1122,16 +1122,20 @@ class VideoRemixer(TabBase):
         delete_button710.click(self.delete_button710,
                                inputs=delete_purged_710,
                                outputs=message_box710)
+
         select_all_button710.click(self.select_all_button710, show_progress=False,
                                 outputs=[delete_purged_710])
+
         select_none_button710.click(self.select_none_button710, show_progress=False,
                                 outputs=[delete_purged_710])
 
         delete_button711.click(self.delete_button711,
                                inputs=[delete_source_711, delete_dropped_711, delete_thumbs_711],
                                outputs=message_box711)
+
         select_all_button711.click(self.select_all_button711, show_progress=False,
                                 outputs=[delete_source_711, delete_dropped_711, delete_thumbs_711])
+
         select_none_button711.click(self.select_none_button711, show_progress=False,
                                 outputs=[delete_source_711, delete_dropped_711, delete_thumbs_711])
 
@@ -1140,10 +1144,12 @@ class VideoRemixer(TabBase):
                                        delete_inflated_712, delete_upscaled_712, delete_audio_712,
                                        delete_video_712, delete_clips_712],
                                 outputs=message_box712)
+
         select_all_button712.click(self.select_all_button712, show_progress=False,
                                 outputs=[delete_kept_712, delete_resized_712, delete_resynth_712,
                                          delete_inflated_712, delete_upscaled_712, delete_audio_712,
                                          delete_video_712, delete_clips_712])
+
         select_none_button712.click(self.select_none_button712, show_progress=False,
                                 outputs=[delete_kept_712, delete_resized_712, delete_resynth_712,
                                          delete_inflated_712, delete_upscaled_712,
@@ -1159,12 +1165,6 @@ class VideoRemixer(TabBase):
 
     def dummy_args(self, num, arg=None):
         return [arg for _ in range(num)]
-
-    # def dummy_args(self, num):
-    #     return self.dupe_args(num, None)
-
-    # def noop_args(self, num):
-    #     return self.dupe_args(num, lambda: gr.update(visible=True))
 
     ### REMIX HOME EVENT HANDLERS
 
@@ -1662,6 +1662,12 @@ class VideoRemixer(TabBase):
             self.log("saving project after clearing scene label")
             self.state.save()
         return self.scene_chooser_details(self.state.current_scene)
+
+    def click_scene_label(self, scene_index, scene_label):
+        return self.save_scene_label(scene_index, scene_label)
+
+    def submit_scene_label(self, scene_index, scene_label):
+        return self.save_scene_label(scene_index, scene_label)
 
     def next_labeled_scene(self, scene_index, scene_name):
         for index in range(scene_index+1, len(self.state.scene_names)):
@@ -2178,7 +2184,16 @@ class VideoRemixer(TabBase):
         except ValueError as error:
             return format_markdown(str(error), "error")
 
-    def back_button6(self):
+    def back_button60(self):
+        return gr.update(selected=self.TAB_PROC_OPTIONS)
+
+    def back_button61(self):
+        return gr.update(selected=self.TAB_PROC_OPTIONS)
+
+    def back_button62(self):
+        return gr.update(selected=self.TAB_PROC_OPTIONS)
+
+    def back_button63(self):
         return gr.update(selected=self.TAB_PROC_OPTIONS)
 
     def drop_button700(self, scene_index):
@@ -2357,7 +2372,7 @@ class VideoRemixer(TabBase):
             return None
         return frame_files[split_frame]
 
-    def preview_button702(self, scene_index, split_percent):
+    def update_preview(self, scene_index, split_percent):
         if not isinstance(scene_index, (int, float)):
             return self.dummy_args(2)
         scene_index = int(scene_index)
@@ -2367,6 +2382,12 @@ class VideoRemixer(TabBase):
         display_frame = self.compute_preview_frame(scene_index, split_percent)
         _, _, _, scene_info, _ = self.state.scene_chooser_details(scene_index)
         return display_frame, scene_info
+
+    def update_preview_scene_id(self, scene_index, split_percent):
+        return self.update_preview(scene_index, split_percent)
+
+    def update_preview_split_percent(self, scene_index, split_percent):
+        return self.update_preview(scene_index, split_percent)
 
     def compute_advance_702(self,
                             scene_index,

--- a/tabs/video_remixer_ui.py
+++ b/tabs/video_remixer_ui.py
@@ -1170,12 +1170,12 @@ class VideoRemixer(TabBase):
         empty_args = self.empty_args(9)
         if not video_path:
             return gr.update(selected=self.TAB_REMIX_HOME), \
-                   gr.update(value=format_markdown("Enter a path to a video on this server to get started", "warning")), \
+                   format_markdown("Enter a path to a video on this server to get started", "warning"), \
                    *empty_args
 
         if not os.path.exists(video_path):
             return gr.update(selected=self.TAB_REMIX_HOME), \
-                   gr.update(value=format_markdown(f"File '{video_path}' was not found", "error")), \
+                   format_markdown(f"File '{video_path}' was not found", "error"), \
                    *empty_args
 
         self.new_project()
@@ -1184,15 +1184,15 @@ class VideoRemixer(TabBase):
             self.state.video_info1 = self.state.ingested_video_report()
         except ValueError as error:
             return gr.update(selected=self.TAB_REMIX_HOME), \
-                   gr.update(value=format_markdown(str(error), "error")), \
+                   format_markdown(str(error), "error"), \
                    *empty_args
 
         # don't save yet, user may change project path next
         self.state.save_progress("settings", save_project=False)
 
         return gr.update(selected=self.TAB_REMIX_SETTINGS), \
-            gr.update(value=format_markdown(self.TAB00_DEFAULT_MESSAGE)), \
-            gr.update(value=self.state.video_info1), \
+            format_markdown(self.TAB00_DEFAULT_MESSAGE), \
+            self.state.video_info1, \
             self.state.project_path, \
             self.state.resize_w, \
             self.state.resize_h, \
@@ -1207,19 +1207,19 @@ class VideoRemixer(TabBase):
         empty_args = self.empty_args(34)
         if not project_path:
             return gr.update(selected=self.TAB_REMIX_HOME), \
-                   gr.update(value=format_markdown("Enter a path to a Video Remixer project directory on this server to get started", "warning")), \
+                   format_markdown("Enter a path to a Video Remixer project directory on this server to get started", "warning"), \
                    *empty_args
 
         if not os.path.exists(project_path):
             return gr.update(selected=self.TAB_REMIX_HOME), \
-                   gr.update(value=format_markdown(f"Directory '{project_path}' was not found", "error")), \
+                   format_markdown(f"Directory '{project_path}' was not found", "error"), \
                    *empty_args
 
         try:
             project_file = VideoRemixerState.determine_project_filepath(project_path)
         except ValueError as error:
             return gr.update(selected=self.TAB_REMIX_HOME), \
-                   gr.update(value=format_markdown(str(error), "error")), \
+                   format_markdown(str(error), "error"), \
                    *empty_args
 
         try:
@@ -1227,7 +1227,7 @@ class VideoRemixer(TabBase):
         except ValueError as error:
             self.log(f"error opening project: {error}")
             return gr.update(selected=self.TAB_REMIX_HOME), \
-                   gr.update(value=format_markdown(str(error), "error")), \
+                   format_markdown(str(error), "error"), \
                    *empty_args
 
         if self.state.project_ported(project_file):
@@ -1236,7 +1236,7 @@ class VideoRemixer(TabBase):
             except ValueError as error:
                 self.log(f"error opening ported project at {project_file}: {error}")
                 return gr.update(selected=self.TAB_REMIX_HOME), \
-                    gr.update(value=format_markdown(str(error), "error")), \
+                    format_markdown(str(error), "error"), \
                    *empty_args
 
         messages = self.state.post_load_integrity_check()
@@ -1251,7 +1251,7 @@ class VideoRemixer(TabBase):
         self.invalidate_split_scene_cache()
 
         return gr.update(selected=return_to_tab), \
-            gr.update(value=message_text), \
+            message_text, \
             self.state.tryattr("video_info1"), \
             self.state.tryattr("project_path"), \
             self.state.tryattr("project_fps", self.config.remixer_settings["def_project_fps"]), \
@@ -1307,12 +1307,12 @@ class VideoRemixer(TabBase):
 
         if not is_safe_path(project_path):
             return gr.update(selected=self.TAB_REMIX_SETTINGS), \
-                gr.update(value=format_markdown(f"The project path is not valid", "warning")),\
+                format_markdown(f"The project path is not valid", "warning"),\
                 *self.empty_args(3)
 
         if split_time < 1:
             return gr.update(selected=self.TAB_REMIX_SETTINGS), \
-                gr.update(value=format_markdown(f"Scene Split Seconds should be >= 1", "warning")),\
+                format_markdown(f"Scene Split Seconds should be >= 1", "warning"),\
                 *self.empty_args(3)
 
         # TODO validate the other entries
@@ -1369,14 +1369,14 @@ class VideoRemixer(TabBase):
             Session().set("last-video-remixer-settings", last_settings)
 
             return gr.update(selected=self.TAB_SET_UP_PROJECT), \
-                gr.update(value=format_markdown(self.TAB1_DEFAULT_MESSAGE)), \
+                format_markdown(self.TAB1_DEFAULT_MESSAGE), \
                 self.state.project_info2, \
-                gr.update(value=format_markdown(self.TAB2_DEFAULT_MESSAGE)), \
+                format_markdown(self.TAB2_DEFAULT_MESSAGE), \
                 project_path
 
         except ValueError as error:
             return gr.update(selected=self.TAB_REMIX_SETTINGS), \
-                gr.update(value=format_markdown(str(error), "error")), \
+                format_markdown(str(error), "error"), \
                 *self.noop_args(3)
 
     def back_button1(self):
@@ -1425,7 +1425,7 @@ class VideoRemixer(TabBase):
 
         if not self.state.project_path:
             return gr.update(selected=self.TAB_SET_UP_PROJECT), \
-                   gr.update(value=format_markdown(f"Project settings have not yet been saved on the previous tab", "error")), \
+                   format_markdown(f"Project settings have not yet been saved on the previous tab", "error"), \
                    *empty_args
 
         self.state.thumbnail_type = thumbnail_type
@@ -1491,7 +1491,7 @@ class VideoRemixer(TabBase):
             error = self.state.split_scenes(self.log, prevent_overwrite=False)
             if error:
                 return gr.update(selected=self.TAB_SET_UP_PROJECT), \
-                    gr.update(value=format_markdown(f"There was an error splitting the source video: {error}", "error")), \
+                    format_markdown(f"There was an error splitting the source video: {error}", "error"), \
                    *empty_args
             self.log("saving project after splitting into scenes")
             self.state.save()
@@ -1510,7 +1510,7 @@ class VideoRemixer(TabBase):
                 self.state.save()
             except ValueError as error:
                 return gr.update(selected=self.TAB_SET_UP_PROJECT), \
-                    gr.update(value=format_markdown(f"There was an error retrieving source frame dimensions: {error}", "error")), \
+                    format_markdown(f"There was an error retrieving source frame dimensions: {error}", "error"), \
                    *empty_args
 
             # if there's only one scene, assume it should be kept to save some time
@@ -1528,7 +1528,7 @@ class VideoRemixer(TabBase):
             self.state.create_thumbnails(self.log, global_options, self.config.remixer_settings)
         except ValueError as error:
             return gr.update(selected=self.TAB_SET_UP_PROJECT), \
-                   gr.update(value=format_markdown(f"There was an error creating thumbnails from the source video: {error}", "error")), \
+                   format_markdown(f"There was an error creating thumbnails from the source video: {error}", "error"), \
                    *empty_args
 
         self.state.thumbnails = sorted(get_files(self.state.thumbnail_path))
@@ -1549,7 +1549,7 @@ class VideoRemixer(TabBase):
         self.state.save_progress("choose")
 
         return gr.update(selected=self.TAB_CHOOSE_SCENES), \
-               gr.update(value=format_markdown(self.TAB2_DEFAULT_MESSAGE)), \
+               format_markdown(self.TAB2_DEFAULT_MESSAGE), \
                *self.scene_chooser_details(self.state.current_scene)
 
     def back_button2(self):
@@ -1763,7 +1763,7 @@ class VideoRemixer(TabBase):
     def next_button4(self):
         if not self.state.project_path:
             return gr.update(selected=self.TAB_COMPILE_SCENES), \
-                   gr.update(value=format_markdown(f"The project has not yet been set up from the Set Up Project tab.", "error")), \
+                   format_markdown(f"The project has not yet been set up from the Set Up Project tab.", "error"), \
                    None
 
         self.log("moving dropped scenes to dropped scenes directory")
@@ -1779,8 +1779,8 @@ class VideoRemixer(TabBase):
         self.state.save_progress("process")
 
         return gr.update(selected=self.TAB_PROC_OPTIONS),  \
-               gr.update(value=format_markdown(self.TAB4_DEFAULT_MESSAGE)), \
-               gr.update(value=format_markdown(self.TAB5_DEFAULT_MESSAGE))
+               self.TAB4_DEFAULT_MESSAGE, \
+               self.TAB5_DEFAULT_MESSAGE
 
     def back_button4(self):
         return gr.update(selected=self.TAB_CHOOSE_SCENES)
@@ -1799,8 +1799,7 @@ class VideoRemixer(TabBase):
         noop_args = self.noop_args(9)
         if not self.state.project_path or not self.state.scenes_path:
             return gr.update(selected=self.TAB_PROC_OPTIONS), \
-                   gr.update(value=format_markdown(
-                    "The project has not yet been set up from the Set Up Project tab.", "error")), \
+                   format_markdown("The project has not yet been set up from the Set Up Project tab.", "error"), \
                    *noop_args
 
         self.state.resize = resize
@@ -1912,19 +1911,19 @@ class VideoRemixer(TabBase):
             self.state.save_progress("save")
 
             return gr.update(selected=self.TAB_SAVE_REMIX), \
-                   gr.update(value=format_markdown(self.TAB5_DEFAULT_MESSAGE)), \
+                   format_markdown(self.TAB5_DEFAULT_MESSAGE), \
                    styled_report, \
                    self.state.output_filepath, \
                    output_filepath_custom, \
                    output_filepath_marked, \
                    output_filepath_labeled, \
-                   gr.update(value=format_markdown(self.TAB60_DEFAULT_MESSAGE)), \
-                   gr.update(value=format_markdown(self.TAB61_DEFAULT_MESSAGE)), \
-                   gr.update(value=format_markdown(self.TAB62_DEFAULT_MESSAGE)), \
-                   gr.update(value=format_markdown(self.TAB63_DEFAULT_MESSAGE))
+                   self.TAB60_DEFAULT_MESSAGE, \
+                   self.TAB61_DEFAULT_MESSAGE, \
+                   self.TAB62_DEFAULT_MESSAGE, \
+                   self.TAB63_DEFAULT_MESSAGE
         else:
             return gr.update(selected=self.TAB_PROC_OPTIONS), \
-                   gr.update(value=format_markdown("At least one scene must be set to 'Keep' before processing can proceed", "warning")), \
+                   format_markdown("At least one scene must be set to 'Keep' before processing can proceed", "warning"), \
                    *noop_args
 
     def back_button5(self):
@@ -2033,8 +2032,7 @@ class VideoRemixer(TabBase):
     # User has clicked Save Remix from Save Remix
     def next_button60(self, output_filepath, quality):
         if not self.state.project_path:
-            return gr.update(value=format_markdown(
-                    "The project has not yet been set up from the Set Up Project tab.", "error"))
+            return format_markdown("The project has not yet been set up from the Set Up Project tab.", "error")
 
         self.state.output_filepath = output_filepath
         self.state.output_quality = quality
@@ -2046,16 +2044,15 @@ class VideoRemixer(TabBase):
         try:
             global_options, kept_scenes = self.prepare_save_remix(output_filepath)
             self.save_remix(global_options, kept_scenes)
-            return gr.update(value=format_markdown(f"Remixed video {output_filepath} is complete.", "highlight"))
+            return format_markdown(f"Remixed video {output_filepath} is complete.", "highlight")
 
         except ValueError as error:
-            return gr.update(value=format_markdown(str(error), "error"))
+            return format_markdown(str(error), "error")
 
     # User has clicked Save Custom Remix from Save Remix
     def next_button61(self, custom_video_options, custom_audio_options, output_filepath):
         if not self.state.project_path:
-            return gr.update(value=format_markdown(
-                    "The project has not yet been set up from the Set Up Project tab.", "error"))
+            return format_markdown("The project has not yet been set up from the Set Up Project tab.", "error")
 
         self.state.recompile_scenes()
 
@@ -2063,15 +2060,14 @@ class VideoRemixer(TabBase):
             global_options, kept_scenes = self.prepare_save_remix(output_filepath)
             self.save_custom_remix(output_filepath, global_options, kept_scenes,
                                    custom_video_options, custom_audio_options)
-            return gr.update(value=format_markdown(f"Remixed custom video {output_filepath} is complete.", "highlight"))
+            return format_markdown(f"Remixed custom video {output_filepath} is complete.", "highlight")
         except ValueError as error:
-            return gr.update(value=format_markdown(str(error), "error"))
+            return format_markdown(str(error), "error")
 
     # User has clicked Save Marked Remix from Save Remix
     def next_button62(self, marked_video_options, marked_audio_options, output_filepath):
         if not self.state.project_path:
-            return gr.update(value=format_markdown(
-                    "The project has not yet been set up from the Set Up Project tab.", "error"))
+            return format_markdown("The project has not yet been set up from the Set Up Project tab.", "error")
 
         self.state.recompile_scenes()
 
@@ -2103,9 +2099,9 @@ class VideoRemixer(TabBase):
 
             self.save_custom_remix(output_filepath, global_options, kept_scenes,
                                    marked_video_options, marked_audio_options, draw_text_options)
-            return gr.update(value=format_markdown(f"Remixed marked video {output_filepath} is complete.", "highlight"))
+            return format_markdown(f"Remixed marked video {output_filepath} is complete.", "highlight")
         except ValueError as error:
-            return gr.update(value=format_markdown(str(error), "error"))
+            return format_markdown(str(error), "error")
 
     # User has clicked Save Labeled Remix from Save Remix
     def next_button63(self,
@@ -2120,30 +2116,22 @@ class VideoRemixer(TabBase):
                       output_filepath,
                       quality):
         if not self.state.project_path:
-            return gr.update(value=format_markdown(
-                "The project has not yet been set up from the Set Up Project tab.", "error"))
+            return format_markdown("The project has not yet been set up from the Set Up Project tab.", "error")
         if label_font_size <= 0.0:
-            return gr.update(value=format_markdown(
-                "The Font Factor must be > 0", "warning"))
+            return format_markdown("The Font Factor must be > 0", "warning")
         if not label_font_file:
-           return gr.update(value=format_markdown(
-                "The Font File must not be blank", "warning"))
+           return format_markdown("The Font File must not be blank", "warning")
         if not os.path.exists(label_font_file):
-           return gr.update(value=format_markdown(
-                f"The Font File {os.path.abspath(label_font_file)} was not found", "error"))
+           return format_markdown(f"The Font File {os.path.abspath(label_font_file)} was not found", "error")
         if not label_font_file:
-           return gr.update(value=format_markdown(
-                "The Font File must not be blank", "warning"))
+           return format_markdown("The Font File must not be blank", "warning")
         if not label_font_color:
-           return gr.update(value=format_markdown(
-                "The Font Color must not be blank", "warning"))
+           return format_markdown("The Font Color must not be blank", "warning")
         if label_draw_box:
             if (label_border_size <= 0.0):
-                return gr.update(value=format_markdown(
-                    "The Border Factor must be > 0", "warning"))
+                return format_markdown("The Border Factor must be > 0", "warning")
         if not label_box_color:
-           return gr.update(value=format_markdown(
-                "The Background Color must not be blank", "warning"))
+           return format_markdown("The Background Color must not be blank", "warning")
 
         self.state.recompile_scenes()
 
@@ -2184,10 +2172,10 @@ class VideoRemixer(TabBase):
                 return format_markdown(
                     f"Remixed labeled video {output_filepath} is complete.", "highlight")
             except FFRuntimeError as error:
-                return gr.update(value=format_markdown(f"Error: {error}.", "error"))
+                return format_markdown(f"Error: {error}.", "error")
 
         except ValueError as error:
-            return gr.update(value=format_markdown(str(error), "error"))
+            return format_markdown(str(error), "error")
 
     def back_button6(self):
         return gr.update(selected=self.TAB_PROC_OPTIONS)
@@ -2197,11 +2185,11 @@ class VideoRemixer(TabBase):
         last_scene = num_scenes - 1
 
         if not isinstance(scene_index, (int, float)):
-            return gr.update(value=format_markdown(f"Please enter a Scene Index to get started", "warning"))
+            return format_markdown(f"Please enter a Scene Index to get started", "warning")
 
         scene_index = int(scene_index)
         if scene_index < 0 or scene_index > last_scene:
-            return gr.update(value=format_markdown(f"Please enter a Scene Index from 0 to {last_scene}", "warning"))
+            return format_markdown(f"Please enter a Scene Index from 0 to {last_scene}", "warning")
 
         removed = self.state.force_drop_processed_scene(scene_index)
 
@@ -2214,7 +2202,7 @@ class VideoRemixer(TabBase):
             f"saving project after using force_drop_processed_scene for scene index {scene_index}")
         self.state.save()
         removed = "\r\n".join(removed)
-        return gr.update(value=format_markdown(f"Removed:\r\n{removed}"))
+        return format_markdown(f"Removed:\r\n{removed}")
 
     def choose_button701(self, first_scene_index, last_scene_index, scene_state):
         empty_args = self.empty_args(6)
@@ -2224,7 +2212,7 @@ class VideoRemixer(TabBase):
         if not isinstance(first_scene_index, (int, float)) \
                 or not isinstance(last_scene_index, (int, float)):
             return gr.update(selected=self.TAB_REMIX_EXTRA), \
-    gr.update(value=format_markdown("Please enter Scene Indexes to get started", "warning")), \
+                format_markdown("Please enter Scene Indexes to get started", "warning"), \
                 *empty_args
 
         first_scene_index = int(first_scene_index)
@@ -2234,17 +2222,21 @@ class VideoRemixer(TabBase):
                 or last_scene_index < 0 \
                 or last_scene_index > last_scene:
             return gr.update(selected=self.TAB_REMIX_EXTRA), \
-                gr.update(value=format_markdown(f"Please enter valid Scene Indexes between 0 and {last_scene} to get started", "warning")), \
+                format_markdown(
+                    f"Please enter valid Scene Indexes between 0 and {last_scene} to get started",
+                    "warning"), \
                 *empty_args
 
         if first_scene_index >= last_scene_index:
             return gr.update(selected=self.TAB_REMIX_EXTRA), \
-                gr.update(value=format_markdown(f"'Ending Scene Index' must be higher than 'Starting Scene Index'", "warning")), \
+                format_markdown(
+                    f"'Ending Scene Index' must be higher than 'Starting Scene Index'",
+                    "warning"), \
                 *empty_args
 
         if scene_state not in ["Keep", "Drop"]:
             return gr.update(selected=self.TAB_REMIX_EXTRA), \
-    gr.update(value=format_markdown("Please make a Scenes Choice to get started", "warning")), \
+                format_markdown("Please make a Scenes Choice to get started", "warning"), \
                 *empty_args
 
         for scene_index in range(first_scene_index, last_scene_index + 1):
@@ -2260,7 +2252,7 @@ class VideoRemixer(TabBase):
         self.state.save()
 
         return gr.update(selected=self.TAB_CHOOSE_SCENES), \
-            gr.update(value=format_markdown(message)), \
+            format_markdown(message), \
             *self.scene_chooser_details(self.state.current_scene)
 
     def valid_split_scene_cache(self, scene_index):
@@ -2446,15 +2438,17 @@ class VideoRemixer(TabBase):
     def export_project_703(self, new_project_path : str, new_project_name : str):
         empty_args = [gr.update(visible=False), gr.update(visible=False)]
         if not new_project_path:
-            return gr.update(value=format_markdown("Please enter a Project Path for the new project", "warning")), *empty_args
+            return format_markdown("Please enter a Project Path for the new project", "warning"), \
+                *empty_args
         if not is_safe_path(new_project_path):
-            return gr.update(value=format_markdown("The entered Project Path is not valid", "warning")), *empty_args
+            return format_markdown("The entered Project Path is not valid", "warning"), *empty_args
         if not new_project_name:
-            return gr.update(value=format_markdown("Please enter a Project Name for the new project", "warning")), *empty_args
+            return format_markdown("Please enter a Project Name for the new project", "warning"), \
+                *empty_args
 
         kept_scenes = self.state.kept_scenes()
         if not kept_scenes:
-            return gr.update(value=format_markdown("No kept scenes were found", "warning")), *empty_args
+            return format_markdown("No kept scenes were found", "warning"), *empty_args
 
         new_project_name = new_project_name.strip()
         full_new_project_path = os.path.join(new_project_path, new_project_name)
@@ -2523,17 +2517,17 @@ class VideoRemixer(TabBase):
 
             Session().set("last-video-remixer-export-dir", new_project_path)
 
-            return gr.update(value=format_markdown(f"Kept scenes saved as new project: {full_new_project_path} ")), \
+            return format_markdown(f"Kept scenes saved as new project: {full_new_project_path} "), \
                 gr.update(visible=True, value=full_new_project_path), \
                 gr.update(visible=True)
 
         except ValueError as error:
-            return gr.update(value=format_markdown(str(error), "error")), *empty_args
+            return format_markdown(str(error), "error"), *empty_args
 
     def open_result703(self, new_project_path):
         return gr.update(selected=self.TAB_REMIX_HOME), \
-            gr.update(value=new_project_path), \
-            gr.update(value=format_markdown(self.TAB01_DEFAULT_MESSAGE))
+            new_project_path, \
+            format_markdown(self.TAB01_DEFAULT_MESSAGE)
 
     CLEANSE_SCENES_PATH = "cleansed_scenes"
     CLEANSE_SCENES_FACTOR = 4.0
@@ -2541,7 +2535,7 @@ class VideoRemixer(TabBase):
     def cleanse_button704(self):
         kept_scenes = self.state.kept_scenes()
         if len(kept_scenes) < 1:
-            return gr.update(value=format_markdown("No kept scenes were found", "warning"))
+            return format_markdown("No kept scenes were found", "warning")
 
         self.state.uncompile_scenes()
 
@@ -2550,7 +2544,7 @@ class VideoRemixer(TabBase):
         try:
             self.state.enhance_video_info(self.log, ignore_errors=False)
         except ValueError as error:
-            return gr.update(value=format_markdown(f"Error: {error}", "error"))
+            return format_markdown(f"Error: {error}", "error")
 
         working_path = os.path.join(self.state.project_path, self.CLEANSE_SCENES_PATH)
         if os.path.exists(working_path):
@@ -2610,7 +2604,7 @@ class VideoRemixer(TabBase):
             self.log(f"Error removing path '{working_path}' ignored: {error}")
 
         self.invalidate_split_scene_cache()
-        return gr.update(value=format_markdown("Kept scenes replaced with cleaned versions"))
+        return format_markdown("Kept scenes replaced with cleaned versions")
 
     def merge_scenes(self, first_scene_index, last_scene_index):
         """Merge the specified scenes. Returns the new scene name. Raises ValueError and RuntimeError."""
@@ -2854,14 +2848,15 @@ class VideoRemixer(TabBase):
         last_scene = num_scenes - 1
 
         if not isinstance(scene_index, (int, float)):
-            return gr.update(value=format_markdown(f"Please enter a Scene Index to get started", "warning")), \
+            return format_markdown(f"Please enter a Scene Index to get started", "warning"), \
                 gr.update(selected=self.APP_TAB_VIDEO_REMIXER), \
                 gr.update(selected=VideoBlender.TAB_NEW_PROJECT), \
                 *empty_args
 
         scene_index = int(scene_index)
         if scene_index < 0 or scene_index > last_scene:
-            return gr.update(value=format_markdown(f"Please enter a Scene Index from 0 to {last_scene}", "warning")), \
+            return format_markdown(f"Please enter a Scene Index from 0 to {last_scene}",
+                                   "warning"), \
                 gr.update(selected=self.APP_TAB_VIDEO_REMIXER), \
                 gr.update(selected=VideoBlender.TAB_NEW_PROJECT), \
                 *empty_args
@@ -2897,9 +2892,9 @@ class VideoRemixer(TabBase):
         if delete_purged:
             self.log("about to remove content from 'purged_content' directory")
             removed = self.state.delete_purged_content()
-            return gr.update(value=format_markdown(f"Removed: {removed}"))
+            return format_markdown(f"Removed: {removed}")
         else:
-            return gr.update(value=format_markdown(f"Removed: None"))
+            return format_markdown(f"Removed: None")
 
     def select_all_button710(self):
         return gr.update(value=True)
@@ -2921,7 +2916,7 @@ class VideoRemixer(TabBase):
             message = f"Removed:\r\n{removed_str}"
         else:
             message = f"Removed: None"
-        return gr.update(value=format_markdown(message))
+        return format_markdown(message)
 
     def select_all_button711(self):
         return gr.update(value=True), \
@@ -2965,7 +2960,7 @@ class VideoRemixer(TabBase):
             message = f"Removed:\r\n{removed_str}"
         else:
             message = f"Removed: None"
-        return gr.update(value=format_markdown(message))
+        return format_markdown(message)
 
     def select_all_button712(self):
         return gr.update(value=True), \
@@ -3008,7 +3003,7 @@ class VideoRemixer(TabBase):
             message = f"Removed:\r\n{removed_str}"
         else:
             message = f"Removed: None"
-        return gr.update(value=format_markdown(message))
+        return format_markdown(message)
 
     def restore_button714(self):
         global_options = self.config.ffmpeg_settings["global_options"]
@@ -3017,5 +3012,5 @@ class VideoRemixer(TabBase):
                                    log_fn=self.log)
         message = f"Project recovered"
         return gr.update(selected=self.TAB_CHOOSE_SCENES), \
-            gr.update(value=format_markdown(message)), \
+            format_markdown(message), \
             *self.scene_chooser_details(self.state.current_scene)

--- a/tabs/video_remixer_ui.py
+++ b/tabs/video_remixer_ui.py
@@ -1157,17 +1157,20 @@ class VideoRemixer(TabBase):
 
     ### UTILITY FUNCTIONS
 
-    def empty_args(self, num):
-        return [None for _ in range(num)]
+    def dummy_args(self, num, arg=None):
+        return [arg for _ in range(num)]
 
-    def noop_args(self, num):
-        return [gr.update(visible=True) for _ in range(num)]
+    # def dummy_args(self, num):
+    #     return self.dupe_args(num, None)
+
+    # def noop_args(self, num):
+    #     return self.dupe_args(num, lambda: gr.update(visible=True))
 
     ### REMIX HOME EVENT HANDLERS
 
     # User has clicked New Project > from Remix Home
     def next_button00(self, video_path):
-        empty_args = self.empty_args(9)
+        empty_args = self.dummy_args(9)
         if not video_path:
             return gr.update(selected=self.TAB_REMIX_HOME), \
                    format_markdown("Enter a path to a video on this server to get started", "warning"), \
@@ -1204,7 +1207,7 @@ class VideoRemixer(TabBase):
 
     # User has clicked Open Project > from Remix Home
     def next_button01(self, project_path):
-        empty_args = self.empty_args(34)
+        empty_args = self.dummy_args(34)
         if not project_path:
             return gr.update(selected=self.TAB_REMIX_HOME), \
                    format_markdown("Enter a path to a Video Remixer project directory on this server to get started", "warning"), \
@@ -1303,17 +1306,18 @@ class VideoRemixer(TabBase):
                      crop_offset_y,
                      deinterlace,
                      split_time):
+        empty_args = self.dummy_args(3)
         self.state.project_path = project_path
 
         if not is_safe_path(project_path):
             return gr.update(selected=self.TAB_REMIX_SETTINGS), \
                 format_markdown(f"The project path is not valid", "warning"),\
-                *self.empty_args(3)
+                *empty_args
 
         if split_time < 1:
             return gr.update(selected=self.TAB_REMIX_SETTINGS), \
                 format_markdown(f"Scene Split Seconds should be >= 1", "warning"),\
-                *self.empty_args(3)
+                *empty_args
 
         # TODO validate the other entries
 
@@ -1377,7 +1381,7 @@ class VideoRemixer(TabBase):
         except ValueError as error:
             return gr.update(selected=self.TAB_REMIX_SETTINGS), \
                 format_markdown(str(error), "error"), \
-                *self.noop_args(3)
+                *empty_args
 
     def back_button1(self):
         return gr.update(selected=self.TAB_REMIX_HOME)
@@ -1419,7 +1423,7 @@ class VideoRemixer(TabBase):
 
     # User has clicked Set Up Project from Set Up Project
     def next_button2(self, thumbnail_type, min_frames_per_scene, skip_detection):
-        empty_args = self.empty_args(6)
+        empty_args = self.dummy_args(6)
         global_options = self.config.ffmpeg_settings["global_options"]
         source_audio_crf = self.config.remixer_settings["source_audio_crf"]
 
@@ -1732,14 +1736,14 @@ class VideoRemixer(TabBase):
     def scene_chooser_details(self, scene_index):
         if not self.state.thumbnails:
             self.log(f"thumbnails don't exist yet in scene_chooser_details()")
-            return self.empty_args(6)
+            return self.dummy_args(6)
         try:
             scene_name, thumbnail_path, scene_state, scene_info, scene_label = \
                 self.state.scene_chooser_details(scene_index)
             return scene_index, scene_name, thumbnail_path, scene_state, scene_info, scene_label
         except ValueError as error:
             self.log(error)
-            return self.empty_args(6)
+            return self.dummy_args(6)
 
     # User has clicked Done Choosing Scenes from Scene Chooser
     def next_button3(self):
@@ -1796,11 +1800,11 @@ class VideoRemixer(TabBase):
                      inflate_by_option,
                      inflate_slow_option,
                      resynth_option):
-        noop_args = self.noop_args(9)
+        empty_args = self.dummy_args(9)
         if not self.state.project_path or not self.state.scenes_path:
             return gr.update(selected=self.TAB_PROC_OPTIONS), \
                    format_markdown("The project has not yet been set up from the Set Up Project tab.", "error"), \
-                   *noop_args
+                   *empty_args
 
         self.state.resize = resize
 
@@ -1924,16 +1928,13 @@ class VideoRemixer(TabBase):
         else:
             return gr.update(selected=self.TAB_PROC_OPTIONS), \
                    format_markdown("At least one scene must be set to 'Keep' before processing can proceed", "warning"), \
-                   *noop_args
+                   *empty_args
 
     def back_button5(self):
         return gr.update(selected=self.TAB_COMPILE_SCENES)
 
     def process_all_changed(self, process_all : bool):
-        return gr.update(value=process_all), \
-            gr.update(value=process_all), \
-            gr.update(value=process_all), \
-            gr.update(value=process_all)
+        return process_all, process_all, process_all, process_all
 
     ### SAVE REMIX EVENT HANDLERS
 
@@ -1985,7 +1986,7 @@ class VideoRemixer(TabBase):
         self.state.save()
 
         if not self.state.clips:
-            return gr.update(value="No processed video clips were found", visible=True)
+            raise ValueError("No processed video clips were found")
 
         self.log("about to create remix viedeo")
         ffcmd = self.state.create_remix_video(self.log, global_options, self.state.output_filepath)
@@ -2205,7 +2206,7 @@ class VideoRemixer(TabBase):
         return format_markdown(f"Removed:\r\n{removed}")
 
     def choose_button701(self, first_scene_index, last_scene_index, scene_state):
-        empty_args = self.empty_args(6)
+        empty_args = self.dummy_args(6)
         num_scenes = len(self.state.scene_names)
         last_scene = num_scenes - 1
 
@@ -2287,7 +2288,7 @@ class VideoRemixer(TabBase):
         except ValueError as error:
             return gr.update(selected=self.TAB_REMIX_EXTRA), \
                 format_markdown(f"Unable to split scene: {error}", "warning"), \
-                *self.empty_args(6)
+                *self.dummy_args(6)
 
     def split_keep_before_702(self, scene_index, split_percent):
         global_options = self.config.ffmpeg_settings["global_options"]
@@ -2307,7 +2308,7 @@ class VideoRemixer(TabBase):
         except ValueError as error:
             return gr.update(selected=self.TAB_REMIX_EXTRA), \
                 format_markdown(f"Unable to split scene: {error}", "warning"), \
-                *self.empty_args(6)
+                *self.dummy_args(6)
 
     def split_keep_after_702(self, scene_index, split_percent):
         global_options = self.config.ffmpeg_settings["global_options"]
@@ -2327,7 +2328,7 @@ class VideoRemixer(TabBase):
         except ValueError as error:
             return gr.update(selected=self.TAB_REMIX_EXTRA), \
                 format_markdown(f"Unable to split scene: {error}", "warning"), \
-                *self.empty_args(6)
+                *self.dummy_args(6)
 
     def back_button702(self):
         return gr.update(selected=self.TAB_CHOOSE_SCENES)
@@ -2358,10 +2359,10 @@ class VideoRemixer(TabBase):
 
     def preview_button702(self, scene_index, split_percent):
         if not isinstance(scene_index, (int, float)):
-            return self.empty_args(2)
+            return self.dummy_args(2)
         scene_index = int(scene_index)
         if scene_index < 0 or scene_index >= len(self.state.scene_names):
-            return self.empty_args(2)
+            return self.dummy_args(2)
 
         display_frame = self.compute_preview_frame(scene_index, split_percent)
         _, _, _, scene_info, _ = self.state.scene_chooser_details(scene_index)
@@ -2376,7 +2377,7 @@ class VideoRemixer(TabBase):
                             by_exact_second=False,
                             exact_second=0):
         if not isinstance(scene_index, (int, float)):
-            return self.empty_args(2)
+            return self.dummy_args(2)
 
         scene_index = int(scene_index)
         scene_name = self.state.scene_names[scene_index]
@@ -2436,7 +2437,7 @@ class VideoRemixer(TabBase):
                                         exact_second=go_to_second)
 
     def export_project_703(self, new_project_path : str, new_project_name : str):
-        empty_args = [gr.update(visible=False), gr.update(visible=False)]
+        empty_args = self.dummy_args(2)
         if not new_project_path:
             return format_markdown("Please enter a Project Path for the new project", "warning"), \
                 *empty_args
@@ -2727,7 +2728,7 @@ class VideoRemixer(TabBase):
         return new_scene_name
 
     def merge_button705(self, first_scene_index, last_scene_index):
-        empty_args = self.empty_args(6)
+        empty_args = self.dummy_args(6)
         if not isinstance(first_scene_index, (int, float)) \
                 or not isinstance(last_scene_index, (int, float)):
             return gr.update(selected=self.TAB_REMIX_EXTRA), \
@@ -2750,7 +2751,7 @@ class VideoRemixer(TabBase):
                 *empty_args
 
     def coalesce_button706(self, coalesce_scenes):
-        empty_args = self.empty_args(6)
+        empty_args = self.dummy_args(6)
         kept_scenes = self.state.kept_scenes()
         if len(kept_scenes) < 2:
             return gr.update(selected=self.TAB_REMIX_EXTRA), \
@@ -2843,7 +2844,7 @@ class VideoRemixer(TabBase):
     APP_TAB_VIDEO_REMIXER=5
 
     def export_button707(self, scene_index):
-        empty_args = self.empty_args(10)
+        empty_args = self.dummy_args(10)
         num_scenes = len(self.state.scene_names)
         last_scene = num_scenes - 1
 
@@ -2897,10 +2898,10 @@ class VideoRemixer(TabBase):
             return format_markdown(f"Removed: None")
 
     def select_all_button710(self):
-        return gr.update(value=True)
+        return True
 
     def select_none_button710(self):
-        return gr.update(value=False)
+        return False
 
     def delete_button711(self, delete_source, delete_dropped, delete_thumbs):
         removed = []
@@ -2919,14 +2920,10 @@ class VideoRemixer(TabBase):
         return format_markdown(message)
 
     def select_all_button711(self):
-        return gr.update(value=True), \
-                gr.update(value=True), \
-                gr.update(value=True)
+        return True, True, True
 
     def select_none_button711(self):
-        return gr.update(value=False), \
-                gr.update(value=False), \
-                gr.update(value=False)
+        return False, False, False
 
     def delete_button712(self,
                          delete_kept,
@@ -2963,24 +2960,10 @@ class VideoRemixer(TabBase):
         return format_markdown(message)
 
     def select_all_button712(self):
-        return gr.update(value=True), \
-                gr.update(value=True), \
-                gr.update(value=True), \
-                gr.update(value=True), \
-                gr.update(value=True), \
-                gr.update(value=True), \
-                gr.update(value=True), \
-                gr.update(value=True)
+        return True, True, True, True, True, True, True, True
 
     def select_none_button712(self):
-        return gr.update(value=False), \
-                gr.update(value=False), \
-                gr.update(value=False), \
-                gr.update(value=False), \
-                gr.update(value=False), \
-                gr.update(value=False), \
-                gr.update(value=False), \
-                gr.update(value=False)
+        return False, False, False, False, False, False, False, False
 
     def delete_button713(self, delete_all):
         removed = []

--- a/tabs/video_remixer_ui.py
+++ b/tabs/video_remixer_ui.py
@@ -99,7 +99,7 @@ class VideoRemixer(TabBase):
                     with gr.Column():
                         gr.Markdown("**Input a video to get started remixing**")
                         with gr.Row():
-                            video_path = gr.Textbox(label="Video Path",
+                            video_path = gr.Textbox(label="Video Path", max_lines=1,
                                 placeholder="Path on this server to the video to be remixed")
                         with gr.Row():
                             message_box00 = gr.Markdown(
@@ -111,7 +111,7 @@ class VideoRemixer(TabBase):
                     with gr.Column():
                         gr.Markdown("**Open an existing Video Remixer project**")
                         with gr.Row():
-                            project_load_path = gr.Textbox(label="Project Path",
+                            project_load_path = gr.Textbox(label="Project Path", max_lines=1,
             placeholder="Path on this server to the Video Remixer project directory or file",
                                 value=lambda : Session().get("last-video-remixer-project"))
                         with gr.Row():
@@ -134,7 +134,7 @@ class VideoRemixer(TabBase):
                 with gr.Row():
                     with gr.Column():
                         with gr.Row():
-                            project_path = gr.Textbox(label="Set Project Path",
+                            project_path = gr.Textbox(label="Set Project Path", max_lines=1,
                                         placeholder="Path on this server to store project data")
                         with gr.Row():
                             split_type = gr.Radio(label="Split Type", value="Scene",
@@ -217,8 +217,10 @@ class VideoRemixer(TabBase):
             ## CHOOSE SCENES
             with gr.Tab(SimpleIcons.FOUR + " Choose Scenes", id=self.TAB_CHOOSE_SCENES):
                 with gr.Row():
-                    scene_name = gr.Text(label="Scene Name", interactive=False, scale=1)
-                    scene_info = gr.Text(label="Scene Details", interactive=False, scale=1)
+                    scene_name = gr.Text(label="Scene Name", max_lines=1, interactive=False,
+                                         scale=1)
+                    scene_info = gr.Text(label="Scene Details", max_lines=1, interactive=False,
+                                         scale=1)
                     with gr.Column(scale=2):
                         with gr.Row():
                             scene_state = gr.Radio(label="Choose", value=None,
@@ -396,10 +398,10 @@ class VideoRemixer(TabBase):
 
                     ### CREATE CUSTOM REMIX
                     with gr.Tab(label="Create Custom Remix"):
-                        custom_video_options = gr.Textbox(value=custom_ffmpeg_video,
+                        custom_video_options = gr.Textbox(value=custom_ffmpeg_video, max_lines=1,
                             label="Custom FFmpeg Video Output Options",
                     info="Passed to FFmpeg as output video settings when converting PNG frames")
-                        custom_audio_options = gr.Textbox(value=custom_ffmpeg_audio,
+                        custom_audio_options = gr.Textbox(value=custom_ffmpeg_audio, max_lines=1,
                             label="Custom FFmpeg Audio Output Options",
                     info="Passed to FFmpeg as output audio settings when combining with video")
                         output_filepath_custom = gr.Textbox(label="Output Filepath",
@@ -421,10 +423,10 @@ class VideoRemixer(TabBase):
 
                     ### CREATE MARKED REMIX
                     with gr.Tab(label="Create Marked Remix"):
-                        marked_video_options = gr.Textbox(value=marked_ffmpeg_video,
+                        marked_video_options = gr.Textbox(value=marked_ffmpeg_video, max_lines=1,
                             label="Marked FFmpeg Video Output Options",
                     info="Passed to FFmpeg as output video settings when converting PNG frames")
-                        marked_audio_options = gr.Textbox(value=marked_ffmpeg_audio,
+                        marked_audio_options = gr.Textbox(value=marked_ffmpeg_audio, max_lines=1,
                             label="Marked FFmpeg Audio Output Options",
                     info="Passed to FFmpeg as output audio settings when combining with video")
                         output_filepath_marked = gr.Textbox(label="Output Filepath",
@@ -490,7 +492,7 @@ class VideoRemixer(TabBase):
                                 with gr.Row():
                                     scene_id_702 = gr.Number(value=-1,
                                                                 label="Scene Index")
-                                    scene_info_702 = gr.Text(label="Scene Details",
+                                    scene_info_702 = gr.Textbox(label="Scene Details", max_lines=1,
                                                                 interactive=False)
                                 with gr.Row():
                                     split_percent_702 = gr.Slider(value=50.0,

--- a/tabs/video_remixer_ui.py
+++ b/tabs/video_remixer_ui.py
@@ -1789,8 +1789,8 @@ class VideoRemixer(TabBase):
         self.state.save_progress("process")
 
         return gr.update(selected=self.TAB_PROC_OPTIONS),  \
-               self.TAB4_DEFAULT_MESSAGE, \
-               self.TAB5_DEFAULT_MESSAGE
+               format_markdown(self.TAB4_DEFAULT_MESSAGE), \
+               format_markdown(self.TAB5_DEFAULT_MESSAGE)
 
     def back_button4(self):
         return gr.update(selected=self.TAB_CHOOSE_SCENES)
@@ -1927,10 +1927,10 @@ class VideoRemixer(TabBase):
                    output_filepath_custom, \
                    output_filepath_marked, \
                    output_filepath_labeled, \
-                   self.TAB60_DEFAULT_MESSAGE, \
-                   self.TAB61_DEFAULT_MESSAGE, \
-                   self.TAB62_DEFAULT_MESSAGE, \
-                   self.TAB63_DEFAULT_MESSAGE
+                   format_markdown(self.TAB60_DEFAULT_MESSAGE), \
+                   format_markdown(self.TAB61_DEFAULT_MESSAGE), \
+                   format_markdown(self.TAB62_DEFAULT_MESSAGE), \
+                   format_markdown(self.TAB63_DEFAULT_MESSAGE)
         else:
             return gr.update(selected=self.TAB_PROC_OPTIONS), \
                    format_markdown("At least one scene must be set to 'Keep' before processing can proceed", "warning"), \


### PR DESCRIPTION
Clean up use of Gradio in preparation for upgrading
- Don't share predict function between events
- Remove redundant `gr.update(value=...` calls
- Add `max_lines=` to single-line text fields currently showing unneeded resize handles
