### PR TITLE
Fix error when aborting app using CTRL-C

### DIFF
--- a/webui.py
+++ b/webui.py
@@ -1,5 +1,6 @@
 """EMA-VFI-WebUI Application"""
 import os
+os.environ['FOR_DISABLE_CONSOLE_CTRL_HANDLER'] = "1"
 import shutil
 import time
 import signal


### PR DESCRIPTION
Set an env var that disables a CTRL-C handler set by a Fortran runtime library used by SciPy 

see: https://stackoverflow.com/questions/45199817/stopping-a-python-process-so-that-context-managers-still-call-exit-in-windo