### PR TITLE
Video Remixer: Support JPG for frame file format

### DIFF
--- a/resize_frames.py
+++ b/resize_frames.py
@@ -100,14 +100,14 @@ class ResizeFrames:
         except KeyError:
             raise ValueError(f"The crop type {crop_type} is unknown")
 
-    def resize(self) -> None:
+    def resize(self, type : str="png") -> None:
         """Invoke the Resize Frames feature"""
         if not self.scale_width:
             raise ValueError("scale_width must be provided")
         if not self.scale_height:
             raise ValueError("scale_height must be provided")
 
-        files = sorted(glob.glob(os.path.join(self.input_path, "*.png")))
+        files = sorted(glob.glob(os.path.join(self.input_path, "*." + type)))
         num_files = len(files)
         self.log(f"Found {num_files} files")
         create_directory(self.output_path)

--- a/slice_video.py
+++ b/slice_video.py
@@ -143,7 +143,7 @@ class SliceVideo:
             return message
 
     # slice from a pre-grouped set of frame files
-    def _slice_frame_group(self, group_name, slice_name):
+    def _slice_frame_group(self, group_name, slice_name, type : str="png"):
         first_index, last_index, num_width = details_from_group_name(group_name)
         output_path = self.output_path or os.path.join(self.group_path, group_name)
 
@@ -163,7 +163,7 @@ class SliceVideo:
             last_index = first_index + 1
 
         frames_source = os.path.join(self.group_path, group_name)
-        pattern = determine_input_pattern(frames_source)
+        pattern = determine_input_pattern(frames_source, type)
         frames_path = os.path.join(frames_source, pattern)
         self.log(f"slicing from frames path {frames_path}")
 
@@ -228,7 +228,7 @@ class SliceVideo:
             Mtqdm().update_bar(bar)
         return errors
 
-    def slice_frame_group(self, group_name, ignore_errors=False, slice_name=""):
+    def slice_frame_group(self, group_name, ignore_errors=False, slice_name="", type : str="png"):
         validate_input_path(self.group_path, -1)
         if self.output_path:
             self.log(f"Creating output path {self.output_path}")
@@ -237,7 +237,7 @@ class SliceVideo:
         pbar_desc = f"Slice {self.type}"
         errors = []
         with Mtqdm().open_bar(total=1, desc=pbar_desc) as bar:
-            error = self._slice_frame_group(group_name, slice_name=slice_name)
+            error = self._slice_frame_group(group_name, slice_name=slice_name, type=type)
             if error:
                 errors.append({group_name : error})
                 if not ignore_errors:

--- a/slice_video.py
+++ b/slice_video.py
@@ -5,7 +5,7 @@ from typing import Callable
 from webui_utils.simple_log import SimpleLog
 from webui_utils.file_utils import create_directory, is_safe_path
 from webui_utils.video_utils import validate_input_path, details_from_group_name, slice_video, \
-    determine_input_pattern, slice_png_frames
+    determine_input_pattern, slice_video_frames
 from webui_utils.mtqdm import Mtqdm
 from ffmpy import FFRuntimeError
 
@@ -142,12 +142,12 @@ class SliceVideo:
             self.log(message)
             return message
 
-    # slice from a pre-grouped set of PNG frames
-    def _slice_png_group(self, group_name, slice_name):
+    # slice from a pre-grouped set of frame files
+    def _slice_frame_group(self, group_name, slice_name):
         first_index, last_index, num_width = details_from_group_name(group_name)
         output_path = self.output_path or os.path.join(self.group_path, group_name)
 
-        # offset to zero time - the PNG frames should start at the beginning
+        # offset to zero time - the frame files should start at the beginning
         last_index -= first_index
         first_index = 0
 
@@ -168,7 +168,7 @@ class SliceVideo:
         self.log(f"slicing from frames path {frames_path}")
 
         try:
-            ffmpeg_cmd, errors = slice_png_frames(frames_path,
+            ffmpeg_cmd, errors = slice_video_frames(frames_path,
                         self.fps,
                         output_path,
                         num_width,
@@ -228,7 +228,7 @@ class SliceVideo:
             Mtqdm().update_bar(bar)
         return errors
 
-    def slice_png_group(self, group_name, ignore_errors=False, slice_name=""):
+    def slice_frame_group(self, group_name, ignore_errors=False, slice_name=""):
         validate_input_path(self.group_path, -1)
         if self.output_path:
             self.log(f"Creating output path {self.output_path}")
@@ -237,7 +237,7 @@ class SliceVideo:
         pbar_desc = f"Slice {self.type}"
         errors = []
         with Mtqdm().open_bar(total=1, desc=pbar_desc) as bar:
-            error = self._slice_png_group(group_name, slice_name=slice_name)
+            error = self._slice_frame_group(group_name, slice_name=slice_name)
             if error:
                 errors.append({group_name : error})
                 if not ignore_errors:

--- a/tabs/video_remixer_ui.py
+++ b/tabs/video_remixer_ui.py
@@ -64,7 +64,9 @@ class VideoRemixer(TabBase):
         "resize_w" : 1920,
         "resize_h" : 1080,
         "crop_w" : 1920,
-        "crop_h" : 1080
+        "crop_h" : 1080,
+        "frame_format" : "png",
+        "sound_format" : "wav"
     }
 
     TAB_REMIX_HOME = 0

--- a/tabs/video_remixer_ui.py
+++ b/tabs/video_remixer_ui.py
@@ -448,7 +448,7 @@ class VideoRemixer(TabBase):
                     with gr.Tab(label="Create Custom Remix"):
                         custom_video_options = gr.Textbox(value=custom_ffmpeg_video, max_lines=1,
                             label="Custom FFmpeg Video Output Options",
-                    info="Passed to FFmpeg as output video settings when converting PNG frames")
+                    info="Passed to FFmpeg as output video settings when converting frames to video")
                         custom_audio_options = gr.Textbox(value=custom_ffmpeg_audio, max_lines=1,
                             label="Custom FFmpeg Audio Output Options",
                     info="Passed to FFmpeg as output audio settings when combining with video")
@@ -473,7 +473,7 @@ class VideoRemixer(TabBase):
                     with gr.Tab(label="Create Marked Remix"):
                         marked_video_options = gr.Textbox(value=marked_ffmpeg_video, max_lines=1,
                             label="Marked FFmpeg Video Output Options",
-                    info="Passed to FFmpeg as output video settings when converting PNG frames")
+                    info="Passed to FFmpeg as output video settings when converting frames to video")
                         marked_audio_options = gr.Textbox(value=marked_ffmpeg_audio, max_lines=1,
                             label="Marked FFmpeg Audio Output Options",
                     info="Passed to FFmpeg as output audio settings when combining with video")
@@ -777,13 +777,13 @@ class VideoRemixer(TabBase):
                                     with gr.Tab(SimpleIcons.CROSSMARK +
                                                 " Remove Scene Chooser Content"):
                                         gr.Markdown(
-                                "**_Delete source PNG frame files, thumbnails and dropped scenes_**")
+                                "**_Delete source frame files, thumbnails and dropped scenes_**")
                                         with gr.Row():
                                             delete_source_711 = gr.Checkbox(value=True,
                                                 label="Remove Source Video Frames")
                                             with gr.Column(variant="compact"):
                                                 gr.Markdown(
-                            "Delete source video PNG frame files used to split content into scenes.")
+                            "Delete source video frame files used to split content into scenes.")
                                         with gr.Row():
                                             delete_dropped_711 = gr.Checkbox(
                                                 label="Remove Dropped Scenes")
