### PR TITLE
Video Remixer and Deduplication fixes

### DIFF
--- a/interpolate.py
+++ b/interpolate.py
@@ -35,6 +35,8 @@ def main():
         type=float, help="Middle frame time step if one frame (Default: 0.5)")
     parser.add_argument("--multiple", dest="multiple", default=1,
         type=int, help="Create multiple evenly-spaced frames if > 1 (Default: 1)")
+    parser.add_argument("--type", default="png", type=str,
+                        help="File type for frame files (Default 'png')")
     parser.add_argument("--verbose", dest="verbose", default=False, action="store_true",
         help="Show extra details")
     args = parser.parse_args()
@@ -57,9 +59,11 @@ class Interpolate:
 
     def __init__(self,
                 model,
-                log_fn : Callable | None):
+                log_fn : Callable | None,
+                type : str="png"):
         self.model = model
         self.log_fn = log_fn
+        self.type = type
         self.output_paths = []
 
     def create_between_frame(self,
@@ -110,7 +114,7 @@ class Interpolate:
         set_count = 2 if frame_count < 1 else frame_count + 1
 
         output_path, filename, extension = split_filepath(middle_filepath)
-        output_filepath = os.path.join(output_path, f"{filename}@0.0.png")
+        output_filepath = os.path.join(output_path, f"{filename}@0.0.{self.type}")
         images = [I0[:, :, ::-1]]
         imsave(output_filepath, images[0])
         self.output_paths.append(output_filepath)
@@ -125,13 +129,13 @@ class Interpolate:
             for index, image in enumerate(images):
                 if 0 < index < len(images) - 1:
                     time = sortable_float_index(index / set_count)
-                    output_filepath = os.path.join(output_path, f"{filename}@{time}.png")
+                    output_filepath = os.path.join(output_path, f"{filename}@{time}.{self.type}")
                     imsave(output_filepath, image)
                     self.output_paths.append(output_filepath)
                     self.log("create_between_frames() saved " + output_filepath)
                 Mtqdm().update_bar(bar)
 
-        output_filepath = os.path.join(output_path, f"{filename}@1.0.png")
+        output_filepath = os.path.join(output_path, f"{filename}@1.0.{self.type}")
         imsave(output_filepath, images[-1])
         self.output_paths.append(output_filepath)
         self.log("create_between_frames() saved " + output_filepath)

--- a/restore_frames.py
+++ b/restore_frames.py
@@ -32,6 +32,8 @@ def main():
         help="Base filename for interpolated PNGs")
     parser.add_argument("--time_step", dest="time_step", default=False, action="store_true",
         help="Use Time Step instead of Binary Search interpolation (Default: False)")
+    parser.add_argument("--type", default="png", type=str,
+                        help="File type for frame files (Default 'png')")
     parser.add_argument("--verbose", dest="verbose", default=False, action="store_true",
         help="Show extra details")
     args = parser.parse_args()
@@ -39,9 +41,10 @@ def main():
     log = SimpleLog(args.verbose)
     create_directory(args.output_path)
     engine = InterpolateEngine(args.model, args.gpu_ids, use_time_step=args.time_step)
-    interpolater = Interpolate(engine.model, log.log)
-    target_interpolater = TargetInterpolate(interpolater, log.log)
-    frame_restorer = RestoreFrames(interpolater, target_interpolater, args.time_step, log.log)
+    interpolater = Interpolate(engine.model, log.log, type=args.type)
+    target_interpolater = TargetInterpolate(interpolater, log.log, type=args.type)
+    frame_restorer = RestoreFrames(interpolater, target_interpolater, args.time_step, log.log,
+                                   type=args.type)
 
     frame_restorer.restore_frames(args.img_before, args.img_after, args.num_frames,
         args.depth, args.output_path, args.base_filename)
@@ -52,11 +55,13 @@ class RestoreFrames():
                 interpolater : Interpolate,
                 target_interpolater : TargetInterpolate,
                 time_step : bool,
-                log_fn : Callable | None):
+                log_fn : Callable | None,
+                type : str="png"):
         self.interpolater = interpolater
         self.target_interpolater = target_interpolater
         self.time_step = time_step
         self.log_fn = log_fn
