### PR TITLE
Bulk video remixer

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -107,6 +107,18 @@ remixer_settings:
   default_crf: 23
   def_project_fps: 29.97
   default_gif_fps: 10
+  file_types:
+  - "avi"
+  - "flv"
+  - "gif"
+  - "m4v"
+  - "mov"
+  - "mp4"
+  - "mpeg"
+  - "mpg"
+  - "qt"
+  - "webm"
+  - "wmv"
   gif_end_delay: 1.0
   gif_factor: 10
   labeled_ffmpeg_video: -vf "drawtext=<LABEL>" -c:v libx264 -crf <CRF>

--- a/tabs/video_remixer_ui.py
+++ b/tabs/video_remixer_ui.py
@@ -1619,7 +1619,21 @@ class VideoRemixer(TabBase):
         self.state.source_frames_invalid = deinterlace != self.state.deinterlace
 
         try:
-            self._next_button1(project_path)
+            self._next_button1(project_path,
+                               project_fps,
+                               split_type,
+                               scene_threshold,
+                               break_duration,
+                               break_ratio,
+                               resize_w,
+                               resize_h,
+                               crop_w,
+                               crop_h,
+                               crop_offset_x,
+                               crop_offset_y,
+                               frame_format,
+                               deinterlace,
+                               split_time)
             # # this is first project write
             # self.state.project_path = project_path
             # self.log(f"creating project path {project_path}")
@@ -3326,11 +3340,6 @@ class VideoRemixer(TabBase):
             message = format_markdown("There is no loaded project.", "error")
             return gr.update(selected=self.TAB_REMIX_EXTRA), \
                 message
-
-        create_button716.click(self.create_button716,
-                            inputs=[videos_path,
-                                    thumbnail_type, min_frames_per_scene],
-                            outputs=message_box716)
 
     def create_button716(self,
                          videos_path,

--- a/tabs/video_remixer_ui.py
+++ b/tabs/video_remixer_ui.py
@@ -3326,7 +3326,7 @@ class VideoRemixer(TabBase):
             return format_markdown(f"Directory '{videos_path}' was not found", "error")
 
         file_types = ",".join(self.config.remixer_settings["file_types"])
-        file_list = get_files(videos_path, file_types)
+        file_list = sorted(get_files(videos_path, file_types))
         num_files = len(file_list)
 
         if num_files < 1:
@@ -3377,7 +3377,7 @@ class VideoRemixer(TabBase):
         if not os.path.exists(projects_path):
             return format_markdown(f"Directory '{projects_path}' was not found", "error")
 
-        dir_list = get_directories(projects_path)
+        dir_list = sorted(get_directories(projects_path))
         num_dirs = len(dir_list)
 
         if num_dirs < 1:
@@ -3431,7 +3431,7 @@ class VideoRemixer(TabBase):
             gr.update(selected=self.TAB_REMIX_EXTRA), \
             *empty_args
 
-        dir_list = get_directories(projects_path)
+        dir_list = sorted(get_directories(projects_path))
         num_dirs = len(dir_list)
 
         if num_dirs < 1:

--- a/tabs/video_remixer_ui.py
+++ b/tabs/video_remixer_ui.py
@@ -3349,8 +3349,7 @@ class VideoRemixer(TabBase):
                 except ValueError as error:
                     messages.append(str(error))
 
-                finally:
-                    Mtqdm().update_bar(bar)
+                Mtqdm().update_bar(bar)
 
         if messages:
             return format_markdown("\r\n".join(messages), "warning")
@@ -3392,6 +3391,9 @@ class VideoRemixer(TabBase):
                     project_path = os.path.join(projects_path, dir)
                     message = self._next_button01(project_path)
                     messages.append(message)
+
+                    if len(self.state.kept_scenes() < 1):
+                        self.state.keep_all_scenes()
 
                     message = self._next_button5(resynthesize,
                                                  inflate,

--- a/tabs/video_remixer_ui.py
+++ b/tabs/video_remixer_ui.py
@@ -2330,12 +2330,12 @@ class VideoRemixer(TabBase):
                                          auto_delete_remix)
         except ValueError as error:
             return gr.update(selected=self.TAB_PROC_REMIX), \
-                format_markdown(error, "error"), \
+                format_markdown(str(error), "error"), \
                 *empty_args
 
         if auto_save_remix:
             return gr.update(selected=self.TAB_PROC_REMIX), \
-                format_markdown("\r\n".join(messages)), \
+                format_markdown(messages), \
                 *empty_args
 
         else:

--- a/tabs/video_remixer_ui.py
+++ b/tabs/video_remixer_ui.py
@@ -943,7 +943,8 @@ class VideoRemixer(TabBase):
                         "Use the Remix Settings and Set Up Project tabs to choose project options"))
                                 with gr.Row():
                                     videos_path = gr.Textbox(label="Videos Path", max_lines=1,
-                                placeholder="Path on this server to the videos to be remixed")
+                                placeholder="Path on this server to the videos to be remixed",
+                                value=lambda : Session().get("last-bulk-create-path"))
                                 with gr.Row():
                                    message_box716 = gr.Markdown(
                                         format_markdown(
@@ -965,7 +966,8 @@ class VideoRemixer(TabBase):
                                         "**_Open the first found project in the specified state_**")
                                 with gr.Row():
                                     projects_path718 = gr.Textbox(label="Projects Path", max_lines=1,
-                                placeholder="Path on this server to the Video Remixer projects to be opened")
+                    placeholder="Path on this server to the Video Remixer projects to be opened",
+                                value=lambda : Session().get("last-bulk-open-path"))
                                 with gr.Row():
                                     project_state718 = gr.Dropdown(choices=["Settings", "Setup", "Choose", "Compile", "Process", "Save"], value="Choose", label="Project State")
                                 with gr.Row():
