### PR TITLE
Video Remixer: Fixed issues with Zoom processing hint

### DIFF
--- a/resize_frames.py
+++ b/resize_frames.py
@@ -119,7 +119,6 @@ class ResizeFrames:
                 image = cv2.imread(file)
 
                 if params_fn:
-                    self.log(f"calling 'param_fn' to get parameters")
                     scale_width, \
                     scale_height, \
                     crop_offset_x, \
@@ -151,7 +150,6 @@ class ResizeFrames:
                     max_x = int(min_x + crop_width)
                     max_y = int(min_y + crop_height)
 
-                    self.log(f"cropping {file} with [{min_y}:{max_y}, {min_x}:{max_x}]")
                     image = image[min_y:max_y, min_x:max_x]
 
                 _, filename, ext = split_filepath(file)

--- a/slice_video.py
+++ b/slice_video.py
@@ -197,7 +197,6 @@ class SliceVideo:
             self.log(f"Creating output path {self.output_path}")
             create_directory(self.output_path)
 
-        self.log("using slice_video (may cause long delay while processing request)")
         pbar_desc = f"Slice {self.type}"
         errors = []
         with Mtqdm().open_bar(total=len(group_names), desc=pbar_desc) as bar:
@@ -216,7 +215,6 @@ class SliceVideo:
             self.log(f"Creating output path {self.output_path}")
             create_directory(self.output_path)
 
-        self.log("using slice_video (may cause long delay while processing request)")
         pbar_desc = f"Slice {self.type}"
         errors = []
         with Mtqdm().open_bar(total=1, desc=pbar_desc) as bar:

--- a/video_remixer.py
+++ b/video_remixer.py
@@ -1815,27 +1815,49 @@ class VideoRemixerState():
         return resize_w, resize_h, crop_offset_x, crop_offset_y
 
     def compute_combined_zoom(self, quadrant, quadrants, zoom_percent, main_resize_w, main_resize_h, main_offset_x, main_offset_y, main_crop_w, main_crop_h):
-        percent_resize_w, percent_resize_h, _, _ = self.compute_percent_zoom(zoom_percent,
+        percent_resize_w, percent_resize_h, percent_offset_x, percent_offset_y = self.compute_percent_zoom(zoom_percent,
+                                                            main_resize_w, main_resize_h,
+                                                            main_offset_x, main_offset_y,
+                                                            main_crop_w, main_crop_h)
+        # the offsets are based on the center of the screen not the quadrant
+
+        quadrant_resize_w, quadrant_resize_h, quadrant_offset_x, quadrant_offset_y = self.compute_quadrant_zoom(quadrant, quadrants,
                                                             main_resize_w, main_resize_h,
                                                             main_offset_x, main_offset_y,
                                                             main_crop_w, main_crop_h)
 
-        quadrant_resize_w, _, quadrant_offset_x, quadrant_offset_y = self.compute_quadrant_zoom(quadrant, quadrants,
-                                                            main_resize_w, main_resize_h,
-                                                            main_offset_x, main_offset_y,
-                                                            main_crop_w, main_crop_h)
+        # quadrant_zoom_percent = (main_resize_w / quadrant_resize_w) * 100.0
 
+        # percent_resize_w2, percent_resize_h2, percent_offset_x2, percent_offset_y2 = self.compute_percent_zoom(quadrant_zoom_percent,
+        #                                                     main_resize_w, main_resize_h,
+        #                                                     main_offset_x, main_offset_y,
+        #                                                     main_crop_w, main_crop_h)
+
+        # diff_w = percent_offset_x - percent_offset_x2
+        # diff_h = percent_offset_y - percent_offset_y2
+
+        # return quadrant_resize_w, quadrant_resize_h, quadrant_offset_x - diff_w, quadrant_offset_y - diff_h
+
+        # reality check, should just be the quadrant zoom - does
+        # return quadrant_resize_w, quadrant_resize_h, quadrant_offset_x, quadrant_offset_y
+
+        # seems to work the same as the below
+        # scale = percent_resize_w / quadrant_resize_w
+        # scaled_offset_x = ((quadrant_offset_x + (main_crop_w / 2)) * scale) - (main_crop_w / 2)
+        # scaled_offset_y = ((quadrant_offset_y + (main_crop_h / 2)) * scale) - (main_crop_h / 2)
+        # return percent_resize_w, percent_resize_h, scaled_offset_x, scaled_offset_y
+
+        # close but center point shifts
         scale = percent_resize_w / quadrant_resize_w
         scaled_offset_x = quadrant_offset_x * scale
         scaled_offset_y = quadrant_offset_y * scale
-
-        # both return the upper left corner of a main_crop-sized rectangle in their resize domain
-        # adding 1/2 the main_crop size will give the centerpoint in that domain
-        # scaling by the difference in domain size will make the rectangles compatible
-        # want the centerpoint of the quadrant resize to dominate
-        # once scaled by the percent resize size, the quadrant offset will work without needing to compute centerpoints
-
         return percent_resize_w, percent_resize_h, scaled_offset_x, scaled_offset_y
+
+        # definitely not right
+        # scale = quadrant_resize_w / percent_resize_w
+        # scaled_offset_x = quadrant_offset_x * scale
+        # scaled_offset_y = quadrant_offset_y * scale
+        # return percent_resize_w, percent_resize_h, scaled_offset_x, scaled_offset_y
 
     def compute_animated_zoom(self, num_frames, from_type, from_param1, from_param2, from_param3,
                                     to_type, to_param1, to_param2, to_param3,

--- a/video_remixer.py
+++ b/video_remixer.py
@@ -1655,8 +1655,6 @@ class VideoRemixerState():
             else:
                 quadrant, quadrants = 1, 1
 
-            print(quadrant, quadrants)
-
             return quadrant, quadrants
         else:
             return None, None
@@ -1845,6 +1843,7 @@ class VideoRemixerState():
                                                             main_crop_w, main_crop_h)
 
         # scale the quadrant center point to the percent resize
+        # this seems to work on the left and middle but not on the right
         scale = percent_resize_w / quadrant_resize_w
         center_x = quadrant_center_x * scale
         center_y = quadrant_center_y * scale
@@ -2045,6 +2044,7 @@ class VideoRemixerState():
                                                     crop_type="crop")
                                     resize_handled = True
                     except Exception as error:
+                        # TODO
                         print(error)
                         raise
                         log_fn(

--- a/video_remixer.py
+++ b/video_remixer.py
@@ -1845,6 +1845,9 @@ class VideoRemixerState():
         diff_crop_offset_x = to_crop_offset_x - from_crop_offset_x
         diff_crop_offset_y = to_crop_offset_y - from_crop_offset_y
 
+        # ensure the final transition occurs
+        num_frames -= 1
+
         step_resize_w = diff_resize_w / num_frames
         step_resize_h = diff_resize_h / num_frames
         step_crop_offset_x = diff_crop_offset_x / num_frames

--- a/video_remixer.py
+++ b/video_remixer.py
@@ -1756,9 +1756,15 @@ class VideoRemixerState():
                 grid_y = int(parts[1])
                 magnitude_x = grid_x
                 magnitude_y = grid_y
-                magnitude = max(magnitude_x, magnitude_y)
-                row = int(quadrant / magnitude)
-                column = quadrant % magnitude
+
+                if magnitude_x >= magnitude_y:
+                    magnitude = magnitude_x
+                    row = int(quadrant / magnitude_x)
+                    column = quadrant % magnitude_x
+                else:
+                    magnitude = magnitude_y
+                    row = int(quadrant / magnitude_x)
+                    column = quadrant % magnitude_x
             else:
                 magnitude = 1
                 magnitude_x = magnitude

--- a/video_remixer.py
+++ b/video_remixer.py
@@ -1848,6 +1848,15 @@ class VideoRemixerState():
         center_x = quadrant_center_x * scale
         center_y = quadrant_center_y * scale
 
+        crop_offset_x = center_x - (main_crop_w / 2.0)
+        crop_offset_y = center_y - (main_crop_h / 2.0)
+        if crop_offset_x < 0 or crop_offset_x + main_crop_w > percent_resize_w \
+            or crop_offset_y < 0 or crop_offset_y + main_crop_h > percent_resize_h:
+            # if out of bounds, resort to a quadrant zoom
+            resize_w, resize_h, center_x, center_y = \
+                self.compute_quadrant_zoom(quadrant, quadrants, main_resize_w, main_resize_h, main_offset_x, main_offset_y, main_crop_w, main_crop_h)
+            return resize_w, resize_h, center_x, center_y
+
         return percent_resize_w, percent_resize_h, center_x, center_y
 
     def compute_animated_zoom(self, num_frames, from_type, from_param1, from_param2, from_param3,
@@ -1975,9 +1984,10 @@ class VideoRemixerState():
                                                                main_offset_x, main_offset_y,
                                                                main_crop_w, main_crop_h)
 
-                                scale_type = remixer_settings["scale_type_up"]
                                 crop_offset_x = center_x - (main_crop_w / 2.0)
                                 crop_offset_y = center_y - (main_crop_h / 2.0)
+
+                                scale_type = remixer_settings["scale_type_up"]
                                 self.resize_scene(log_fn,
                                                 scene_input_path,
                                                 scene_output_path,


### PR DESCRIPTION
- Fix various rectangular calculations to ensure custom resizing, and animated zooming & panning, work between arbitrary frame locations, zoom magnifications, and methods of specifying location & zoom
- Can specify a location and magnification these ways
- `%` such as `{R:125%}`, where `125` sets a magnification of 1.25 at the frame center
- `X/Y` such as `{R:5/9}`, where `9` means a 3x3 grid, `5` means the numbered square within the grid
  - the center of the grid specifies the zoom anchor point
  - the 3x3 grid means a magnification of 300% 
- `X/NxM` such as `{R:2/3x2}`, where `3x2` means a 3x2 grid, `2` means the numbered square within the grid
  - the larger of the two grid dimensions specifies the magnification
- `X/Y@Z%` such as `{R:12/25@400%}` where `12/25` specifies as above, and `400%` overrides the magnification implied by the grid layout
  - If a zoom percentage is specified that goes outside the bounds of the frame, a fitting algorithm will attempt to find a best fit zoom percentage (recorded in the application log)
- Can specify an animated zoom/pan by using a `-` between two zoom/panning specifications, such as:
  - `{R:100%-6/9}`

 **The _Guide_ accordion on the _Scene Chooser_ tab has more details about Processing Hints**
