### PR TITLE
Video Remixer: Enhance Zoom Processing Hint

### DIFF
--- a/video_remixer_processor.py
+++ b/video_remixer_processor.py
@@ -41,6 +41,11 @@ class VideoRemixerProcessor():
     ANIMATED_ZOOM_HINT = "-"
     ANIMATION_TIME_HINT = "#"
     ANIMATION_SCHEDULE_HINT = "$"
+    QUADRATRIC_SCHEDULE = "Q"
+    BEZIER_SCHEDULE = "B"
+    PARAMETRIC_SCHEDULE = "P"
+    LINEAR_SCHEDULE = "L"
+    LENS_SCHEDULE = "Z"
     QUADRANT_ZOOM_MIN_LEN = 3 # 1/3
     PERCENT_ZOOM_MIN_LEN = 4  # 123%
     COMBINED_ZOOM_MIN_LEN = 8 # 1/1@100%
@@ -50,7 +55,6 @@ class VideoRemixerProcessor():
     TEMP_UPSCALE_PATH = "upscaled_frames"
     DEFAULT_DOWNSCALE_TYPE = "area"
     DEFAULT_ZOOM = "100%"
-
     DEFAULT_ANIMATION_SCHEDULE = "L" # linear
     DEFAULT_ANIMATION_TIME = 0 # whole scene
 
@@ -858,7 +862,7 @@ f"Error in resize_scenes() handling processing hint {resize_hint} - skipping pro
                                     main_crop_w, main_crop_h):
 
         # animation time override
-        if time > 0 and time < num_frames:
+        if time > 0 and time <= num_frames:
             num_frames = time
 
         from_resize_w, from_resize_h, from_center_x, from_center_y = \
@@ -906,17 +910,20 @@ f"Error in resize_scenes() handling processing hint {resize_hint} - skipping pro
     # https://stackoverflow.com/questions/13462001/ease-in-and-ease-out-animation-formula
     def _apply_animation_schedule(self, schedule, num_frames, frame):
         t = float(frame) / float(num_frames)
-        if schedule == "Q":
+        if schedule == self.QUADRATRIC_SCHEDULE:
             if t <= 0.5:
                 f = 2.0 * t * t
             else:
                 t -= 0.5
                 f = 2.0 * t * (1.0 - t) + 0.5
-        elif schedule == "B":
+        elif schedule == self.BEZIER_SCHEDULE:
             f = t * t * (3.0 - 2.0 * t)
-        elif schedule == "P":
+        elif schedule == self.PARAMETRIC_SCHEDULE:
             f = (t * t) / (2.0 * ((t * t) - t) + 1.0)
-        else:
+        elif schedule == self.LENS_SCHEDULE:
+            f = t + (1.03 ** t) # self.LENS_FACTOR
+            f = min(1.0, f)
+        else: # Linear
             f = t
         return int(f * num_frames)
 

--- a/video_remixer_processor.py
+++ b/video_remixer_processor.py
@@ -612,13 +612,13 @@ f"Error in resize_scenes() handling processing hint {resize_hint} - skipping pro
                 remainder = None
                 if self.ANIMATION_TIME_HINT in view_to:
                     split_pos = view_to.index(self.ANIMATION_TIME_HINT)
+                    remainder = view_to[split_pos:]
                     view_to = view_to[:split_pos]
                     # may include schedule part, which can come after time part
-                    remainder = view_to[split_pos:]
                 elif self.ANIMATION_SCHEDULE_HINT in view_to:
                     split_pos = view_to.index(self.ANIMATION_SCHEDULE_HINT)
-                    view_to = view_to[:split_pos]
                     remainder = view_to[split_pos:]
+                    view_to = view_to[:split_pos]
 
                 if not hint_from or not view_to:
                     if not hint_from and not view_to:
@@ -644,7 +644,7 @@ f"Error in resize_scenes() handling processing hint {resize_hint} - skipping pro
                 if view_to:
                     self.saved_zoom = view_to
 
-                return f"{hint_from}-{hint_to}{remainder}"
+                return f"{hint_from}-{view_to}{remainder}"
         return hint
 
     def get_animated_zoom(self, hint):

--- a/video_remixer_processor.py
+++ b/video_remixer_processor.py
@@ -613,7 +613,7 @@ f"Error in resize_scenes() handling processing hint {resize_hint} - skipping pro
 
                 # if the hint_to part includes time or schedule info, remove it to get only the view
                 view_to = hint_to
-                remainder = None
+                remainder = ""
                 if self.ANIMATION_TIME_HINT in view_to:
                     split_pos = view_to.index(self.ANIMATION_TIME_HINT)
                     remainder = view_to[split_pos:]


### PR DESCRIPTION
## Added _Implied Zoom_

While using _Resize_ Processing Hints to animate switching views, It's cumbersome having to specify the _from_ and _to_ parts each time
- Save the last _to_ view that was animated to
- It is reset to the default `100%` before processing
- When animating to a zoom, save that _to_ view as the new _saved_ to
- In an animated zoom processing hint, the _from_ and or _to_ can be left out, with the missing part filled in with the saved _to_
- If both parts are missing, it means: animate from the last _saved to_ to a default of _100%_ (reset the view)
    - ex: `{R:-}`
- When a scene does not specify a Resize Processing Hint, and animation has been used to animate to a non-default view, the scene is automatically set to the last saved view to maintain continuity across scenes

## Added _Animation Timing_

When achieving a zoom of a particular length, it's cumbersome to use the _Split Scenes_ feature to do so
- After the _from_ and _to_ parts of the animation zoom hint, an optional timing can be added using the `#` character and a number of frames
  - Ex: `{R:100%-200%#10}` - zoom from 100% to 200% in 10 frames

## Added _Ease In/Ease Out_

When using the zoom feature, the _linear_ nature of the zoom animation schedule is weary and robotic, due to the gradual speed change
- Added _Quadratic_ `Q`, _Bezier_ `B` and _Parametric_ `P` Ease In/Out per this article:
  - https://stackoverflow.com/questions/13462001/ease-in-and-ease-out-animation-formula
- Also kept the original _Linear_ `L` schedule
- Also added an **experimental** _lenZ_ `Z` schedule that attempts to make the _Linear_ animation feel more like the continuous zooming feeling of an optical lens 
- After the _from_ and _to_ parts, and after the optional _timing_ part, an optional _schedule_ part can be added using the `$` character following by the first letter of the above methods
  - Ex: `{R:100%-200%#10$P}` zoom from 100% to 200% in 10 frames per the _Parametric_ easing schedule