@@ -825,26 +825,26 @@ class VideoRemixer(TabBase):
                                             label="Remove Resized Frames")
                                         with gr.Column(variant="compact"):
                                             gr.Markdown(
-    "Delete Resized PNG frame files used as inputs for processing and creating remix video clips.")
+    "Delete Resized frame files used as inputs for processing and creating remix video clips.")
                                     with gr.Row():
                                         delete_resynth_712 = gr.Checkbox(value=True,
                                             label="Remove Resynthesized Frames")
                                         with gr.Column(variant="compact"):
                                             gr.Markdown(
-                                        "Delete Resynthesized PNG frame files used as inputs " +\
+                                        "Delete Resynthesized frame files used as inputs " +\
                                         "for processing and creating remix video clips.")
                                     with gr.Row():
                                         delete_inflated_712 = gr.Checkbox(value=True,
                                             label="Remove Inflated Frames")
                                         with gr.Column(variant="compact"):
                                             gr.Markdown(
-    "Delete Inflated PNG frame files used as inputs for processing and creating remix video clips.")
+    "Delete Inflated frame files used as inputs for processing and creating remix video clips.")
                                     with gr.Row():
                                         delete_upscaled_712 = gr.Checkbox(value=True,
                                             label="Remove Upscaled Frames")
                                         with gr.Column(variant="compact"):
                                             gr.Markdown(
-    "Delete Upscaled PNG frame files used as inputs for processing and creating remix video clips.")
+    "Delete Upscaled frame files used as inputs for processing and creating remix video clips.")
                                     with gr.Row():
                                         delete_audio_712 = gr.Checkbox(label="Delete Audio Clips")
                                         with gr.Column(variant="compact"):
@@ -1542,16 +1542,16 @@ class VideoRemixer(TabBase):
             self.log("resetting project on rendering for project settings")
             self.state.reset_at_project_settings()
 
-            # split video into raw PNG frames, avoid doing again if redoing setup
+            # split video into frames, avoid doing again if redoing setup
             # unless the source frames were flagged invalid in the previous step
-            self.log("splitting source video into PNG frames")
+            self.log("splitting source video into frames")
             prevent_overwrite = not self.state.source_frames_invalid
             ffcmd = self.state.render_source_frames(global_options=global_options,
                                                     prevent_overwrite=prevent_overwrite)
             if not ffcmd:
                 self.log("rendering source frames skipped")
             else:
-                self.log("saving project after converting video to PNG frames")
+                self.log("saving project after converting video to frames")
                 self.state.save()
                 self.log(f"FFmpeg command: {ffcmd}")
 
@@ -2341,7 +2341,7 @@ class VideoRemixer(TabBase):
 
         self.state.uncompile_scenes()
 
-        # the native size of the on-disk PNG frames is needed
+        # the native dimensions of the on-disk frame files are needed
         # older project.yaml files won't have this data
         try:
             self.state.enhance_video_info(self.log, ignore_errors=False)
@@ -2449,7 +2449,7 @@ class VideoRemixer(TabBase):
         # resequence the files within the selected scenes contiguously
         self.log("about to call resequence_groups() with the selected scene names")
         ResequenceFiles(self.state.scenes_path,
-                        "png",
+                        self.state.frame_format,
                         "merged_frame",
                         0, 1,
                         1, 0,

--- a/video_remixer.py
+++ b/video_remixer.py
@@ -1567,7 +1567,7 @@ class VideoRemixerState():
                     crop_width=self.crop_w,
                     crop_height=self.crop_h,
                     crop_offset_x=self.crop_offset_x,
-                    crop_offset_y=self.crop_offset_y).resize()
+                    crop_offset_y=self.crop_offset_y).resize(type=self.frame_format)
 
     def resize_scenes(self, log_fn, kept_scenes, remixer_settings):
         scenes_base_path = self.scenes_source_path(self.RESIZE_STEP)
@@ -1591,10 +1591,12 @@ class VideoRemixerState():
                 Mtqdm().update_bar(bar)
 
     # TODO dry up this code with same in resynthesize_video_ui - maybe a specific resynth script
-    def one_pass_resynthesis(self, log_fn, input_path, output_path, output_basename, engine):
+    def one_pass_resynthesis(self, log_fn, input_path, output_path, output_basename,
+                             engine : InterpolateSeries):
         file_list = sorted(get_files(input_path, extension=self.frame_format))
         log_fn(f"beginning series of frame recreations at {output_path}")
