### PR TITLE
Video Remixer: Move non-UI logic to state class & Enhance Slow Motion

### DIFF
--- a/tabs/video_remixer_ui.py
+++ b/tabs/video_remixer_ui.py
@@ -2180,16 +2180,13 @@ class VideoRemixer(TabBase):
             format_markdown(message), \
             *self.scene_chooser_details(self.state.current_scene)
 
-    def split_button702(self, scene_index, split_percent):
+    def split_scene(self, scene_index, split_percent, keep_before, keep_after):
         global_options = self.config.ffmpeg_settings["global_options"]
         try:
-            message = self.state.split_scene(self.log, scene_index, split_percent, self.config.remixer_settings, global_options)
-
-            self.log("saving project after completing scene split")
+            message = self.state.split_scene(self.log, scene_index, split_percent,
+                                             self.config.remixer_settings, global_options,
+                                             keep_before, keep_after)
             self.state.save()
-
-            self.log("invalidating scene split cache after splitting")
-            self.state.invalidate_split_scene_cache()
 
             return gr.update(selected=self.TAB_CHOOSE_SCENES), \
                 format_markdown(message), \
@@ -2199,46 +2196,15 @@ class VideoRemixer(TabBase):
             return gr.update(selected=self.TAB_REMIX_EXTRA), \
                 format_markdown(f"Unable to split scene: {error}", "warning"), \
                 *dummy_args(6)
+
+    def split_button702(self, scene_index, split_percent):
+        return self.split_scene(scene_index, split_percent, False, False)
 
     def split_keep_before_702(self, scene_index, split_percent):
-        global_options = self.config.ffmpeg_settings["global_options"]
-        try:
-            message = self.state.split_scene(self.log, scene_index, split_percent, self.config.remixer_settings, global_options, keep_before=True)
-
-            self.log("saving project after completing scene split")
-            self.state.save()
-
-            self.log("invalidating scene split cache after splitting")
-            self.state.invalidate_split_scene_cache()
-
-            return gr.update(selected=self.TAB_CHOOSE_SCENES), \
-                format_markdown(message), \
-                *self.scene_chooser_details(self.state.current_scene)
-
-        except ValueError as error:
-            return gr.update(selected=self.TAB_REMIX_EXTRA), \
-                format_markdown(f"Unable to split scene: {error}", "warning"), \
-                *dummy_args(6)
+        return self.split_scene(scene_index, split_percent, True, False)
 
     def split_keep_after_702(self, scene_index, split_percent):
-        global_options = self.config.ffmpeg_settings["global_options"]
-        try:
-            message = self.state.split_scene(self.log, scene_index, split_percent, self.config.remixer_settings, global_options, keep_after=True)
-
-            self.log("saving project after completing scene split")
-            self.state.save()
-
-            self.log("invalidating scene split cache after splitting")
-            self.state.invalidate_split_scene_cache()
-
-            return gr.update(selected=self.TAB_CHOOSE_SCENES), \
-                format_markdown(message), \
-                *self.scene_chooser_details(self.state.current_scene)
-
-        except ValueError as error:
-            return gr.update(selected=self.TAB_REMIX_EXTRA), \
-                format_markdown(f"Unable to split scene: {error}", "warning"), \
-                *dummy_args(6)
+        return self.split_scene(scene_index, split_percent, False, True)
 
     def back_button702(self):
         return gr.update(selected=self.TAB_CHOOSE_SCENES)

--- a/tabs/video_remixer_ui.py
+++ b/tabs/video_remixer_ui.py
@@ -1929,11 +1929,6 @@ class VideoRemixer(TabBase):
                 format_markdown(self.TAB62_DEFAULT_MESSAGE), \
                 format_markdown(self.TAB63_DEFAULT_MESSAGE)
 
-
-
-
-
-
     def back_button5(self):
         return gr.update(selected=self.TAB_COMPILE_SCENES)
 
@@ -1942,7 +1937,6 @@ class VideoRemixer(TabBase):
 
     ### SAVE REMIX EVENT HANDLERS
 
