### PR TITLE
Video Blender: update to work with JPG files

### DIFF
--- a/simplify_png_files.py
+++ b/simplify_png_files.py
@@ -33,14 +33,15 @@ class SimplifyPngFiles:
         num_files = len(files)
         self.log(f"Found {num_files} files")
 
-        with Mtqdm().open_bar(len(files), desc="Simplifying") as bar:
-            for file in files:
-                self.log(f"removing image info from {file}")
-                img = Image.open(file)
-                if img.info:
-                    self.log(f"removing: {img.info}")
-                img.save(file)
-                Mtqdm().update_bar(bar)
+        if files:
+            with Mtqdm().open_bar(len(files), desc="Simplifying") as bar:
+                for file in files:
+                    self.log(f"removing image info from {file}")
+                    img = Image.open(file)
+                    if img.info:
+                        self.log(f"removing: {img.info}")
+                    img.save(file)
+                    Mtqdm().update_bar(bar)
 
     def log(self, message : str) -> None:
         """Logging"""


### PR DESCRIPTION
While using _Video Blender_ with _Video Remixer_ to fix some damaged frames, I discovered that Video Blender has not yet been updated to work with JPG files, instead of only PNG files. This update make it agnostic to file type. Tested to work using the _Video Blend Scene_ under _Remix Extra -> Scene Cleaning_.