+        self.type = type
         self.output_paths = []
 
     def restore_frames(self,

--- a/tabs/dedupe_autofill_ui.py
+++ b/tabs/dedupe_autofill_ui.py
@@ -13,7 +13,9 @@ from interpolation_target import TargetInterpolate
 from restore_frames import RestoreFrames
 from webui_utils.auto_increment import AutoIncrementDirectory, AutoIncrementFilename
 from webui_utils.video_utils import determine_input_format
-from webui_utils.file_utils import create_directory
+from webui_utils.file_utils import create_directory, is_safe_path, get_directories
+from webui_utils.simple_utils import format_markdown
+from webui_utils.mtqdm import Mtqdm
 
 class AutofillFrames(TabBase):
     """Encapsulates UI elements and events for the Deduplicate Frames feature"""
@@ -22,6 +24,10 @@ class AutofillFrames(TabBase):
                     engine : InterpolateEngine,
                     log_fn : Callable):
         TabBase.__init__(self, config, engine, log_fn)
+
+    DEFAULT_MESSAGE_SINGLE = "Click Deduplicate Frames to: Detect and replace duplicate frames"
+    DEFAULT_MESSAGE_BATCH = \
+        "Click Deduplicate Batch to: Detect and replace duplicate frames for each batch directory"
 
     def render_tab(self):
         """Render tab into UI"""
@@ -37,13 +43,6 @@ class AutofillFrames(TabBase):
             gr.Markdown(SimpleIcons.BANDAGE +\
                         "Detect and fill duplicate frames with interpolated replacements")
             with gr.Row():