@@ -988,7 +990,8 @@ class VideoRemixer(TabBase):
                         "Use the Process Remix tab to choose processing options"))
                                 with gr.Row():
                                     projects_path717 = gr.Textbox(label="Projects Path", max_lines=1,
-                                placeholder="Path on this server to the Video Remixer projects to be processed")
+                    placeholder="Path on this server to the Video Remixer projects to be processed",
+                                value=lambda : Session().get("last-bulk-process-path"))
                                 with gr.Row():
                                    message_box717 = gr.Markdown(
                                         format_markdown(
@@ -3334,6 +3337,8 @@ class VideoRemixer(TabBase):
         f"Directory '{videos_path}' was not found to contain files of these types: {file_types}",
                 "error")
 
+        Session().set("last-bulk-create-path", videos_path)
+
         with Mtqdm().open_bar(total=num_files, desc="Create Projects") as bar:
             for file in file_list:
                 try:
@@ -3384,6 +3389,8 @@ class VideoRemixer(TabBase):
             return format_markdown(
                 f"Directory '{projects_path}' was not found to contain Video Remixer projects",
                 "error")
+
+        Session().set("last-bulk-process-path", projects_path)
 
         with Mtqdm().open_bar(total=num_dirs, desc="Process Projects") as bar:
             for dir in dir_list:
@@ -3440,6 +3447,8 @@ class VideoRemixer(TabBase):
                 "error"), \
             gr.update(selected=self.TAB_REMIX_EXTRA), \
             *empty_args
+
+        Session().set("last-bulk-open-path", projects_path)
 
         with Mtqdm().open_bar(total=num_dirs, desc="Search Projects") as bar:
             for dir in dir_list:

--- a/tabs/video_remixer_ui.py
+++ b/tabs/video_remixer_ui.py
@@ -3392,7 +3392,7 @@ class VideoRemixer(TabBase):
                     message = self._next_button01(project_path)
                     messages.append(message)
 
