### PR TITLE
Video Remixer: various conveniences

### DIFF
--- a/guide/autofill_duplicates.md
+++ b/guide/autofill_duplicates.md
@@ -1,10 +1,6 @@
 **Auto-Fill Duplicate Frames** - Detect duplicate frames and fill with interpolated replacements
 
 ## How It Works
-1. Set _Input PNG Files Path_ to a path on this server for the PNG files being deduplicated
-1. Set _Output PNG Files Path_ to a path on this server to store the deduplicated PNG files
-    - Output PNG File Path can be left blank to use the default folder
-    - _Tip: The default folder is set by the_ `config.directories.output_deduplication` _setting_
 1. Set _Detect Threshold_ to specify the sensitivity to frame differences
     - A lower value finds fewer duplicates; a higher value finds more
     - This value requires experimentation. See _More Details_ below.
@@ -18,9 +14,16 @@
 1. Set _Search Precision_ to the depth of search needed for accuracy
     - High precision yields precise frame timing, but takes a long time
     - Less precision is faster, with possible imprecise frame timing
-1. Click _Deduplicate Frames_
-1. The _Details_ box shows the result of the operation, or any errors encountered
+1. Choose _Individual Path_ or _Batch Processing_
+    - If **Individual Path**
+        1. Set _Input PNG Files Path_ to a path on this server for the PNG files being deduplicated
+        1. Set _Output PNG Files Path_ to a path on this server to store the deduplicated PNG files
+    - If **Batch Processing**
+        1. Set _Input PNG Files Path_ to a directory on this servery containing the frame groups to be deduplicated
+        1. Set _Output PNG Files Path_ to a directory on this server for the deduplicated frame groups
+1. Click _Deduplicate Frames_ or _Deduplicate Batch_
 1. On completion, a report .txt file is written to the output path with details of the auto-filling
+- Progress can be tracked in the console
 
 ## Important
 - This process could be slow, perhaps many hours long!

--- a/guide/video_remixer_choose.md
+++ b/guide/video_remixer_choose.md
@@ -34,29 +34,30 @@ _Choose Scene Range_
 
 ## Properties Accordion
 _Scene Label_
-- Enter a scene label and click _Set_ to save it with the scene
+- Enter a scene label and press _Enter_ or click _Set_ to save it with the scene
 - _Tip:_ Use the < and > buttons to navigate to labeled scenes
 
 ### About Scene Labels
 - Labels can be used to add a scene title
   - The entered scene title will appear in the video when using the _Labeled Remix_ feature
-  - The entered title will also be used as the based for the scene remix clip, making it easier to reuse individual clips
+  - The entered title will also be used as the basis for the scene remix clip, making it easier to find and reuse individual scene clips
 - Labels can be used to rearrange scene order in the remix video
   - When a label starts with a value inside parentheses, the value will be used to arrange the clips in sorted order
-  - _Tip:_ use the _Auto Label Scenes_ button to automatically add a sorting mark to each scene
-- Labels can be used to mark a scene for 2X or 4X audio slow motion
-  - **NOTE** the main video must use 2X Inflation for this feature to work
-  - Use the _Add 2X Audio Slo Mo_ or _Add 4X Audio Slo Mo_ buttons to add a _processing hint_ to the scene label
+  - _Tip:_ use the _+ Sort Keys_ button to automatically add a sorting mark to each scene
+- Labels can be used to mark a scene for 2X, 4X or 8X audio slow motion
+  - Use the _+ 2X Slo Mo_, _+ 4X Slo Mo_ or _+ 8X Slo Mo_ buttons to add a _processing hint_ to the scene label that adds audio pitch-adjusted slow motion
 
-_Auto Label Scenes_
+_+ Sort Keys_
 - Automatically adds a sorting mark to each scene
 
-_Reset Scene Labels_
+_+ Title_
+- Automatically adds a default title to each scene
+
+_Reset_
 - Clears the contents of all scene labels
 
-_Add 2X Audio Slo Mo_ and _Add 4X Audio Slo Mo_
-- Add a _processing hint_ to the scene label to enabled 2X or 4X audio slow motion processing
-- **NOTE** the main video must use 2X Inflation for this feature to work
+_+ 2X Slo Mo_, _+ 4X Slo Mo_ and _+ 8X Slo Mo_
+- Add a _processing hint_ to the scene label to enable 2X, 4X or 8X audio slow motion with pitch adjustment processing
 
 The _Keep All Scenes_ and _Drop All Scenes_ buttons (inside the _Danger Zone_ accordion)
 - **Destructively** _Keep_ or _Drop_ all scenes (there is no undo)