-                input_path_text = gr.Text(max_lines=1, label="Input PNG Files Path",
-                    placeholder="Path on this server to the PNG files to be deduplicated")
-            with gr.Row():
-                output_path_text = gr.Text(max_lines=1, label="Output PNG Files Path",
-                    placeholder="Path on this server for the deduplicated PNG files," +
-                                " leave blank to use default path")
-            with gr.Row():
                 threshold = gr.Slider(value=default_threshold, minimum=min_threshold,
                     maximum=max_threshold, step=threshold_step, label="Detection Threshold")
                 max_dupes = gr.Slider(value=def_max_dupes, minimum=0, maximum=max_max_dupes, step=1,
@@ -51,70 +50,200 @@ class AutofillFrames(TabBase):
             with gr.Row():
                 precision = gr.Slider(value=default_precision, minimum=1, maximum=max_precision,
                     step=1, label="Search Precision")
-            gr.Markdown("*Progress can be tracked in the console*")
-            dedupe_button = gr.Button("Deduplicate Frames " + SimpleIcons.SLOW_SYMBOL,
-                                        variant="primary")
-            with gr.Row():
-                output_text = gr.Textbox(label="Result", interactive=False, visible=False)
+            with gr.Tabs():
+                with gr.Tab(label="Individual Path"):
+                    with gr.Row():
+                        input_path_text = gr.Text(max_lines=1, label="Input Path",
+                            placeholder="Path on this server to the PNG files to be deduplicated")
+                    with gr.Row():
+                        output_path_text = gr.Text(max_lines=1, label="Output Path",
+                            placeholder="Path on this server for the deduplicated PNG files")
+                    message_box_single = gr.Markdown(format_markdown(self.DEFAULT_MESSAGE_SINGLE))
+                    gr.Markdown("*Progress can be tracked in the console*")
+                    dedupe_button = gr.Button("Deduplicate Frames " + SimpleIcons.SLOW_SYMBOL,
+                                              variant="primary")
+                with gr.Tab(label="Batch Processing"):
+                    with gr.Row():
+                        input_path_batch = gr.Text(max_lines=1, label="Input Path",
+                            placeholder="Path on this server to the frame groups to be deduplicated")
+                    with gr.Row():
+                        output_path_batch = gr.Text(max_lines=1, label="Output Path",
+                            placeholder="Path on this server for the deduplicated PNG files")
+                    message_box_batch = gr.Markdown(format_markdown(self.DEFAULT_MESSAGE_BATCH))
+                    gr.Markdown("*Progress can be tracked in the console*")
+                    dedupe_batch = gr.Button("Deduplicate Frames " + SimpleIcons.SLOW_SYMBOL,
+                                             variant="primary")
             with gr.Accordion(SimpleIcons.TIPS_SYMBOL + " Guide", open=False):
                 WebuiTips.autofill_duplicates.render()
+
         dedupe_button.click(self.autofill_dupe_frames, inputs=[input_path_text, output_path_text,
                                                                threshold, max_dupes, precision],
-                                                        outputs=output_text)
+                                                       outputs=message_box_single)
+
+        dedupe_batch.click(self.autofill_dupe_batch, inputs=[input_path_batch, output_path_batch,
+                                                               threshold, max_dupes, precision],
+                                                       outputs=message_box_batch)
+
+    def autofill_dupe_batch(self,
+                        input_path : str,
+                        output_path : str,
+                        threshold : int,
+                        max_dupes : int,
+                        depth : int):
+        if not input_path:
+            return format_markdown("Please enter an input path to begin", "warning")
+        if not os.path.exists(input_path):
+            return format_markdown(f"The input path {input_path} was not found", "error")
+        if not is_safe_path(input_path):
+            return format_markdown(f"The input path {input_path} is not valid", "error")
+        if not output_path:
+            return format_markdown("Please enter an output path to begin", "warning")
+        if not is_safe_path(output_path):
+            return format_markdown(f"The output path {output_path} is not valid", "error")
+        if threshold < 0:
+            return format_markdown("Please enter a value >= zero for Threshold", "warning")
+        if max_dupes < 0:
+            return format_markdown("Please enter a value >= zero for Maximum Group Size", "warning")
+        if depth < 1:
+            return format_markdown("Please enter a value >= one for Search Precision", "warning")
+
+        self.log(f"creating group output path {output_path}")
+        create_directory(output_path)
+
+        group_names = get_directories(input_path)
+        if not group_names:
+            return format_markdown(f"No directories were found at the input path {input_path}",
+                                   "error")
+
+        self.log(f"beginning batch Deduplication Auto-Fill processing with input_path={input_path}" +\
+                    f" output_path={output_path}")
+        self.log(f"found {len(group_names)} groups to process")
+
+        errors = []
+        with Mtqdm().open_bar(total=len(group_names), desc="Frame Group") as bar:
+            for group_name in group_names:
+                group_input_path = os.path.join(input_path, group_name)
+                group_output_path = os.path.join(output_path, group_name)
+                try:
+                    self.autofill_dupe_frames(group_input_path, group_output_path, threshold,
+                                              max_dupes, depth, interactive=False)
+                except ValueError as error:
+                    errors.append(f"Error handling directory {group_name}: " + str(error))
+                Mtqdm().update_bar(bar)
+        if errors:
+            message = "\r\n".join(errors)
+            return format_markdown(message, "error")
+        else:
+            message = f"Batch processed deduplicated frames saved to {os.path.abspath(output_path)}"
+            return format_markdown(message)
 
     def autofill_dupe_frames(self,
                         input_path : str,
                         output_path : str,
                         threshold : int,
                         max_dupes : int,
-                        depth : int):
+                        depth : int,
+                        interactive : bool=True):
         """Deduplicate Frames button handler"""
-        if input_path:
-            try:
-                type = determine_input_format(input_path)
 
-                if not output_path:
-                    base_output_path = self.config.directories["output_deduplication"]
-                    output_path, _ = AutoIncrementDirectory(base_output_path).next_directory("run")
+        if not input_path:
+            if interactive:
+                return format_markdown("Please enter an input path to begin", "warning")
+            else:
+                raise ValueError("The input path is empty")
+        if not os.path.exists(input_path):
+            message = f"The input path {input_path} was not found"
+            if interactive:
+                return format_markdown(message, "error")
+            else:
+                raise ValueError(message)
+        if not is_safe_path(input_path):
+            message = f"The input path {input_path} is not valid"
+            if interactive:
+                return format_markdown(message, "error")
+            else:
+                raise ValueError(message)
 
