### PR TITLE
Video Remixer: Add Animated Zoom

### DIFF
--- a/resequence_files.py
+++ b/resequence_files.py
@@ -181,11 +181,9 @@ class ResequenceFiles:
                 if self.rename:
                     new_filepath = os.path.join(self.input_path, new_filename)
                     os.replace(old_filepath, new_filepath)
-                    self.log(f"File {file} renamed to {new_filepath}")
                 else:
                     new_filepath = os.path.join(self.output_path, new_filename)
                     shutil.copy(old_filepath, new_filepath)
-                    self.log(f"File {file} copied to {new_filepath}")
 
                 running_index += self.index_step
                 Mtqdm().update_bar(bar)

--- a/resize_frames.py
+++ b/resize_frames.py
@@ -119,15 +119,11 @@ class ResizeFrames:
                 image = cv2.imread(file)
 
                 if params_fn:
-                    try:
-                        self.log(f"calling 'param_fn' to get parameters")
-                        scale_width, \
-                        scale_height, \
-                        crop_offset_x, \
-                        crop_offset_y = params_fn(index, params_context)
-                    except Exception as error:
-                        print(error)
-                        1/0
+                    self.log(f"calling 'param_fn' to get parameters")
+                    scale_width, \
+                    scale_height, \
+                    crop_offset_x, \
+                    crop_offset_y = params_fn(index, params_context)
                 else:
                     scale_width = self.scale_width
                     scale_height = self.scale_height

--- a/tabs/video_remixer_ui.py
+++ b/tabs/video_remixer_ui.py
@@ -2061,6 +2061,11 @@ class VideoRemixer(TabBase):
         self.log("purging now-stale remix content")
         self.state.clean_remix_content(purge_from="audio_clips")
 
+        # TODO reconcile with the line above
+        # Compiling scenes implies a last state before processing,
+        # and the user may expect that all content will be processed
+        self.state.processed_content_invalid = True
+
         # user will expect to return to the processing tab on reopening
         self.log("saving project after compiling scenes")
         self.save_progress("process")

--- a/video_remixer.py
+++ b/video_remixer.py
@@ -1233,7 +1233,8 @@ class VideoRemixerState():
         return self.resize or self.hint_present("R")
 
     def resize_needed(self):
-        return self.resize_chosen() and not self.processed_content_complete(self.RESIZE_STEP)
+        return (self.resize and not self.processed_content_complete(self.RESIZE_STEP)) \
+            or self.resize_chosen()
 
     def resynthesize_chosen(self):
         return self.resynthesize or self.hint_present("Y")
@@ -1682,7 +1683,7 @@ class VideoRemixerState():
                 resize_hint = self.get_hint(self.scene_labels.get(scene_name), "R")
                 if resize_hint:
                     main_resize_w, main_resize_h, main_crop_w, main_crop_h, main_offset_x, \
-                        main_offset_y = self.setup_resize_hint(content_width, content_width)
+                        main_offset_y = self.setup_resize_hint(content_width, content_height)
 
                     try:
                         if "/" in resize_hint and len(resize_hint) >= 3:


### PR DESCRIPTION
Add animated zooming/panning processing hints:

Regular Zoom
- By Percent: `{R:300%}` (zoom to the center at 300%)
- By Grid `{R:5/9}` (zoom to the middle grid of a 3x3 grid, effectively also a zoom to the center at 300%)
- Combined: `{R:3/4@200%}` (zoom to the lower left of a 2x2 grid at 200%)

Animated Zoom
- Use a `-` between two zoom values
- Example: Zoom in from 100% to 200%: `{R:100%-200%}`
- Example: Pan from the upper left to the lower right in a 3x3 grid: `{R:1/9-9/9}`
- Example: Go from 100% zoom to the rightmost grid at 400% `{R:100%-6/9@400%}`