-                    if len(self.state.kept_scenes() < 1):
+                    if len(self.state.kept_scenes()) < 1:
                         self.state.keep_all_scenes()
 
                     message = self._next_button5(resynthesize,

--- a/tabs/video_remixer_ui.py
+++ b/tabs/video_remixer_ui.py
@@ -57,6 +57,7 @@ class VideoRemixer(TabBase):
     TAB_EXTRA_MANAGE_STORAGE = 5
     TAB_EXTRA_MERGE_SCENES = 6
     TAB_EXTRA_VIDEO_BLEND_SCENE = 7
+    TAB_EXTRA_BULK_PROCESSING = 8
 
     TAB_EXTRA_MERGE_RANGE = 0
     TAB_EXTRA_MERGE_COALESCE = 1
@@ -738,8 +739,7 @@ class VideoRemixer(TabBase):
                                                         variant="stop", scale=0)
 
                     # MANAGE STORAGE
-                    with gr.Tab(SimpleIcons.HERB +" Manage Storage",
-                                id=self.TAB_EXTRA_MANAGE_STORAGE):
+                    with gr.Tab(SimpleIcons.HERB +" Manage Storage", id=self.TAB_EXTRA_MANAGE_STORAGE):
                         gr.Markdown("Free Disk Space by Removing Unneeded Content")
                         with gr.Tabs():
 
@@ -923,6 +923,33 @@ class VideoRemixer(TabBase):
                                                 value="Select All", scale=0)
                                             select_none_button712 = gr.Button(
                                                 value="Select None", scale=0)
+
+                    # BULK PROCESSING
+                    with gr.Tab(SimpleIcons.ROBOT +" Bulk Processing", id=self.TAB_EXTRA_BULK_PROCESSING):
+                        gr.Markdown("Processing Across Multiple Projects")
+                        with gr.Tabs():
+
+                            with gr.Tab(SimpleIcons.FACTORY + " Create Multiple Projects"):
+                                gr.Markdown(
+                    "**_Create Video Remixer projects for each video in a directory_**")
+                                with gr.Row():
+                                    videos_path = gr.Textbox(label="Videos Path", max_lines=1,
+                                placeholder="Path on this server to the videos to be remixed")
+                                with gr.Row():
+                                   message_box716 = gr.Markdown(
+                                        format_markdown(
+                                "Click Create Projects to: Make a project for each video"))
+                                gr.Markdown(
+                                    format_markdown(
+                                        SimpleIcons.WARNING + \
+                                            " This action consumes large amounts of disk space",
+                                            "warning"))
+                                gr.Markdown(
+                                    format_markdown(
+                "Progress can be tracked in the console", color="none", italic=True, bold=False))
+                                with gr.Row():
+                                    create_button716 = gr.Button(value="Create Projects",
+                                                                variant="primary", scale=0)
 
                 with gr.Accordion(SimpleIcons.TIPS_SYMBOL + " Guide", open=False):
                     WebuiTips.video_remixer_extra.render()
@@ -1313,6 +1340,8 @@ class VideoRemixer(TabBase):
                                     set_scene_label])
 
         purge_button715.click(self.purge_button715, outputs=[tabs_video_remixer, message_box715])
+
+        create_button716.click(self.create_button716, inputs=videos_path, outputs=message_box716)
 
     def _gather_fonts(self):
         fonts = get_files(self.FONTS_ROOT, "ttf")
@@ -3119,6 +3148,24 @@ class VideoRemixer(TabBase):
             message = format_markdown("There is no loaded project.", "error")
             return gr.update(selected=self.TAB_REMIX_EXTRA), \
                 message
+
+    def create_button716(self, videos_path):
+        if not videos_path:
+            return format_markdown(
+                "Enter a path to a directory of videos on this server to get started", "warning")
+
+        if not os.path.exists(videos_path):
+            return format_markdown(f"Directory '{videos_path}' was not found", "error")
+
+        file_types = ",".join(self.config.remixer_settings["file_types"])
+        file_list = get_files(videos_path, file_types)
+
+        if len(file_list) == 0:
+            return format_markdown(
+        f"Directory '{videos_path}' was not found to contain files of these types: {file_types}",
+                "error")
+
+        return format_markdown(f"{len(file_list)} files found")
 
     def save_mp4_video(self, output_filepath, quality=None):
         self.state.output_filepath = output_filepath