-                interpolater = Interpolate(self.engine.model, self.log, type=type)
-                target_interpolater = TargetInterpolate(interpolater, self.log, type=type)
-                use_time_step = self.config.engine_settings["use_time_step"]
-                frame_restorer = RestoreFrames(interpolater, target_interpolater, use_time_step,
-                                               self.log, type=type)
+        if not output_path:
+            if interactive:
+                return format_markdown("Please enter an output path to begin", "warning")
+            else:
+                raise ValueError("The output path is empty")
+        if not is_safe_path(output_path):
+            message = f"The output path {output_path} is not valid"
+            if interactive:
+                return format_markdown(message, "error")
+            else:
+                raise ValueError(message)
 
-                message, auto_filled_files, _ = DeduplicateFrames(frame_restorer,
-                                                                  input_path,
-                                                                  output_path,
-                                                                  threshold,
-                                                                  max_dupes,
-                                                                  depth,
-                                                                  self.log,
-                                                                  type=type).invoke_autofill(
-                                                                      suppress_output=True)
-                report = self.create_autofill_report(input_path,
-                                                     output_path,
-                                                     threshold,
-                                                     max_dupes,
-                                                     depth,
-                                                     message,
-                                                     auto_filled_files)
+        if threshold < 0:
+            if interactive:
+                return format_markdown("Please enter a value >= zero for Threshold", "warning")
+            else:
+                raise ValueError("Threshold must be >= 0")
+        if max_dupes < 0:
+            if interactive:
+                return format_markdown("Please enter a value >= zero for Maximum Group Size",
+                                       "warning")
+            else:
+                raise ValueError("Maximum Groups Size must be >= 0")
+        if depth < 1:
+            if interactive:
+                return format_markdown("Please enter a value >= one for Search Precision", "warning")
+            else:
+                raise ValueError("Search Precision must be >= 1")
 
-                report_name = "autofill-report"
-                report_path = os.path.join(output_path, report_name)
-                create_directory(report_path)
-                report_filepath, _ = AutoIncrementFilename(report_path, "txt").next_filename(
-                                                                                        report_name,
-                                                                                        "txt")
-                with open(report_filepath, "w", encoding="UTF-8") as file:
-                    file.write(report)
+        try:
+            type = determine_input_format(input_path)
+
+            if not output_path:
+                base_output_path = self.config.directories["output_deduplication"]
+                output_path, _ = AutoIncrementDirectory(base_output_path).next_directory("run")
+
+            interpolater = Interpolate(self.engine.model, self.log, type=type)
+            target_interpolater = TargetInterpolate(interpolater, self.log, type=type)
+            use_time_step = self.config.engine_settings["use_time_step"]
+            frame_restorer = RestoreFrames(interpolater, target_interpolater, use_time_step,
+                                            self.log, type=type)
+
+            message, auto_filled_files, _ = DeduplicateFrames(frame_restorer,
+                                                                input_path,
+                                                                output_path,
+                                                                threshold,
+                                                                max_dupes,
+                                                                depth,
+                                                                self.log,
+                                                                type=type).invoke_autofill(
+                                                                    suppress_output=True)
+            report = self.create_autofill_report(input_path,
+                                                    output_path,
+                                                    threshold,
+                                                    max_dupes,
+                                                    depth,
+                                                    message,
+                                                    auto_filled_files)
+
+            report_name = "autofill-report"
+            report_path = os.path.join(output_path, report_name)
+            create_directory(report_path)
+            report_filepath, _ = AutoIncrementFilename(report_path, "txt").next_filename(
+                                                                                    report_name,
+                                                                                    "txt")
+            with open(report_filepath, "w", encoding="UTF-8") as file:
+                file.write(report)
+            if interactive:
                 return gr.update(value=message, visible=True)
+            else:
+                self.log(message)
 
-            except RuntimeError as error:
-                message = \
+        except Exception as error:
+            message = \
 f"""Error deduplicating frames:
 {error}"""
+            if interactive:
                 return gr.update(value=message, visible=True)
+            else:
+                raise ValueError(message)
 
     def create_autofill_report(self, input_path : str, output_path : str, threshold : int,
                     max_dupes : int, depth : int, message : str, auto_filled_files : list) -> str:

--- a/tabs/dedupe_frames_ui.py
+++ b/tabs/dedupe_frames_ui.py
@@ -64,14 +64,14 @@ class DedupeFrames(TabBase):
                 # repurpose max_dupes for delete to mean: skip delete on groups larger than this size
                 ignore_over_size = max_dupes
                 max_dupes = 0