@@ -68,7 +69,7 @@ The _Split Scene_ and _Drop Processed Scene_ buttons (inside the _Danger Zone_ a
 ## Danger Zone Accordion
 
 _Keep All Scenes_ and _Drop All Scenes_
-- Sets all sets to _Keep_ or _Drop_
+- Sets **_all_** scenes to _Keep_ or _Drop_
 
 _Invert Scene Choices_
 - Changes all scene keep/drop statues to the opposite state
@@ -78,6 +79,17 @@ _Invert Scene Choices_
 
 _Drop Processed Scene_
 - Opens the _Drop Processed Scenes_ tab to drop a scene, including its processed content, to save the remix video without that the dropped scene, avoiding reprocessing the whole video
+
+_Mark Scene_
+- Remembers the current scene ID to make it easier to use features that require entering a scene ID range
+- This can be used with the _Merge Scene Range_ and _Choose Scene Range_ features
+  1. Go to the first scene of the range and click _Mark Scene_
+  1. Go to the last scene of the range, then click either of these shortcut buttons
+    - Merge Scenes
+    - Choose Scene Range
+
+_Merge Scenes_
+- Shortcut that takes you to the Remix Extra _Merge Scenes_ tab
 
 ## Important
 - `ffmpeg.exe` must be available on the system path

--- a/guide/video_remixer_choose.md
+++ b/guide/video_remixer_choose.md
@@ -44,8 +44,10 @@ _Scene Label_
 - Labels can be used to rearrange scene order in the remix video
   - When a label starts with a value inside parentheses, the value will be used to arrange the clips in sorted order
   - _Tip:_ use the _+ Sort Keys_ button to automatically add a sorting mark to each scene
-- Labels can be used to mark a scene for 2X, 4X or 8X audio slow motion
-  - Use the _+ 2X Slo Mo_, _+ 4X Slo Mo_ or _+ 8X Slo Mo_ buttons to add a _processing hint_ to the scene label that adds audio pitch-adjusted slow motion
+- Labels can be used to add _Processing Hints_
+  - Use the _+ 2X Slo Mo_, _+ 4X Slo Mo_ or _+ 8X Slo Mo_ buttons to add a _Processing Hint_ to the scene label that adds audio pitch-adjusted slow motion
+
+_Tip: See below for more details on_ Processing Hints
 
 _+ Sort Keys_
 - Automatically adds a sorting mark to each scene
@@ -90,6 +92,38 @@ _Mark Scene_
 
 _Merge Scenes_
 - Shortcut that takes you to the Remix Extra _Merge Scenes_ tab
+
+## Processing Hints
+
+Resize:
+- `{R:x/y}` zoom into quadrant `x` of `y` sized grid
+  - Example:
+  - `{R:1/4}` zoom into upper left quadrant of 2x2 grid
+  - `{R:5/9}` zoom into center quadrant of 3x3 grid (like a telephone keypad)
+- `{R:z%}` zoom in the center at `z` percent
+  - Example:
+  - `{R:200%}` zoom in at 200%
+
+Resynthesize:
+- `{Y:type}` enable resynthesis of `type`
+  - Types:
+  - `C` clean (first past only of two pass resynth)
+  - `S` scrub (two pass resynth)
+  - `R` replace (one pass resynth)
+  - `N` no resynthesis
+
+Inflation:
+- `{I:nt}` inflate amount `n` with type `y`
+  - Amounts: `1`, `2`, `4`, `8`, `16`
+    - `1` means don't inflate
+  - Types:
+  - `A` slow motion with audio pitch adjust
+  - `S` slow motion with silent audio
+  - `N` no slow motion (can be omitted)
+
+Upscale:
+- `{U:_}` upscale at 1X for clean-up
+  - `_` reserved for future use
 
 ## Important
 - `ffmpeg.exe` must be available on the system path

--- a/guide/video_remixer_processing.md
+++ b/guide/video_remixer_processing.md
@@ -14,22 +14,27 @@
         - Clean frames by completely replacing with interpolations from adjacent frames
         - Deepest cleaning method, but does not handle fast-moving content well
 1. Check _Inflate New Frames_ to insert AI-interpolated frames between all real frames
-    - Choose whether to inflate by _2X_, _4X_ or _8X_
-        - The choices will insert 1, 3 or 7 new frames between existing frames
+    - Choose whether to inflate by _2X_, _4X_, _8X_ or _16X_
+        - The choices will insert 1, 3, 7 or 15 new frames between existing frames
     - Choose whether to produce a slow-motion video
         - **_No_** Create a real-time video
             - Adjust the output FPS to compensate for the inserted frames
         - **_Audio_** Create a slow-motion video with audio
             - Adjust the output FPS and audio pitch to compensate for the new frames
-            - **_Tip:_** See below for more information about slow-motion videos
         - **_Silent_** Create a slow-motion video without audio
-            - Keep the original FPS to reveal the most motion slowdown
+            - Use silence instead of pitch-compensated audio
 1. Check _Upscale Frames_ to use AI to clean and enlarge frames
-    - Choose whether to upscale by _1X_, _2X_ or _4X_
+    - Choose whether to upscale by _1X_, _2X_, _3X_ or _4X_
     - Upscaling at 1X will cleanse the frames without enlarging
-    - Upscaling at 2X - 4X will cleanse the frames and double or quadruple the frame size
+    - Upscaling at 2X - 4X will cleanse the frames and double, triple or quadruple the frame size
 1. Click _Process Remix_ to kick off the processing
 - Progress can be tracked in the console
+
+## Advanced Options Accordion
+- Check _Automatically save default MP4 video_ to:
+  - Save the Remix Video using default MP4 settings as seen on the _Save MP4 Remix_ tab
+- Check _Delete processed content after saving_ to:
+  - Automatically purged all generated project content after saving the Remix Video
 
 ## Note
 - Content may be _purged_ (soft-deleted) when clicking _Process Remix_
@@ -41,26 +46,3 @@
 - The browser window does NOT need to be left open
     - The project can be reopened later to resume where you left off
 - `ffmpeg.exe` must be available on the system path
-
-## More About Slow-Motion Videos
-
-### _Real-Time_ and _Slow-Motion_ Video Compatibility
-If creating slow-motion videos to combine with real-time videos, note the following chart showing the effect of Inflation options on Remix Video FPS:
-
-| Inflate By | Slo Mo 'NO' | Slo Mo 'AUDIO' | Slo Mo 'SILENT'
-| :-: | :-: | :-: | :-: |
-| 2X | FPS x 2 | FPS x 1, Audio Pitch x .50 | FPS x 1 |
-| 4X | FPS x 4 | FPS x 2, Audio Pitch x .50 | FPS x 1 |
-| 8X | FPS x 8 | FPS x 2, Audio Pitch x .25 | FPS x 1 |
-
-### Examples
-
-_Tip:_ Use the _Video Assembler_ tab under _Tools_, _File Conversion_ to assemble video clips sharing like characteristics
-
-- Make a video combining real-time footage and 8X silent slow motion
-    - Create the real-time remix video **_without_** using Inflation
-    - Create the slow-motion remix video with the "8X" and "Silent" Inflation options
-
-- Make a smoothed video combining real-time footage with 2X and 4X slow motion
-    - Create the real-time remix video with the "2X" and "No" Inflation options
-    - Create the slow-motion remix video with the "2X" and "4X", and "Audio" Inflation options

--- a/guide/video_remixer_settings.md
+++ b/guide/video_remixer_settings.md
@@ -50,8 +50,10 @@
 
 ## More Options Accordion
 1. Click _More Options_ to access additional project setup options
-    - Click _Reuse Last-Used Settings_, to load the settings from the last created project
+    - Click _Reuse Last-Used Settings_ to load the settings from the last created project
         - Useful when processing a series of similar content such as TV programs
+    - Click _Use Memorized Setting_ to load the settings that were previously _remembered_
+    - Click _Remember These Settings_ to save the settings for later use
     - Set _Crop X Offset_ and _Crop Y Offset_, useful for:
         - Removing letter/pillar boxes
         - Fixing incorrectly centered content

--- a/tabs/dedupe_autofill_ui.py
+++ b/tabs/dedupe_autofill_ui.py
@@ -71,7 +71,7 @@ class AutofillFrames(TabBase):
                             placeholder="Path on this server for the deduplicated PNG files")
                     message_box_batch = gr.Markdown(format_markdown(self.DEFAULT_MESSAGE_BATCH))
                     gr.Markdown("*Progress can be tracked in the console*")