--- a/tabs/video_remixer_ui.py
+++ b/tabs/video_remixer_ui.py
@@ -240,9 +240,9 @@ class VideoRemixer(TabBase):
                     skip_detection = gr.Checkbox(value=False, label="Recreate Thumbnails Only",
                 info="Remake thumbnails with existing scenes if present, skipping project setup")
                 with gr.Accordion(label="More Options", open=False):
-                    with gr.Row(variant="compact"):
-                        remove_source = gr.Checkbox(value=False, label="Remove Source Frames",
-                    info="Delete the source frames after scenes have been created")
+                    # with gr.Row(variant="compact"):
+                    remove_source = gr.Checkbox(value=False, label="Remove Source Frames",
+                        info="Delete the source frames after scenes have been created")
 
                 with gr.Row():
                     message_box2 = gr.Markdown(value=format_markdown(self.TAB2_DEFAULT_MESSAGE))
@@ -938,6 +938,10 @@ class VideoRemixer(TabBase):
                                 gr.Markdown(
                     "**_Create Video Remixer projects for each video in a directory_**")
                                 with gr.Row():
+                                    gr.Markdown(
+                                        format_markdown(
+                        "Use the Remix Settings and Set Up Project tabs to choose project options"))
+                                with gr.Row():
                                     videos_path = gr.Textbox(label="Videos Path", max_lines=1,
                                 placeholder="Path on this server to the videos to be remixed")
                                 with gr.Row():
@@ -959,6 +963,10 @@ class VideoRemixer(TabBase):
                             with gr.Tab(SimpleIcons.TORNADO + " Process Multiple Projects"):
                                 gr.Markdown(
                     "**_Perform Processing for each Video Remixer project in a directory_**")
+                                with gr.Row():
+                                    gr.Markdown(
+                                        format_markdown(
+                        "Use the Process Remix tab to choose processing options"))
                                 with gr.Row():
                                     projects_path = gr.Textbox(label="Projects Path", max_lines=1,
                                 placeholder="Path on this server to the Video Remixer projects to be processed")

--- a/video_remixer_processor.py
+++ b/video_remixer_processor.py
@@ -2775,7 +2775,7 @@ f"Error in upscale_scenes() handling processing hint {upscale_hint} - skipping p
             for scene_name in kept_scenes:
                 scene_input_path = os.path.join(scenes_base_path, scene_name)
                 scene_output_filepath = os.path.join(self.state.video_clips_path,
-                                                     f"{source_name}_{scene_name}.mp4")
+                                                     f"{source_name}_[{scene_name}].mp4")
 
                 video_clip_fps, fps_factor = self.compute_scene_fps(scene_name)
 
@@ -2994,7 +2994,12 @@ f"Error in upscale_scenes() handling processing hint {upscale_hint} - skipping p
                 for index, scene_name in enumerate(kept_scenes):
                     scene_video_path = self.state.video_clips[index]
                     scene_audio_path = self.state.audio_clips[index]
-                    scene_output_filepath = os.path.join(self.state.clips_path, f"{scene_name}.mp4")
+
+                    _, source_name, _ = split_filepath(self.state.source_video)
+                    source_name = simple_sanitize_filename(source_name)
+
+                    scene_output_filepath = os.path.join(self.state.clips_path,
+                                                         f"{source_name}_[{scene_name}].mp4")
 
                     force_inflation, force_audio, force_inflate_by, force_silent =\
                         self.compute_forced_inflation(scene_name)

--- a/video_remixer_processor.py
+++ b/video_remixer_processor.py
@@ -2767,12 +2767,15 @@ f"Error in upscale_scenes() handling processing hint {upscale_hint} - skipping p
         # save the project now to preserve the newly established path
         self.state.save()
 
