### PR TITLE
Add requirement on Gradio client version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 ffmpy==0.3.0
 gradio==3.36.1
+gradio_client==0.7.1
 matplotlib==3.6.3
 numpy==1.23.5
 opencv_python==4.8.1.78


### PR DESCRIPTION
While testing later Gradio versions I ended up with an incompatible version of Gradio Client. This fixes it.