-    # User has clicked Save Remix from Save Remix
     def next_button60(self, output_filepath, quality):
         if not self.state.project_path:
             return format_markdown(
@@ -1966,7 +1960,6 @@ class VideoRemixer(TabBase):
         except ValueError as error:
             return format_markdown(str(error), "error")
 
-    # User has clicked Save Custom Remix from Save Remix
     def next_button61(self, custom_video_options, custom_audio_options, output_filepath):
         if not self.state.project_path:
             return format_markdown(
@@ -1986,7 +1979,7 @@ class VideoRemixer(TabBase):
         except ValueError as error:
             return format_markdown(str(error), "error")
 
-    # User has clicked Save Marked Remix from Save Remix
+    # TODO move
     def next_button62(self, marked_video_options, marked_audio_options, output_filepath):
         if not self.state.project_path:
             return format_markdown(
@@ -2031,7 +2024,7 @@ class VideoRemixer(TabBase):
         except ValueError as error:
             return format_markdown(str(error), "error")
 
-    # User has clicked Save Labeled Remix from Save Remix
+    # TODO move
     def next_button63(self,
                       label_text,
                       label_font_size,
@@ -2231,6 +2224,7 @@ class VideoRemixer(TabBase):
     def update_preview_split_percent(self, scene_index, split_percent):
         return self.update_preview(scene_index, split_percent)
 
+    # TODO move
     def compute_advance_702(self,
                             scene_index,
                             split_percent,
@@ -2305,7 +2299,7 @@ class VideoRemixer(TabBase):
     def go_to_s_submit702(self, scene_index, split_percent, go_to_second):
         return self.go_to_s_button702(scene_index, split_percent, go_to_second)
 
-    # TODO some of this should be moved out of here as logic, but might not belong directly in the state class
+    # TODO move
     def export_project_703(self, new_project_path : str, new_project_name : str):
         empty_args = dummy_args(2, lambda : gr.update(visible=True))
         if not new_project_path:
@@ -2403,6 +2397,7 @@ class VideoRemixer(TabBase):
     CLEANSE_SCENES_PATH = "cleansed_scenes"
     CLEANSE_SCENES_FACTOR = 4.0
 
+    # TODO move
     def cleanse_button704(self):
         kept_scenes = self.state.kept_scenes()
         if len(kept_scenes) < 1:
@@ -2477,6 +2472,7 @@ class VideoRemixer(TabBase):
         self.state.invalidate_split_scene_cache()
         return format_markdown("Kept scenes replaced with cleaned versions")
 
+    # TODO move
     def merge_scenes(self, first_scene_index, last_scene_index):
         """Merge the specified scenes. Returns the new scene name. Raises ValueError and RuntimeError."""
         global_options = self.config.ffmpeg_settings["global_options"]
@@ -2620,6 +2616,7 @@ class VideoRemixer(TabBase):
                 format_markdown(f"Error: {error}", "warning"), \
                 *empty_args
 
+    # TODO move
     def coalesce_button706(self, coalesce_scenes):
         empty_args = dummy_args(6)
         kept_scenes = self.state.kept_scenes()

--- a/tabs/video_remixer_ui.py
+++ b/tabs/video_remixer_ui.py
@@ -5,7 +5,7 @@ from typing import Callable
 import gradio as gr
 from webui_utils.simple_config import SimpleConfig
 from webui_utils.simple_icons import SimpleIcons
-from webui_utils.simple_utils import format_markdown, style_report
+from webui_utils.simple_utils import format_markdown, style_report, dummy_args0
 from webui_utils.file_utils import get_files, create_directory, get_directories, split_filepath, \
     is_safe_path, duplicate_directory, move_files
 from webui_utils.video_utils import details_from_group_name
@@ -1166,16 +1166,11 @@ class VideoRemixer(TabBase):
 
         purge_button715.click(self.purge_button715, outputs=[tabs_video_remixer, message_box715])
 
-    ### UTILITY FUNCTIONS
-
-    def dummy_args(self, num, arg=None):
-        return [arg for _ in range(num)]
-
     ### REMIX HOME EVENT HANDLERS
 
     # User has clicked New Project > from Remix Home
     def next_button00(self, video_path):
-        empty_args = self.dummy_args(9)
+        empty_args = dummy_args(9)
         if not video_path:
             return gr.update(selected=self.TAB_REMIX_HOME), \
                    format_markdown("Enter a path to a video on this server to get started", "warning"), \
@@ -1212,7 +1207,7 @@ class VideoRemixer(TabBase):
 
     # User has clicked Open Project > from Remix Home
     def next_button01(self, project_path):
-        empty_args = self.dummy_args(34)
+        empty_args = dummy_args(34)
         if not project_path:
             return gr.update(selected=self.TAB_REMIX_HOME), \
                    format_markdown("Enter a path to a Video Remixer project directory on this server to get started", "warning"), \
@@ -1311,7 +1306,7 @@ class VideoRemixer(TabBase):
                      crop_offset_y,
                      deinterlace,
                      split_time):
-        empty_args = self.dummy_args(3)
+        empty_args = dummy_args(3)
         self.state.project_path = project_path
 
         if not is_safe_path(project_path):
@@ -1428,7 +1423,7 @@ class VideoRemixer(TabBase):
 
     # User has clicked Set Up Project from Set Up Project
     def next_button2(self, thumbnail_type, min_frames_per_scene, skip_detection):
-        empty_args = self.dummy_args(6)
+        empty_args = dummy_args(6)
         global_options = self.config.ffmpeg_settings["global_options"]
         source_audio_crf = self.config.remixer_settings["source_audio_crf"]
 
@@ -1747,14 +1742,14 @@ class VideoRemixer(TabBase):
     def scene_chooser_details(self, scene_index):
         if not self.state.thumbnails:
             self.log(f"thumbnails don't exist yet in scene_chooser_details()")
-            return self.dummy_args(6)
+            return dummy_args(6)
         try:
             scene_name, thumbnail_path, scene_state, scene_info, scene_label = \
                 self.state.scene_chooser_details(scene_index)
             return scene_index, scene_name, thumbnail_path, scene_state, scene_info, scene_label
         except ValueError as error:
             self.log(error)
-            return self.dummy_args(6)
+            return dummy_args(6)
 
     # User has clicked Done Choosing Scenes from Scene Chooser
     def next_button3(self):
@@ -1811,7 +1806,7 @@ class VideoRemixer(TabBase):
                      inflate_by_option,
                      inflate_slow_option,
                      resynth_option):
-        empty_args = self.dummy_args(9)
+        empty_args = dummy_args(9)
         if not self.state.project_path or not self.state.scenes_path:
             return gr.update(selected=self.TAB_PROC_REMIX), \
                    format_markdown("The project has not yet been set up from the Set Up Project tab.", "error"), \
@@ -2226,7 +2221,7 @@ class VideoRemixer(TabBase):
         return format_markdown(f"Removed:\r\n{removed}")
 
     def choose_button701(self, first_scene_index, last_scene_index, scene_state):
-        empty_args = self.dummy_args(6)
+        empty_args = dummy_args(6)
         num_scenes = len(self.state.scene_names)
         last_scene = num_scenes - 1
 
@@ -2308,7 +2303,7 @@ class VideoRemixer(TabBase):
         except ValueError as error:
             return gr.update(selected=self.TAB_REMIX_EXTRA), \
                 format_markdown(f"Unable to split scene: {error}", "warning"), \
-                *self.dummy_args(6)
+                *dummy_args(6)
 
     def split_keep_before_702(self, scene_index, split_percent):
         global_options = self.config.ffmpeg_settings["global_options"]
@@ -2328,7 +2323,7 @@ class VideoRemixer(TabBase):
         except ValueError as error:
             return gr.update(selected=self.TAB_REMIX_EXTRA), \
                 format_markdown(f"Unable to split scene: {error}", "warning"), \
-                *self.dummy_args(6)
+                *dummy_args(6)
 
     def split_keep_after_702(self, scene_index, split_percent):
         global_options = self.config.ffmpeg_settings["global_options"]
@@ -2348,7 +2343,7 @@ class VideoRemixer(TabBase):
         except ValueError as error:
             return gr.update(selected=self.TAB_REMIX_EXTRA), \
                 format_markdown(f"Unable to split scene: {error}", "warning"), \
-                *self.dummy_args(6)
+                *dummy_args(6)
 
     def back_button702(self):
         return gr.update(selected=self.TAB_CHOOSE_SCENES)
@@ -2379,10 +2374,10 @@ class VideoRemixer(TabBase):
 
     def update_preview(self, scene_index, split_percent):
         if not isinstance(scene_index, (int, float)):
-            return self.dummy_args(2)
+            return dummy_args(2)
         scene_index = int(scene_index)
         if scene_index < 0 or scene_index >= len(self.state.scene_names):
-            return self.dummy_args(2)
+            return dummy_args(2)
 
         display_frame = self.compute_preview_frame(scene_index, split_percent)
         _, _, _, scene_info, _ = self.state.scene_chooser_details(scene_index)
@@ -2403,7 +2398,7 @@ class VideoRemixer(TabBase):
                             by_exact_second=False,
                             exact_second=0):
         if not isinstance(scene_index, (int, float)):
-            return self.dummy_args(1)
+            return dummy_args(1)
 
         scene_index = int(scene_index)
         scene_name = self.state.scene_names[scene_index]
@@ -2469,7 +2464,7 @@ class VideoRemixer(TabBase):
         return self.go_to_s_button702(scene_index, split_percent, go_to_second)
 
     def export_project_703(self, new_project_path : str, new_project_name : str):
-        empty_args = self.dummy_args(2, lambda : gr.update(visible=True))
+        empty_args = dummy_args(2, lambda : gr.update(visible=True))
         if not new_project_path:
             return format_markdown("Please enter a Project Path for the new project", "warning"), \
                 *empty_args
@@ -2760,7 +2755,7 @@ class VideoRemixer(TabBase):
         return new_scene_name
 
     def merge_button705(self, first_scene_index, last_scene_index):
-        empty_args = self.dummy_args(6)
+        empty_args = dummy_args(6)
         if not isinstance(first_scene_index, (int, float)) \
                 or not isinstance(last_scene_index, (int, float)):
             return gr.update(selected=self.TAB_REMIX_EXTRA), \
@@ -2783,7 +2778,7 @@ class VideoRemixer(TabBase):
                 *empty_args
 
     def coalesce_button706(self, coalesce_scenes):
-        empty_args = self.dummy_args(6)
+        empty_args = dummy_args(6)
         kept_scenes = self.state.kept_scenes()
         if len(kept_scenes) < 2:
             return gr.update(selected=self.TAB_REMIX_EXTRA), \
@@ -2876,7 +2871,7 @@ class VideoRemixer(TabBase):
     APP_TAB_VIDEO_REMIXER=5
 
     def export_button707(self, scene_index):
-        empty_args = self.dummy_args(10)
+        empty_args = dummy_args(10)
         num_scenes = len(self.state.scene_names)
         last_scene = num_scenes - 1
 

--- a/tabs/video_remixer_ui.py
+++ b/tabs/video_remixer_ui.py
@@ -1893,42 +1893,18 @@ class VideoRemixer(TabBase):
             upscale_option_changed = True
         self.state.upscale_option = upscale_option
 
-        self.state.prepare_remix_processing(resynth_option_changed,
+        self.state.prepare_process_remix(resynth_option_changed,
                                             inflate_option_changed,
                                             upscale_option_changed)
 
-        should_resize = self.state.should_resize()
-        should_resynthesize = self.state.should_resynthesize()
-        should_inflate = self.state.should_inflate()
-        should_upscale = self.state.should_upscale()
+        remix_report = self.state.process_remix(self.log,
+                                                kept_scenes,
+                                                self.config.remixer_settings,
+                                                self.engine,
+                                                self.config.engine_settings,
+                                                self.config.realesrgan_settings)
 
-        if should_resize:
-            self.state.resize_scenes(self.log,
-                                     kept_scenes,
-                                     self.config.remixer_settings)
-        if should_resynthesize:
-            self.state.resynthesize_scenes(self.log,
-                                           kept_scenes,
-                                           self.engine,
-                                           self.config.engine_settings,
-                                           self.state.resynth_option)
-        if should_inflate:
-            self.state.inflate_scenes(self.log,
-                                      kept_scenes,
-                                      self.engine,
-                                      self.config.engine_settings)
-        if should_upscale:
-            self.state.upscale_scenes(self.log,
-                                      kept_scenes,
-                                      self.config.realesrgan_settings,
-                                      self.config.remixer_settings)
-
-        remix_report = self.state.generate_remix_report(should_resize,
-                                                        should_resynthesize,
-                                                        should_inflate,
-                                                        should_upscale)
-
-        styled_report = style_report("Content Ready for Remix Video:", remix_report, color="more")
+        styled_report = style_report("Content Ready for Remix Video:", remix_report, color="info")
         self.state.summary_info6 = styled_report
 
         self.state.output_filepath = self.state.default_remix_filepath()

--- a/video_remixer.py
+++ b/video_remixer.py
@@ -1000,7 +1000,8 @@ class VideoRemixerState():
             shutil.move(frame_path, new_frame_path)
         os.replace(original_scene_path, new_lower_scene_path)
 
-    def split_scene(self, log_fn, scene_index, split_percent, remixer_settings, global_options, keep_before=False, keep_after=False):
+    def split_scene(self, log_fn, scene_index, split_percent, remixer_settings, global_options,
+                    keep_before=False, keep_after=False):
         if not isinstance(scene_index, (int, float)):
             raise ValueError("Scene index must be an int or float")
 
@@ -1115,6 +1116,8 @@ class VideoRemixerState():
         if processed_content_split:
             log_fn("invalidating processed audio content after splitting")
             self.clean_remix_audio()
+
+        self.invalidate_split_scene_cache()
 
         return f"Scene split into new scenes {new_lower_scene_name} and {new_upper_scene_name}"
 

--- a/video_remixer.py
+++ b/video_remixer.py
@@ -2120,12 +2120,11 @@ class VideoRemixerState():
         motion_factor = 1.0
         audio_slow_motion = False
         silent_slow_motion = False
+        project_inflation_rate = 1
 
         if self.inflate or force_inflation:
             if self.inflate:
                 project_inflation_rate = self.inflation_rate(self.inflate_by_option)
-            else:
-                project_inflation_rate = 1
             forced_inflation_rate = self.inflation_rate(force_inflate_by)
 
             motion_factor = project_inflation_rate

--- a/video_remixer.py
+++ b/video_remixer.py
@@ -114,8 +114,10 @@ class VideoRemixerState():
     # remove transient state
     def __getstate__(self):
         state = self.__dict__.copy()
-        del state["split_scene_cache"]
-        del state["split_scene_cached_index"]
+        if "split_scene_cache" in state:
+            del state["split_scene_cache"]
+        if "split_scene_cached_index" in state:
+            del state["split_scene_cached_index"]
         return state
 
     def reset(self):

--- a/video_remixer.py
+++ b/video_remixer.py
@@ -826,7 +826,7 @@ class VideoRemixerState():
             scene_time = f"{scene_start}{self.GAP}+{scene_duration}"
             keep_symbol = SimpleIcons.HEART if keep_state == True else ""
             scene_info = f"{scene_position}{self.GAP}{scene_time}{self.GAP}{keep_symbol}"
-            return scene_name, thumbnail_path, scene_state, scene_info, scene_label
+            return scene_index, scene_name, thumbnail_path, scene_state, scene_info, scene_label
         except ValueError as error:
             raise ValueError(
                 f"ValueError encountered while getting scene chooser data: {error}")

--- a/video_remixer.py
+++ b/video_remixer.py
@@ -2016,12 +2016,11 @@ class VideoRemixerState():
     VIDEO_CLIPS_PATH = "VIDEO"
 
     def compute_inflated_fps(self, force_inflation, force_audio, force_inflate_by, force_silent):
-        motion_factor, audio_slow_motion, silent_slow_motion = \
+        motion_factor, audio_slow_motion, silent_slow_motion, project_inflation_rate = \
             self.compute_effective_slow_motion(force_inflation, force_audio, force_inflate_by,
                                                force_silent)
-
         if audio_slow_motion or silent_slow_motion:
-            fps_factor = 1.0
+            fps_factor = project_inflation_rate
         else:
             fps_factor = motion_factor
         return self.project_fps * fps_factor
@@ -2125,13 +2124,13 @@ class VideoRemixerState():
                 project_inflation_rate = 1
             forced_inflation_rate = self.inflation_rate(force_inflate_by)
 
-            motion_factor = 1
+            motion_factor = project_inflation_rate
             if forced_inflation_rate == project_inflation_rate * 8:
-                motion_factor = 8
+                motion_factor = forced_inflation_rate
             elif forced_inflation_rate == project_inflation_rate * 4:
-                motion_factor = 4
+                motion_factor = forced_inflation_rate
             elif forced_inflation_rate == project_inflation_rate * 2:
-                motion_factor = 2
+                motion_factor = forced_inflation_rate
 
             audio_slow_motion = force_audio or self.inflate_slow_option == "Audio"
             silent_slow_motion = force_silent or self.inflate_slow_option == "Silent"
@@ -2139,12 +2138,12 @@ class VideoRemixerState():
             if audio_slow_motion and motion_factor == 1:
                 audio_slow_motion = False
 
-        return motion_factor, audio_slow_motion, silent_slow_motion
+        return motion_factor, audio_slow_motion, silent_slow_motion, project_inflation_rate
 
     def compute_inflated_audio_options(self, custom_audio_options, force_inflation, force_audio,
                                        force_inflate_by, force_silent):
 
-        motion_factor, audio_slow_motion, silent_slow_motion = \
+        motion_factor, audio_slow_motion, silent_slow_motion, _ = \
             self.compute_effective_slow_motion(force_inflation, force_audio, force_inflate_by,
                                                force_silent)
         if audio_slow_motion:

--- a/video_remixer.py
+++ b/video_remixer.py
@@ -965,23 +965,23 @@ class VideoRemixerState():
                             by_exact_second=False,
                             exact_second=0):
         if not isinstance(scene_index, (int, float)):
-            return dummy_args(1)
+            return None
 
         scene_index = int(scene_index)
-        scene_name = self.state.scene_names[scene_index]
+        scene_name = self.scene_names[scene_index]
         first_frame, last_frame, _ = details_from_group_name(scene_name)
         num_frames = (last_frame - first_frame) + 1
         split_percent_frame = num_frames * split_percent / 100.0
 
         if by_exact_second:
-            frames_1s = self.state.project_fps
+            frames_1s = self.project_fps
             new_split_frame = frames_1s * exact_second
         elif by_minute:
-            frames_60s = self.state.project_fps * 60
+            frames_60s = self.project_fps * 60
             new_split_frame = \
                 split_percent_frame + frames_60s if by_next else split_percent_frame - frames_60s
         elif by_second:
-            frames_1s = self.state.project_fps
+            frames_1s = self.project_fps
             new_split_frame = \
                 split_percent_frame + frames_1s if by_next else split_percent_frame - frames_1s
         else: # by frame

--- a/webui_utils/simple_utils.py
+++ b/webui_utils/simple_utils.py
@@ -333,3 +333,6 @@ def format_table(header_row : list,
         table.append(_format_table_row(styled_row))
 
     return "\r\n".join(table)
+
+def dummy_args(num, arg=None):
+    return [arg for _ in range(num)]

--- a/webui_utils/video_utils.py
+++ b/webui_utils/video_utils.py
@@ -247,13 +247,16 @@ def get_essential_video_details(input_path : str, count_frames=False) -> dict:
         for stream_data in streams_data:
             codec_type = stream_data.get("codec_type")
 
+            # TODO this will remember only the last seen audio stream
             if codec_type == "audio":
                 video_essentials["has_audio"] = True
-                continue
+                video_essentials["sample_rate"] = stream_data.get("sample_rate")
+                video_essentials["channels"] = stream_data.get("channels")
 
             if codec_type != "video":
                 continue
 
+            # TODO this assumes a single video stream
             frame_count = stream_data.get("nb_frames") or stream_data.get("nb_read_frames")
             if not frame_count:
                 if count_frames:


### PR DESCRIPTION
- Moved most code unrelated to the UI out of the Video Remixer UI class into the Video Remixer State class
- Enhanced Inflation handling to support slow motion across a variety of project settings

More about slow motion
- In the Video Remixer _Scene Chooser_, _Properties_ accordion, there are two buttons that add _processing hints_ to enable 2X or 4X audio slow motion for a single scene
  - These were the only two slow motion cases supported
  - The project was required to use 2X inflation to get the proper slow motion
  - _Note:_ the processing hints for them are `{I:4A}` and `{I:8A}` meaning force inflation at 4X and 8X with audio slow motion 

Support for slow motion has been expanded
- The numeric values 1, 2, 4 and 8 can be used to specify the amount of inflation ("1" to disable inflation)
- The characters "A" and "S" and can be used to specify _Audio_ or _Silent_ inflation
- The project is no longer required to use 2X inflation to get these slow motion scenes