-        engine.interpolate_series(file_list, output_path, 1, "interframe", offset=2)
+        engine.interpolate_series(file_list, output_path, 1, "interframe", offset=2,
+                                  type=self.frame_format)
 
         log_fn(f"auto-resequencing recreated frames at {output_path}")
         ResequenceFiles(output_path,
@@ -1606,13 +1608,15 @@ class VideoRemixerState():
                         True, # rename
                         log_fn).resequence()
 
-    def two_pass_resynth_pass(self, log_fn, input_path, output_path, output_basename, engine):
+    def two_pass_resynth_pass(self, log_fn, input_path, output_path, output_basename,
+                              engine : InterpolateSeries):
         file_list = sorted(get_files(input_path, extension=self.frame_format))
 
         inflated_frames = os.path.join(output_path, "inflated_frames")
         log_fn(f"beginning series of interframe recreations at {inflated_frames}")
         create_directory(inflated_frames)
-        engine.interpolate_series(file_list, inflated_frames, 1, "interframe")
+        engine.interpolate_series(file_list, inflated_frames, 1, "interframe",
+                                  type=self.frame_format)
 
         log_fn(f"selecting odd interframes only at {inflated_frames}")
         ResequenceFiles(inflated_frames,

--- a/video_remixer.py
+++ b/video_remixer.py
@@ -1721,7 +1721,8 @@ class VideoRemixerState():
                     series_interpolater.interpolate_series(file_list,
                                                         scene_output_path,
                                                         num_splits,
-                                                        output_basename)
+                                                        output_basename,
+                                                        type=self.frame_format)
                     ResequenceFiles(scene_output_path,
                                     self.frame_format,
                                     "inflated_frame",

--- a/video_remixer.py
+++ b/video_remixer.py
@@ -416,7 +416,8 @@ class VideoRemixerState():
                                   frame_rate,
                                   self.frames_path,
                                   deinterlace=self.deinterlace,
-                                  global_options=global_options)
+                                  global_options=global_options,
+                                  type=self.frame_format)
             Mtqdm().update_bar(bar)
         return ffmpeg_cmd
 
@@ -633,7 +634,7 @@ class VideoRemixerState():
                         0.0,
                         log_fn,
                         global_options=global_options).slice_frame_group(scene_name,
-                            slice_name=thumbnail_filename)
+                            slice_name=thumbnail_filename, type=self.frame_format)
 
         elif self.thumbnail_type == "GIF":
             gif_fps = remixer_settings["default_gif_fps"]
@@ -665,7 +666,8 @@ class VideoRemixerState():
                         log_fn,
                         global_options=global_options).slice_frame_group(scene_name,
                                                                     ignore_errors=True,
-                                                                    slice_name=thumbnail_filename)
+                                                                    slice_name=thumbnail_filename,
+                                                                    type=self.frame_format)
         else:
             raise ValueError(f"thumbnail type '{self.thumbnail_type}' is not implemented")
 
@@ -2101,7 +2103,8 @@ class VideoRemixerState():
                                 video_clip_fps,
                                 scene_output_filepath,
                                 crf=self.output_quality,
-                                global_options=global_options)
+                                global_options=global_options,
+                                type=self.frame_format)
                 Mtqdm().update_bar(bar)
 
         self.video_clips = sorted(get_files(self.video_clips_path))
@@ -2299,7 +2302,8 @@ class VideoRemixerState():
                             video_clip_fps,
                             scene_output_filepath,
                             global_options=global_options,
-                            custom_options=use_custom_video_options)
+                            custom_options=use_custom_video_options,
+                            type=self.frame_format)
                 Mtqdm().update_bar(bar)
         self.video_clips = sorted(get_files(self.video_clips_path))
 

--- a/video_remixer.py
+++ b/video_remixer.py
@@ -54,6 +54,8 @@ class VideoRemixerState():
         self.split_time = None
         self.crop_offset_x = None
         self.crop_offset_y = None
+        self.frame_format = None
+        self.sound_format = None
 
         # set on confirming set up options
         self.split_frames = None
@@ -142,6 +144,8 @@ class VideoRemixerState():
         self.inflate_by_option = defaults["inflate_by_option"]
         self.inflate_slow_option = defaults["inflate_slow_option"]
         self.resynth_option = defaults["resynth_option"]
