### PR TITLE
Video Remixer: Misc. Fixes

### DIFF
--- a/video_remixer_processor.py
+++ b/video_remixer_processor.py
@@ -1220,7 +1220,7 @@ f"Error in resize_scenes() handling processing hint {resize_hint} - skipping pro
 
         if downscaled_width != width or downscaled_height != height:
             # downsample to final size
-            ResizeFrames(scene_input_path,
+            ResizeFrames(working_path,
                         scene_output_path,
                         downscaled_width,
                         downscaled_height,


### PR DESCRIPTION
- Fix broken upscale processing
  - after upscaling to 4X, it should downscale to the right size, which it does, but it reads from the original source directory, ignoring the just-upscaled frames
- Check directory permissions before processing a split scene request