-                message, _, _, deleted_files = DeduplicateFrames(None,
-                                                                input_path,
-                                                                output_path,
-                                                                threshold,
-                                                                max_dupes,
-                                                                None,
-                                                                self.log).invoke_delete(
-                                                                    suppress_output=True,
+                message, _, _, deleted_files, _ = DeduplicateFrames(None,
+                                                                    input_path,
+                                                                    output_path,
+                                                                    threshold,
+                                                                    max_dupes,
+                                                                    None,
+                                                                    self.log).invoke_delete(
+                                                                        suppress_output=True,
                                                             max_size_for_delete=ignore_over_size)
                 report = self.create_delete_report(input_path,
                                                      output_path,

--- a/tabs/resynthesize_video_ui.py
+++ b/tabs/resynthesize_video_ui.py
@@ -198,7 +198,7 @@ class ResynthesizeVideo(TabBase):
                 if interactive:
                     return format_markdown(message, "error")
                 else:
-                    raise ValueError(f"The output path {input_path} is not valid")
+                    raise ValueError(message)
             self.log(f"creating output path {output_path}")
             create_directory(output_path)
         else:

--- a/tabs/video_remixer_ui.py
+++ b/tabs/video_remixer_ui.py
@@ -841,71 +841,71 @@ class VideoRemixer(TabBase):
                                             select_none_button711 = gr.Button(
                                                 value="Select None", scale=0)
 
-                                with gr.Tab(SimpleIcons.CROSSMARK +
-                                            " Remove Remix Video Source Content"):
-                                    gr.Markdown(
-                                    "**_Clear space after final Remix Videos have been saved_**")
-                                    with gr.Row():
-                                        delete_kept_712 = gr.Checkbox(label="Remove Kept Scenes")
-                                        with gr.Column(variant="compact"):
-                                            gr.Markdown(
-                "Delete Kept Scene files used when compiling scenes after making scene choices.")
-                                    with gr.Row():
-                                        delete_resized_712 = gr.Checkbox(value=True,
-                                            label="Remove Resized Frames")
-                                        with gr.Column(variant="compact"):
-                                            gr.Markdown(
-    "Delete Resized frame files used as inputs for processing and creating remix video clips.")
-                                    with gr.Row():
-                                        delete_resynth_712 = gr.Checkbox(value=True,
-                                            label="Remove Resynthesized Frames")
-                                        with gr.Column(variant="compact"):
-                                            gr.Markdown(
-                                        "Delete Resynthesized frame files used as inputs " +\
-                                        "for processing and creating remix video clips.")
-                                    with gr.Row():
-                                        delete_inflated_712 = gr.Checkbox(value=True,
-                                            label="Remove Inflated Frames")
-                                        with gr.Column(variant="compact"):
-                                            gr.Markdown(
-    "Delete Inflated frame files used as inputs for processing and creating remix video clips.")
-                                    with gr.Row():
-                                        delete_upscaled_712 = gr.Checkbox(value=True,
-                                            label="Remove Upscaled Frames")
-                                        with gr.Column(variant="compact"):
-                                            gr.Markdown(
-    "Delete Upscaled frame files used as inputs for processing and creating remix video clips.")
-                                    with gr.Row():
-                                        delete_audio_712 = gr.Checkbox(label="Delete Audio Clips")
-                                        with gr.Column(variant="compact"):
-                                            gr.Markdown(
-                        "Delete Audio WAV/MP3 files used as inputs for creating remix video clips.")
-                                    with gr.Row():
-                                        delete_video_712 = gr.Checkbox(label="Delete Video Clips")
-                                        with gr.Column(variant="compact"):
-                                            gr.Markdown(
-                            "Delete Video MP4 files used as inputs for creating remix video clips.")
-                                    with gr.Row():
-                                        delete_clips_712 = gr.Checkbox(
-                                            label="Delete Remix Video Clips")
-                                        with gr.Column(variant="compact"):
-                                            gr.Markdown(
-        "Delete Video+Audio MP4 files used as inputs to concatentate into the final Remix Video.")
-                                    with gr.Row():
-                                        message_box712 = gr.Markdown(
+                                    with gr.Tab(SimpleIcons.CROSSMARK +
+                                                " Remove Remix Video Source Content"):
+                                        gr.Markdown(
+                                        "**_Clear space after final Remix Videos have been saved_**")
+                                        with gr.Row():
+                                            delete_kept_712 = gr.Checkbox(label="Remove Kept Scenes")
+                                            with gr.Column(variant="compact"):
+                                                gr.Markdown(
+                    "Delete Kept Scene files used when compiling scenes after making scene choices.")
+                                        with gr.Row():
+                                            delete_resized_712 = gr.Checkbox(value=True,
+                                                label="Remove Resized Frames")
+                                            with gr.Column(variant="compact"):
+                                                gr.Markdown(
+        "Delete Resized frame files used as inputs for processing and creating remix video clips.")
+                                        with gr.Row():
+                                            delete_resynth_712 = gr.Checkbox(value=True,
+                                                label="Remove Resynthesized Frames")
+                                            with gr.Column(variant="compact"):
+                                                gr.Markdown(
+                                            "Delete Resynthesized frame files used as inputs " +\
+                                            "for processing and creating remix video clips.")
+                                        with gr.Row():
+                                            delete_inflated_712 = gr.Checkbox(value=True,
+                                                label="Remove Inflated Frames")
+                                            with gr.Column(variant="compact"):
+                                                gr.Markdown(
+        "Delete Inflated frame files used as inputs for processing and creating remix video clips.")
+                                        with gr.Row():
+                                            delete_upscaled_712 = gr.Checkbox(value=True,
+                                                label="Remove Upscaled Frames")
+                                            with gr.Column(variant="compact"):
+                                                gr.Markdown(
+        "Delete Upscaled frame files used as inputs for processing and creating remix video clips.")
+                                        with gr.Row():
+                                            delete_audio_712 = gr.Checkbox(label="Delete Audio Clips")
+                                            with gr.Column(variant="compact"):
+                                                gr.Markdown(
+                            "Delete Audio WAV/MP3 files used as inputs for creating remix video clips.")
+                                        with gr.Row():
+                                            delete_video_712 = gr.Checkbox(label="Delete Video Clips")
+                                            with gr.Column(variant="compact"):
+                                                gr.Markdown(
+                                "Delete Video MP4 files used as inputs for creating remix video clips.")
+                                        with gr.Row():
+                                            delete_clips_712 = gr.Checkbox(
+                                                label="Delete Remix Video Clips")
+                                            with gr.Column(variant="compact"):
+                                                gr.Markdown(
+            "Delete Video+Audio MP4 files used as inputs to concatentate into the final Remix Video.")
+                                        with gr.Row():
+                                            message_box712 = gr.Markdown(
+                                                format_markdown(
+                            "Click Delete Selected Content to: Permanently Remove the selected content"))
+                                        gr.Markdown(
                                             format_markdown(
-                        "Click Delete Selected Content to: Permanently Remove the selected content"))
-                                    gr.Markdown(
-                                        format_markdown(
-                    "Progress can be tracked in the console", color="none", italic=True, bold=False))
-                                    with gr.Row():
-                                        delete_button712 = gr.Button(
-                                            value="Delete Selected Content " +\
-                                                SimpleIcons.SLOW_SYMBOL, variant="stop", scale=0)
-                                        select_all_button712 = gr.Button(
-                                            value="Select All", scale=0)
-                                        select_none_button712 = gr.Button(
-                                            value="Select None", scale=0)
+                        "Progress can be tracked in the console", color="none", italic=True, bold=False))
+                                        with gr.Row():
+                                            delete_button712 = gr.Button(
+                                                value="Delete Selected Content " +\
+                                                    SimpleIcons.SLOW_SYMBOL, variant="stop", scale=0)
+                                            select_all_button712 = gr.Button(
+                                                value="Select All", scale=0)
+                                            select_none_button712 = gr.Button(
+                                                value="Select None", scale=0)
 
                 with gr.Accordion(SimpleIcons.TIPS_SYMBOL + " Guide", open=False):
                     WebuiTips.video_remixer_extra.render()

--- a/tabs/video_remixer_ui.py
+++ b/tabs/video_remixer_ui.py
@@ -318,10 +318,9 @@ class VideoRemixer(TabBase):
                                     reset_scene_labels = gr.Button(value="Reset Scene Labels",
                                                                    size="sm", min_width=80)
                                 with gr.Row():
-                                    add_2x_slomo = gr.Button(value="Add 2X Audio Slo Mo", size="sm",
-                                                             min_width=80, elem_id="highlightbutton")
-                                    add_4x_slomo = gr.Button(value="Add 4X Audio Slo Mo", size="sm",
-                                                             min_width=80, elem_id="highlightbutton")
+                                    add_2x_slomo = gr.Button(value="+ 2X Slo Mo", size="sm", min_width=60, elem_id="highlightbutton")
+                                    add_4x_slomo = gr.Button(value="+ 4X Slo Mo", size="sm", min_width=60, elem_id="highlightbutton")
+                                    add_8x_slomo = gr.Button(value="+ 8X Slo Mo", size="sm", min_width=60, elem_id="highlightbutton")
                             with gr.Accordion(label="Danger Zone", open=False):
                                 with gr.Row():
                                     keep_all_button = gr.Button(value="Keep All Scenes",
@@ -1038,6 +1037,10 @@ class VideoRemixer(TabBase):
                                      scene_info, set_scene_label])
 
         add_4x_slomo.click(self.add_4x_slomo, inputs=scene_index,
+                            outputs=[scene_index, scene_name, scene_image, scene_state,
+                                     scene_info, set_scene_label])
+
+        add_8x_slomo.click(self.add_8x_slomo, inputs=scene_index,
                             outputs=[scene_index, scene_name, scene_image, scene_state,
                                      scene_info, set_scene_label])
 