+        self.frame_format = defaults["frame_format"]
+        self.audio_format = defaults["audio_format"]
 
     DEF_FILENAME = "project.yaml"
 
@@ -2710,6 +2714,17 @@ class VideoRemixerState():
                         state.resynth_option = "Scrub"
                 except AttributeError:
                         state.resynth_option = "Scrub"
+                # new frame and found format options
+                try:
+                    if not state.frame_format:
+                        state.frame_format = "png"
+                except AttributeError:
+                        state.frame_format = "png"
+                try:
+                    if not state.sound_format:
+                        state.sound_format = "wav"
+                except AttributeError:
+                        state.sound_format = "wav"
 
                 return state
 

--- a/video_remixer.py
+++ b/video_remixer.py
@@ -465,7 +465,7 @@ class VideoRemixerState():
                                 self.scene_threshold,
                                 0.0,
                                 0.0,
-                                log_fn).split()
+                                log_fn).split(type=self.frame_format)
                     Mtqdm().update_bar(bar)
 
             elif self.split_type == "Break":
@@ -478,7 +478,7 @@ class VideoRemixerState():
                                 0.0,
                                 float(self.break_duration),
                                 float(self.break_ratio),
-                                log_fn).split()
+                                log_fn).split(type=self.frame_format)
                     Mtqdm().update_bar(bar)
             elif self.split_type == "Time":
                 # split by seconds
@@ -491,7 +491,7 @@ class VideoRemixerState():
                     self.split_frames,
                     "copy",
                     False,
-                    log_fn).split()
+                    log_fn).split(type=self.frame_format)
             else:
                 # single split
                 SplitFrames(
@@ -503,7 +503,7 @@ class VideoRemixerState():
                     0,
                     "copy",
                     False,
-                    log_fn).split()
+                    log_fn).split(type=self.frame_format)
             return None
         except ValueError as error:
             return error

--- a/webui_utils/file_utils.py
+++ b/webui_utils/file_utils.py
@@ -232,18 +232,18 @@ def create_zip(files : list, filepath : str):
     else:
         raise ValueError("'files' must be a list")
 
-def locate_frame_file(png_files_path : str, frame_number : int | float) -> str | None:
+def locate_frame_file(frame_files_path : str, frame_number : int | float, type : str="png") -> str | None:
     """Given a path and index, return the file found at that sorted position"""
-    if not isinstance(png_files_path, str):
-        raise ValueError("'png_files_path' must be a string")
-    if not is_safe_path(png_files_path):
-        raise ValueError("'png_files_path' must be a legal path")
+    if not isinstance(frame_files_path, str):
+        raise ValueError("'frame_files_path' must be a string")
+    if not is_safe_path(frame_files_path):
+        raise ValueError("'frame_files_path' must be a legal path")
     if not isinstance(frame_number, (int, float)):
         raise ValueError("'frame_number' must be an int or float")
     frame_number = int(frame_number)
-    files = sorted(get_files(png_files_path, "png"))
+    files = sorted(get_files(frame_files_path, type))
     if 0 <= frame_number < len(files):
-        if os.path.exists(png_files_path):
+        if os.path.exists(frame_files_path):
             return files[frame_number]
     return None
 

--- a/webui_utils/video_utils.py
+++ b/webui_utils/video_utils.py
@@ -696,7 +696,7 @@ f"{default_filename}[{str(first_frame).zfill(num_width)}-{str(last_frame).zfill(
     ffcmd.run()
     return cmd
 
-def slice_png_frames(input_path : str,
+def slice_video_frames(input_path : str,
                 fps : float,
                 output_path : str,
                 num_width : int,


### PR DESCRIPTION
Add support for storing frames as _jpg_ files instead of _png_ files
- This helps with large format content, such as 4K and larger
- Some processing is sped up by using jpg files 
- Files are stored at the highest FFmpeg quality setting

To choose _JPG_ file format for frames
- Go to the _Remix Settings_ tab of _Video Remixer_
- Open the _More Options_ accordion
- Choose "jpg" for _Frame Format_