### PR TITLE
Video Remixer: Add simple zoom processing hint

### DIFF
--- a/video_remixer.py
+++ b/video_remixer.py
@@ -1945,32 +1945,29 @@ f"Error in resize_scenes() handling processing hint {resize_hint} - skipping pro
         if self.resynthesize_chosen():
             if self.resynthesize:
                 label += "-re"
-            if self.resynth_option == "Clean":
-                label += "C"
-            elif self.resynth_option == "Scrub":
-                label += "S"
-            elif self.resynth_option == "Replace":
-                label += "R"
-        else:
-            label += "-reH"
+                if self.resynth_option == "Clean":
+                    label += "C"
+                elif self.resynth_option == "Scrub":
+                    label += "S"
+                elif self.resynth_option == "Replace":
+                    label += "R"
+            else:
+                label += "-reH"
 
         if self.inflate_chosen():
             if self.inflate:
-                # enabled overall in the project
                 label += "-in" + self.inflate_by_option[0]
                 if self.inflate_slow_option == "Audio":
                     label += "SA"
                 elif self.inflate_slow_option == "Silent":
                     label += "SM"
             else:
-                # enabled via a processing hint
                 label += "-inH"
 
         if self.upscale_chosen():
             if self.upscale:
                 label += "-up" + self.upscale_option[0]
             else:
-                # enabled via a processing hint
                 label += "-upH"
 
         label += "-" + extra_suffix if extra_suffix else ""

--- a/video_remixer.py
+++ b/video_remixer.py
@@ -1396,16 +1396,16 @@ class VideoRemixerState():
     # content is stale if it is present on disk but not currently selected
     # stale content and its derivative content should be purged
     def purge_stale_processed_content(self, purge_resynth, purge_inflation, purge_upscale):
-        if self.processed_content_stale(self.resize, self.resize_path):
+        if self.processed_content_stale(self.resize_chosen(), self.resize_path):
             self.purge_processed_content(purge_from=self.RESIZE_STEP)
 
-        if self.processed_content_stale(self.resynthesize, self.resynthesis_path) or purge_resynth:
+        if self.processed_content_stale(self.resynthesize_chosen(), self.resynthesis_path) or purge_resynth:
             self.purge_processed_content(purge_from=self.RESYNTH_STEP)
 
-        if self.processed_content_stale(self.inflate, self.inflation_path) or purge_inflation:
+        if self.processed_content_stale(self.inflate_chosen(), self.inflation_path) or purge_inflation:
             self.purge_processed_content(purge_from=self.INFLATE_STEP)
 
-        if self.processed_content_stale(self.upscale, self.upscale_path) or purge_upscale:
+        if self.processed_content_stale(self.upscale_chosen(), self.upscale_path) or purge_upscale:
             self.purge_processed_content(purge_from=self.UPSCALE_STEP)
 
     def purge_incomplete_processed_content(self):

--- a/webui_utils/simple_utils.py
+++ b/webui_utils/simple_utils.py
@@ -336,3 +336,7 @@ def format_table(header_row : list,
 
 def dummy_args(num, arg=None):
     return [arg for _ in range(num)]
+
+def evenify(value) -> int:
+    """Return the highest multiple of 2 integer contained in the value"""
+    return (int(value / 2)) * 2


### PR DESCRIPTION
Add the following processing hint to a scene label to get individual scene zooming
- `{R:nnn%}`
  - zooms scene by `nnn`%, centered, keeping frame dimensions
  - Ex: `{R:200%}` would zoom in 2X
- `{R:x/y}`
  - zooms to make `y` even quadrants, then shows quadrant `x`
  - Ex: `{R:5/9}` would show the center quadrant of a 3x3 grid (think of a telephone keypad)
  - Ex: `{R:4/4}` would show the lower right quadrant of a 2x2 grid

Add the following processing hint to a scene label to get 1X upscaling for a scene
- `{U:1}`
  - Uses the Real-ESRGAN upscaler to upscale at 1X for cleaning 
  - _Future:_ support will be added to use the upscaler for high quality AI zooming

Processing hints can be combined
- For example, for zooming, audio slow motion and cleaning
  - `{R:6/9,I:4A,U:1}`

Zooming is done using the method set in `config.yaml`:

```yaml
remixer_settings:
    scale_type_up: "lanczos"
```