@@ -1875,10 +1878,14 @@ class VideoRemixer(TabBase):
         self.state.save()
 
     def add_2x_slomo(self, scene_index):
-        self.add_slomo(scene_index, "I:4A")
+        self.add_slomo(scene_index, "I:2A")
         return self.scene_chooser_details(self.state.current_scene)
 
     def add_4x_slomo(self, scene_index):
+        self.add_slomo(scene_index, "I:4A")
+        return self.scene_chooser_details(self.state.current_scene)
+
+    def add_8x_slomo(self, scene_index):
         self.add_slomo(scene_index, "I:8A")
         return self.scene_chooser_details(self.state.current_scene)
 

--- a/tabs/video_remixer_ui.py
+++ b/tabs/video_remixer_ui.py
@@ -385,7 +385,7 @@ class VideoRemixer(TabBase):
                 with gr.Row():
                     inflate = gr.Checkbox(label="Inflate New Frames",value=True, scale=1)
                     inflate_by_option = gr.Radio(label="Inflate By", value="2X", scale=3,
-                                                choices=["2X", "4X", "8X"], info="Adds 1, 3 or 7 Between Frames")
+                                                choices=["2X", "4X", "8X", "16X"], info="Adds 1, 3, 7 or 15 Between Frames")
                     inflate_slow_option = gr.Radio(label="Slow Motion", value="No",
                                                    choices=["No", "Audio", "Silent"],
                                                    scale=3, info="Audio: Pitch and FPS adjusted, Silent: No FPS adjustment")

