### PR TITLE
Video Remixer minor clean up

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -102,6 +102,7 @@ realesrgan_settings:
   tiling: 256
 remixer_settings:
   audio_format: wav
+  backup_split_scenes: True
   custom_ffmpeg_video: -c:v libx264 -crf 23
   custom_ffmpeg_audio: -c:a aac -shortest
   default_crf: 23

--- a/tabs/video_remixer_ui.py
+++ b/tabs/video_remixer_ui.py
@@ -2242,10 +2242,11 @@ class VideoRemixer(TabBase):
 
     def split_scene(self, scene_index, split_percent, keep_before, keep_after):
         global_options = self.config.ffmpeg_settings["global_options"]
+        backup_split_scenes = self.config.remixer_settings["backup_split_scenes"]
         try:
             message = self.state.split_scene(self.log, scene_index, split_percent,
                                              self.config.remixer_settings, global_options,
-                                             keep_before, keep_after)
+                                             keep_before, keep_after, backup_split_scenes)
             self.state.save()
 
             return gr.update(selected=self.TAB_CHOOSE_SCENES), \

--- a/tabs/video_remixer_ui.py
+++ b/tabs/video_remixer_ui.py
@@ -1393,12 +1393,32 @@ class VideoRemixer(TabBase):
                 format_markdown(f"The project path is not valid", "warning"),\
                 *empty_args
 
+        if os.path.exists(project_path):
+            return gr.update(selected=self.TAB_REMIX_SETTINGS), \
+                format_markdown(f"The project path is already in use", "warning"),\
+                *empty_args
+
+        if resize_h < 1 or resize_w < 1 or crop_h < 1 or crop_w < 1:
+            return gr.update(selected=self.TAB_REMIX_SETTINGS), \
+                format_markdown(f"Resize/Crop values should be >= 1", "warning"),\
+                *empty_args
+
+        if crop_h > resize_h or crop_w > resize_w:
+            return gr.update(selected=self.TAB_REMIX_SETTINGS), \
+                format_markdown(f"Crop values should be <= Resize values", "warning"),\
+                *empty_args
+
+        if crop_offset_x < -1 or crop_offset_x > crop_w - 1 or \
+                crop_offset_y < -1 or crop_offset_y > crop_h - 1:
+            return gr.update(selected=self.TAB_REMIX_SETTINGS), \
+                format_markdown(f"Crop Offset values should be >= -1 and less than Crop values",
+                                "warning"),\
+                *empty_args
+
         if split_time < 1:
             return gr.update(selected=self.TAB_REMIX_SETTINGS), \
                 format_markdown(f"Scene Split Seconds should be >= 1", "warning"),\
                 *empty_args
-
-        # TODO validate the other entries
 
         try:
             # this is first project write

--- a/video_remixer.py
+++ b/video_remixer.py
@@ -1022,7 +1022,7 @@ class VideoRemixerState():
         os.replace(original_scene_path, new_lower_scene_path)
 
     def split_scene(self, log_fn, scene_index, split_percent, remixer_settings, global_options,
-                    keep_before=False, keep_after=False):
+                    keep_before=False, keep_after=False, backup_scene=True):
         if not isinstance(scene_index, (int, float)):
             raise ValueError("Scene index must be an int or float")
 
@@ -1052,11 +1052,11 @@ class VideoRemixerState():
         new_upper_scene_name = VideoRemixerState.encode_scene_name(num_width,
                                                 new_upper_first_frame, new_upper_last_frame, 0, 0)
 
-        # this may fail, so copy the original scene and project file to the purged content directory
-        scene_path = os.path.join(self.scenes_path, scene_name)
-        purge_root = self.purge_paths([scene_path], keep_original=True, additional_path=self.SCENES_PATH)
-        if purge_root:
-            self.copy_project_file(purge_root)
+        if backup_scene:
+            scene_path = os.path.join(self.scenes_path, scene_name)
+            purge_root = self.purge_paths([scene_path], keep_original=True, additional_path=self.SCENES_PATH)
+            if purge_root:
+                self.copy_project_file(purge_root)
 
         try:
             self.split_scene_content(self.scenes_path,


### PR DESCRIPTION
New `config.yaml` parameter

```yaml
remixer_settings:
    backup_split_scenes: True
```
- make _backing up scene before splitting_ a remixer option
- don't create project on top of existing project
- disallow invalid resize/crop/offset entries