### PR TITLE
Video Remixer: Sticky Progress

### DIFF
--- a/tabs/video_remixer_ui.py
+++ b/tabs/video_remixer_ui.py
@@ -1442,7 +1442,9 @@ class VideoRemixer(TabBase):
 
     def _get_progress_tab(self) -> int:
         try:
-            return self.PROGRESS_STEPS[self.state.progress]
+            progress = self.state.progress[:-1] if self.state.progress[-1] == "!" \
+                else self.state.progress
+            return self.PROGRESS_STEPS[progress]
         except:
             return self.PROGRESS_STEPS["home"]
 

--- a/video_remixer.py
+++ b/video_remixer.py
@@ -174,7 +174,9 @@ class VideoRemixerState():
         self.project.save(filepath)
 
     def save_progress(self, progress : str, save_project : bool=True):
-        self.progress = progress
+        # if the saved progress ends with "!" it means to always return to this tab, so don't change
+        if self.progress[-1] != "!":
+            self.progress = progress
         if save_project:
             self.save()
 


### PR DESCRIPTION
This is mostly helpful for development: if the `project.yaml` setting `progress` is set to a value ending with a bang such as `choose!` instead of the usual `choose`, then each time the project is opened it will return to the tab associated with the progress, in this case the _Scene Chooser_ tab. Internally this means, when the value ends with `!` it is not updated on any progress changes to other tabs.