-                    dedupe_batch = gr.Button("Deduplicate Frames " + SimpleIcons.SLOW_SYMBOL,
+                    dedupe_batch = gr.Button("Deduplicate Batch " + SimpleIcons.SLOW_SYMBOL,
                                              variant="primary")
             with gr.Accordion(SimpleIcons.TIPS_SYMBOL + " Guide", open=False):
                 WebuiTips.autofill_duplicates.render()

--- a/tabs/video_remixer_ui.py
+++ b/tabs/video_remixer_ui.py
@@ -2163,7 +2163,8 @@ class VideoRemixer(TabBase):
             global_options = self.config.ffmpeg_settings["global_options"]
             remixer_settings = self.config.remixer_settings
             kept_scenes = self.state.prepare_save_remix(self.log, global_options,
-                                                        remixer_settings, output_filepath)
+                                                        remixer_settings, output_filepath,
+                                                        invalidate_video_clips=False)
             self.state.save_custom_remix(self.log, output_filepath, global_options, kept_scenes,
                                          custom_video_options, custom_audio_options)
             return format_markdown(f"Remixed custom video {output_filepath} is complete.",

--- a/video_remixer.py
+++ b/video_remixer.py
@@ -2490,7 +2490,6 @@ f"Error in upscale_scenes() handling processing hint {upscale_hint} - skipping p
                             replace("%", "\%")
 
                         box_part = f":box=1:boxcolor={box_color}:boxborderw={border_size}" if draw_box else ""
-                        # label_part = f"text='{label}':x={box_x}:y={box_y}:fontsize={font_size}:fontcolor={font_color}:fontfile='{font_file}':expansion=none:{box_part}"
                         label_part = f"text='{label}':x={box_x}:y={box_y}:fontsize={font_size}:fontcolor={font_color}:fontfile='{font_file}':expansion=none{box_part}"
                         shadow_part = f"text='{label}':x={shadow_x}:y={shadow_y}:fontsize={font_size}:fontcolor={shadow_color}:fontfile='{font_file}'" if draw_shadow else ""
                         draw_text = f"{shadow_part},drawtext={label_part}" if draw_shadow else label_part

--- a/video_remixer.py
+++ b/video_remixer.py
@@ -2268,6 +2268,7 @@ f"Error in upscale_scenes() handling processing hint {upscale_hint} - skipping p
                 force_audio = True
             elif "S" in inflation_hint:
                 force_silent = True
+            # else "N" for no slow motion
         return force_inflation, force_audio, force_inflate_by, force_silent
 
     def compute_scene_fps(self, scene_name):

--- a/video_remixer.py
+++ b/video_remixer.py
@@ -696,6 +696,8 @@ class VideoRemixerState():
     def split_label(self, label):
         """Splits a label such as '(01){I:2S} My Title (part1){b}' into
         sort: '01', hint: 'I:2S' label: 'My Title (part1){b}' parts """
+        if not label:
+            return None, None, None
         try:
             matches = re.search(self.SPLIT_LABELS, label)
             groups = matches.groups()

--- a/webui_utils/file_utils.py
+++ b/webui_utils/file_utils.py
@@ -362,10 +362,10 @@ def simple_sanitize_filename(filename, default_filename=None):
        Uses the default_filename if a safe filename cannot be produced
        Raises ValueError if default_filename is not provided
     """
-    # Keep only alphanumeric chars and spaces, and convert all space sequences into underscores
+    # Keep only alphanumeric chars, hyphens, and spaces, and convert all space sequences into underscores
     safe_name = re.sub(r' +',
                        '_',
-                       re.sub(r'[^A-Za-z0-9 ]+',
+                       re.sub(r'[^-A-Za-z0-9 ]+',
                               '',
                               filename)) or default_filename
     if safe_name:


### PR DESCRIPTION
- Add button in _Properties_ accordion of _Scene Chooser_ to add default title to scenes
- Fix labels to properly escape common punctuation chars
- Change _Auto Label Scenes_ to _+Sort Keys_ and make it replace existing keys to prevent duplicates
- Updates to various guide pages
- Add buttons next to _Reuse Last-Used Settings_ to easily store and recall project settings
- The _Custom Remix_ tab will reuse video clips if present (other tabs already recreate them)
  - This is helpful for experimenting with audio settings