--- a/video_remixer.py
+++ b/video_remixer.py
@@ -1817,25 +1817,47 @@ f"Error in resize_scenes() handling processing hint {resize_hint} - skipping pro
                 num_splits = 0
                 disable_inflation = False
 
-                inflation_hint = self.get_hint(self.scene_labels.get(scene_name), "I")
-                if inflation_hint:
-                    if "1" in inflation_hint:
-                        num_splits = 0
-                        disable_inflation = True
-                    elif "2" in inflation_hint:
-                        num_splits = 1
-                    elif "4" in inflation_hint:
-                        num_splits = 2
-                    elif "8" in inflation_hint:
-                        num_splits = 3
-
-                if num_splits == 0 and self.inflate and not disable_inflation:
+                project_splits = 0
+                if self.inflate:
+                    if self.inflate_by_option == "1X":
+                        project_splits = 0
                     if self.inflate_by_option == "2X":
-                        num_splits = 1
+                        project_splits = 1
                     elif self.inflate_by_option == "4X":
-                        num_splits = 2
+                        project_splits = 2
                     elif self.inflate_by_option == "8X":
-                        num_splits = 3
+                        project_splits = 3
+                    elif self.inflate_by_option == "16X":
+                        project_splits = 4
+
+                # if it's for slow motion, the split should be relative to the
+                # project inflation rate
+
+                hinted_splits = 0
+                force_inflation, force_audio, force_inflate_by, force_silent =\
+                    self.compute_forced_inflation(scene_name)
+                if force_inflation:
+                    if force_inflate_by == "1X":
+                        disable_inflation = True
+                    elif force_inflate_by == "2X":
+                        hinted_splits = 1
+                    elif force_inflate_by == "4X":
+                        hinted_splits = 2
+                    elif force_inflate_by == "8X":
+                        hinted_splits = 3
+                    elif force_inflate_by == "16X":
+                        hinted_splits = 4
+
+                if hinted_splits:
+                    if force_audio or force_silent:
+                        # the figures for audio slow motion are relateive to the project split rate
+                        # splits are really exponents of 2^n
+                        num_splits = project_splits + hinted_splits
+                    else:
+                        # if not for slow motion, force an exact split
+                        num_splits = hinted_splits
+                else:
+                    num_splits = 0 if disable_inflation else project_splits
 
                 if num_splits:
                     # the scene needs inflating