+        _, source_name, _ = split_filepath(self.state.source_video)
+        source_name = simple_sanitize_filename(source_name)
+
         scenes_base_path = self.furthest_processed_path()
         with Mtqdm().open_bar(total=len(kept_scenes), desc="Video Clips") as bar:
             for scene_name in kept_scenes:
                 scene_input_path = os.path.join(scenes_base_path, scene_name)
                 scene_output_filepath = os.path.join(self.state.video_clips_path,
-                                                     f"{scene_name}.mp4")
+                                                     f"{source_name}_{scene_name}.mp4")
 
                 video_clip_fps, fps_factor = self.compute_scene_fps(scene_name)
 

--- a/video_remixer_processor.py
+++ b/video_remixer_processor.py
@@ -2999,7 +2999,7 @@ f"Error in upscale_scenes() handling processing hint {upscale_hint} - skipping p
                     source_name = simple_sanitize_filename(source_name)
 
                     scene_output_filepath = os.path.join(self.state.clips_path,
-                                                         f"{source_name}_[{scene_name}].mp4")
+                                                         f"{source_name}_[{scene_name}]_scene.mp4")
 
                     force_inflation, force_audio, force_inflate_by, force_silent =\
                         self.compute_forced_inflation(scene_name)

--- a/webui_utils/file_utils.py
+++ b/webui_utils/file_utils.py
@@ -168,7 +168,9 @@ def get_matching_files(path : str, filespec : str) -> list:
         raise ValueError("'path' must be a string")
 
 def get_directories(path : str, ignore_empty_path=False) -> list:
-    """Get a list of directories in the path"""
+    """Get a list of directories in the path
+       if ignore_empty_path is True
+    """
     if isinstance(path, str):
         if os.path.exists(path) and not ignore_empty_path:
             if is_safe_path(path):

--- a/webui_utils/simple_icons.py
+++ b/webui_utils/simple_icons.py
@@ -84,11 +84,13 @@ class SimpleIcons:
     BOMB = "💣"
     BROKEN_HEART = "💔"
     BROOM = "🧹"
+    BUBBLES = "🫧"
     CHERRY_BLOSSOM = "🌸"
     COCKTAIL = "🍸"
     COOL = "🆒"
     EGGPLANT = "🍆"
     EYES = "👀"
+    FACTORY = "🏭"
     FINISH_FLAG = "🏁"
     FLASHLIGHT ="🔦"
     GEMSTONE = "💎"
@@ -162,6 +164,7 @@ class SimpleIcons:
         CROSSMARK,
         DIVIDE,
         DOCUMENT,
+        FACTORY,
         FILM,
         FINISH_FLAG,
         FIVE,
@@ -190,6 +193,7 @@ class SimpleIcons:
         PROPERTIES,
         RECYCLE,
         RIGHT_DOWN_ARROW,
+        ROBOT,
         ROCKET,
         SCROLL,
         SEEDLING,

--- a/webui_utils/simple_icons.py
+++ b/webui_utils/simple_icons.py
@@ -120,6 +120,7 @@ class SimpleIcons:
     STETHOSCOPE ="🩺"
     STILL = "⚗️"
     SWEAT = "💦"
+    TORNADO = "🌪️"
     TWO_HEARTS = "💕"
 
     # shared symbol definitions
@@ -204,6 +205,7 @@ class SimpleIcons:
         STILL,
         TELEVISION,
         THREE,
+        TORNADO,
         TWO,
         TWO_HEARTS,
         VULCAN_HAND,

