### PR TITLE
Video Remixer: Allow for multiple block hints per scene

### DIFF
--- a/video_remixer_processor.py
+++ b/video_remixer_processor.py
@@ -854,9 +854,9 @@ class VideoRemixerProcessor():
                     output_path = os.path.join(scene_output_path, filename + ext)
                     frame = cv2.imread(file)
 
-                    hint_handled = False
                     for hint in hints:
                         try:
+                            hint_handled = False
                             # handled = handled or \
                             #     self._process_animated_block_hint(hint, scene_input_path, scene_output_path, main_resize_w, main_resize_h, main_offset_x, main_offset_y, main_crop_w, main_crop_h, scene_name, adjust_for_inflation)
 

--- a/video_remixer_processor.py
+++ b/video_remixer_processor.py
@@ -1127,14 +1127,6 @@ class VideoRemixerProcessor():
         block_factor = int(block_param) if block_param else self.DEFAULT_BLOCK_FACTOR
         block_factor /= expansion
 
-        # files = sorted(get_files(scene_input_path))
-        # with Mtqdm().open_bar(total=len(files), desc="Block FX") as bar:
-        #     for file in files:
-        #         _, filename, ext = split_filepath(file)
-        #         output_path = os.path.join(scene_output_path, filename + ext)
-
-        #         frame = cv2.imread(file)
-
         if block_type == self.BLOCK_TYPE_BLACK:
             value = max(0, min(225, int(block_param))) if block_param else self.BLOCK_VALUE_BLACK
             frame = self.block_frame_block(frame, top, bottom, left, right, value)


### PR DESCRIPTION
Add support for adding more than a single _Block_ processing hint. They are separated with commas like all processing hints, and are processed in the order they appear.

- This is necessary because, if using Block FX to obscure content that shouldn't be shown, often there are several places in the scene that need blocking

Also, add support for "Sticky" Block Hints. Follow the Block hint type with `!` to make it stick until stopped.
- This is necessary because, if using Block FX to obscure _constant_ content, such as a company logo, it should not be necessary to add that block to each scene
- Examples:
  - Block a face in the center square of the scene with pixelation; also block the lower-right square with pixelation beginning with this scene and appearing until stopped: `{B:X5/9,X!9/9}`
  - Cancel Sticky Block Hints starting with the next scene after this one: `{B:!}` (place the cancel hint in the last scene the sticky hint should appear)