### PR TITLE
Fix Transpose 

### DIFF
--- a/resize_frames.py
+++ b/resize_frames.py
@@ -34,6 +34,9 @@ def main():
     parser.add_argument("--crop_type", default="none", type=str,
         help="Cropping type 'crop' (default), 'none'")
 
+    parser.add_argument("--type", default="png", type=str,
+                        help="File type for frame files (Default 'png')")
+
     parser.add_argument("--verbose", dest="verbose", default=False, action="store_true",
         help="Show extra details")
     args = parser.parse_args()
@@ -50,7 +53,7 @@ def main():
                  args.crop_offset_x,
                  args.crop_offset_y,
                  args.crop_type,
-                 ).resize()
+                 ).resize(type=args.type)
 
 class ResizeFrames:
     """Encapsulate logic for Resize Frames feature"""

--- a/tabs/transpose_png_files_ui.py
+++ b/tabs/transpose_png_files_ui.py
@@ -5,6 +5,7 @@ import gradio as gr
 from webui_utils.simple_config import SimpleConfig
 from webui_utils.simple_icons import SimpleIcons
 from webui_utils.file_utils import get_directories
+from webui_utils.video_utils import determine_input_format
 from webui_utils.mtqdm import Mtqdm
 from webui_tips import WebuiTips
 from interpolate_engine import InterpolateEngine
@@ -76,5 +77,6 @@ class TransposePngFiles(TabBase):
     def transpose_png_files(self, input_path : str, input_type : str):
         """Transpose button handler"""
         if input_path:
+            type = determine_input_format(input_path)
             input_type = TransposePngFiles.UI_TYPES_TO_INTERNAL[input_type]
-            _TransposePngFiles(input_path, input_type, self.log_fn).transpose()
+            _TransposePngFiles(input_path, input_type, self.log_fn).transpose(type=type)

--- a/transpose_png_files.py
+++ b/transpose_png_files.py
@@ -6,39 +6,43 @@ from typing import Callable
 from webui_utils.simple_log import SimpleLog
 from webui_utils.mtqdm import Mtqdm
 from PIL import Image
+import numpy as np
+import cv2
 
 def main():
     """Use the Transpose PNG Files feature from the command line"""
-    parser = argparse.ArgumentParser(description='Transpose video frame PNG files')
+    parser = argparse.ArgumentParser(description='Transpose video frame image files')
     parser.add_argument("--path", default="./images", type=str,
         help="Path to PNG files to simplify")
-    parser.add_argument("--type", type=str,
-    help=f"Transformation type: {', '.join(TransposePngFiles.TYPES)}")
+    parser.add_argument("--operation", type=str,
+    help=f"Transformation operation: {', '.join(TransposePngFiles.OPERATIONS)}")
+    parser.add_argument("--type", default="png", type=str,
+                    help="File type for frame files (Default 'png')")
     parser.add_argument("--verbose", dest="verbose", default=False, action="store_true",
         help="Show extra details")
     args = parser.parse_args()
 
     try:
-        args.type = args.type.lower()
-        _ = TransposePngFiles.TYPES.index(args.type)
+        args.operation = args.operation.lower()
+        _ = TransposePngFiles.OPERATIONS.index(args.operation)
     except:
-        print(f"'type' must be one of: {', '.join(TransposePngFiles.TYPES)}")
+        print(f"'operation' must be one of: {', '.join(TransposePngFiles.OPERATIONS)}")
         return
 
     log = SimpleLog(args.verbose)
-    TransposePngFiles(args.path, args.type, log.log).transpose()
+    TransposePngFiles(args.path, args.operation, log.log).transpose(type=args.type)
 
 class TransposePngFiles:
     """Encapsulate logic for Resequence Files feature"""
     def __init__(self,
                 path : str,
-                type: str,
+                operation: str,
                 log_fn : Callable | None):
         self.path = path
-        self.type = type.lower()
+        self.operation = operation.lower()
         self.log_fn = log_fn
 
-    TYPES = ["fliph", "flipv", "ccw90", "rot180", "cw90", "transp", "transv"]
+    OPERATIONS = ["fliph", "flipv", "ccw90", "rot180", "cw90", "transp", "transv"]
     PIL_TYPES = {
         "fliph" : Image.Transpose.FLIP_LEFT_RIGHT,
         "flipv" : Image.Transpose.FLIP_TOP_BOTTOM,
@@ -49,23 +53,59 @@ class TransposePngFiles:
         "transv" : Image.Transpose.TRANSVERSE
     }
 
-    def transpose(self) -> None:
-        """Invoke the Simplify PNG Files feature"""
-        files = sorted(glob.glob(os.path.join(self.path, "*.png")))
-        num_files = len(files)
-        self.log(f"Found {num_files} files")
+    METHODS = {
+        "fliph" : "opencv",
+        "flipv" : "opencv",
+        "ccw90" : "pillow",
+        "rot180" : "opencv",
+        "cw90" : "pillow",
+        "transp" : "pillow",
+        "transv" : "pillow"
+    }
 
+    def pillow_transpose(self, file) -> bool:
         try:
-            method = self.PIL_TYPES[self.type]
-        except:
-            raise ValueError(f"Transpose type '{self.type}' is not valid")
+            pil_method = self.PIL_TYPES[self.operation]
+            img = Image.open(file)
+            new_img = img.transpose(method=pil_method)
+            new_img.save(file)
+        except Exception as error:
+            raise ValueError(f"pillow_transpose() failed for file {file} with error '{error}'.")
+
+    def opencv_transpose(self, file) -> bool:
+        try:
+            frame = cv2.imread(file)
+            data = np.array(frame, np.uint8)
+
+            if self.operation == "fliph":
+                data = np.flip(data, axis = 1)
+            elif self.operation == "flipv":
+                data = np.flip(data, axis = 0)
+            elif self.operation == "rot180":
+                data = np.flip(data, axis = 1)
+                data = np.flip(data, axis = 0)
+                data = np.flip(data, axis = 1)
+
+            img = data.astype(np.uint8)
+            cv2.imwrite(file, img)
+        except Exception as error:
+            raise ValueError(f"opencv_transpose() failed for file {file} with error '{error}'.")
+
+    def transpose(self, type) -> None:
+        """Invoke the Transpose Image Files feature"""
+        if not self.operation in self.OPERATIONS:
+            raise ValueError(f"Transpose type '{self.operation}' is not valid")
+
+        files = sorted(glob.glob(os.path.join(self.path, "*." + type)))
+        num_files = len(files)
 
         with Mtqdm().open_bar(len(files), desc="Transposing") as bar:
             for file in files:
-                self.log(f"removing image info from {file}")
-                img = Image.open(file)
-                new_img = img.transpose(method=method)
-                new_img.save(file)
+                method = self.METHODS[self.operation]
+                if method == "pillow":
+                    self.pillow_transpose(file)
+                else:
+                    self.opencv_transpose(file)
                 Mtqdm().update_bar(bar)
 
     def log(self, message : str) -> None:


### PR DESCRIPTION
I needed to horizontally flip FHD 60 FPS content. It took 30 minutes to flip 10 seconds of footage.
- Images are _numpy_ arrays, which are 6X faster to flip with `np.flip()` than using _Pillow_
- With these changes, the flip time was 5 minutes
- Switching the project to JPG instead of PNG, the flip time was 2.5 minutes