--- a/webui_utils/test_file_utils.py
+++ b/webui_utils/test_file_utils.py
@@ -232,9 +232,9 @@ GOOD_LOCATE_FRAME_FILE_ARGS = [
 ]
 
 BAD_LOCATE_FRAME_FILE_ARGS = [
-    ((None, None), "'png_files_path' must be a string"),
-    (("", None), "'png_files_path' must be a legal path"),
-    ((os.path.join(FIXTURE_PATH, ".."), None), "'png_files_path' must be a legal path"),
+    ((None, None), "'frame_files_path' must be a string"),
+    (("", None), "'frame_files_path' must be a legal path"),
+    ((os.path.join(FIXTURE_PATH, ".."), None), "'frame_files_path' must be a legal path"),
     ((FIXTURE_PATH, None), "'frame_number' must be an int or float"),
 ]
 

--- a/webui_utils/test_simple_icons.py
+++ b/webui_utils/test_simple_icons.py
@@ -5,7 +5,7 @@ from .simple_icons import *
 
 GOOD_EXAMPLES = [
     (SimpleIcons.SYMBOLS, 10, 12),
-    (SimpleIcons.APP_ICONS, 62, 89)]
+    (SimpleIcons.APP_ICONS, 63, 91)]
 
 def test_SimpleIcons():
     for example, expected_items, expected_len in GOOD_EXAMPLES:

--- a/webui_utils/test_simple_icons.py
+++ b/webui_utils/test_simple_icons.py
@@ -5,7 +5,7 @@ from .simple_icons import *
 
 GOOD_EXAMPLES = [
     (SimpleIcons.SYMBOLS, 10, 12),
-    (SimpleIcons.APP_ICONS, 60, 87)]
+    (SimpleIcons.APP_ICONS, 62, 89)]
 
 def test_SimpleIcons():
     for example, expected_items, expected_len in GOOD_EXAMPLES:


### PR DESCRIPTION
Video Remixer now has a new **Bulk Processing** tab under the _Remix Extra_ tab. 

**_Bulk Processing_**

This new feature saves time when remixing a series of videos

* Create new _Video Remixer_ projects for all videos in a directory using an identical set of options
* Select projects to open 1-by-1 per project state, e.g., _open the next project requiring scene choices_
* Process all Video Remixer projects in a directory using identical processing options

**_Example Use Cases:_**

* Removing commercial ads from a collection of OTA television recordings
* Splitting a collection of long recordings into shorter manageable videos

**Create Multiple Projects**

* Set _Videos Path_ to the directory of videos to create projects for
* Use the _Remix Settings_ and _Set Up Projects_ tabs to set the project creation options for all videos
* Click _Create Projects_

Video Remixer projects will be created for each video within the selected directory.

**NOTE**

* This feature **can consume vast amounts of disk space**
    * **Tip** Use the new _Remove Source Frames_ feature on the _Set Up Project_ tab (in the _More Options_ accordion) to remove the original source frames after scenes have been created for them  
* The videos should all share the same video properties to ensure they are compatible with the project setup options

**Open Multiple Projects**

* Set _Projects Path_ to the directory of Video Remixer projects to be opened
* Set _Project State_ to the state to search for to open the next project
    * Bulk created projects will be in the state "Choose" on being created
* Click _Open Found Project_

The next project found matching that state will be pre-filled into the _Project Path_ field on the _Remix Home_  tab allowing the project to be opened easily. A message will appear instead if no project was found matching the selected state.

**Process Multiple Projects**

* Set _Projects Path_ to the directory of Video Remixer projects to be processed
* Use the _Process Remix_ tab set to processing options for all projects
    * **Tip** use the _Automatically save default MP4 video_ and _Delete processed content after saving_ options (in the _Advanced Options_ accordion), along with the _Create MP4 Remix_ tab (on the _Save Remix_ tab) to create the video and deleted all generated project content if only needing the final remixed video.
* Click _Process Projects_

Each Video Remixer project will be processed 1-by-1

**NOTE**

* This feature _can take an enormous amount of time to complete
* I have found Python exiting without any messages about why, nor the ability to trap an exception to prevent it while processing dozens of projects.
    * If this happens, remove the completed Video Remixer projects from the projects path, restart the application and try again
    * I have had it fail after as few as 20 projects and as many as 65
    * A proper solution to this issue is still being investigated