@@ -2226,6 +2248,9 @@ f"Error in upscale_scenes() handling processing hint {upscale_hint} - skipping p
             elif "8" in inflation_hint:
                 force_inflation = True
                 force_inflate_by = "8X"
+            elif "16" in inflation_hint:
+                force_inflation = True
+                force_inflate_by = "16X"
 
             if "A" in inflation_hint:
                 force_audio = True
@@ -2287,8 +2312,14 @@ f"Error in upscale_scenes() handling processing hint {upscale_hint} - skipping p
                                       force_silent):
         audio_slow_motion = force_audio or (self.inflate and self.inflate_slow_option == "Audio")
         silent_slow_motion = force_silent or (self.inflate and self.inflate_slow_option == "Silent")
+
         project_inflation_rate = self.inflation_rate(self.inflate_by_option) if self.inflate else 1
         forced_inflation_rate = self.inflation_rate(force_inflate_by) if force_inflation else 1
+
+        # for slow motion hints, interpret the 'force_inflate_by' as relative to the project rate
+        if audio_slow_motion or silent_slow_motion:
+            forced_inflation_rate *= project_inflation_rate
+
         motion_factor = forced_inflation_rate / project_inflation_rate
         return motion_factor, audio_slow_motion, silent_slow_motion, project_inflation_rate, \
             forced_inflation_rate
@@ -2300,7 +2331,6 @@ f"Error in upscale_scenes() handling processing hint {upscale_hint} - skipping p
             self.compute_effective_slow_motion(force_inflation, force_audio, force_inflate_by,
                                                force_silent)
 
-        # audio_inflation = 1 #self.inflation_rate(self.inflate_by_option) if self.inflate else 1
         audio_motion_factor = motion_factor #/ audio_inflation
 
         if audio_slow_motion:
@@ -2322,6 +2352,8 @@ f"Error in upscale_scenes() handling processing hint {upscale_hint} - skipping p
             elif audio_motion_factor == 0.125:
                 output_options = '-filter:a "atempo=2.0,atempo=2.0,atempo=2.0" -c:v copy -shortest ' \
                     + custom_audio_options
+            else:
+                raise ValueError(f"audio_motion_factor {audio_motion_factor} is not supported")
         elif silent_slow_motion:
             # check for an existing audio sample rate, so the silent footage will blend properly
             # with non-silent footage, otherwise there may be an audio/video data length mismatch


### PR DESCRIPTION
Video Remixer
- add 16X inflation
- make processing hints for inflation slow motion relative to the project inflation rate
  - ex: `{I:2A}` now means inflate at twice the project rate and half the audio tempo
- fix issues disabling inflation via processing hint
  - ex: `{I:1A}` forces no inflation regardless of project inflation rate, with proper audio tempo handling
- fix stacked tabs under _Remove Selected Project Content_
- Added buttons to easily add 2x, 4x and 8x slow motion to a scene via the scene label

Deduplication
- make auto-fill work with jpg frames
- add interactive messaging and batch processing
