### PR TITLE
Video Remixer: Secondary split position

### DIFF
--- a/tabs/video_remixer_ui.py
+++ b/tabs/video_remixer_ui.py
@@ -2770,6 +2770,9 @@ class VideoRemixer(TabBase):
         second_keep_before = False
         second_keep_after = False
 
+        if split_percent_alt == split_percent:
+            use_alt_split = False
+
         if use_alt_split and split_percent_alt < split_percent:
             first_split = split_percent_alt
             second_split = split_percent

--- a/tabs/video_remixer_ui.py
+++ b/tabs/video_remixer_ui.py
@@ -601,9 +601,14 @@ class VideoRemixer(TabBase):
                                     with gr.Row():
                                         set_view_hint_702 = gr.Textbox(placeholder="View Hint",
                                                                     max_lines=1, show_label=False,
-                                                                    min_width=100, container=False) #scale=3,
+                                                                    min_width=100, container=False)
                                         preview_view_hint_702 = gr.Button(value="Visualize View Hint",
-                                                                      size="sm", min_width=40) # scale=0,
+                                                                      size="sm", min_width=40)
+                                    with gr.Row():
+                                        use_alt_split_702 = gr.Checkbox(value=False, label="Use Secondary Split")
+                                        split_percent_alt_702 = gr.Slider(value=50.0,
+                                            label="Secondary Split Position", minimum=0.0,
+                                            maximum=100.0, step=0.1)
 
                             with gr.Column():
                                 preview_image702 = gr.Image(type="filepath",
@@ -1251,8 +1256,14 @@ class VideoRemixer(TabBase):
         scene_id_702.change(self.update_preview_scene_id, inputs=[scene_id_702, split_percent_702],
                                 outputs=[preview_image702, scene_info_702], show_progress=False)
 
-        split_percent_702.change(self.update_preview_split_percent, inputs=[scene_id_702, split_percent_702],
+        split_percent_702.change(self.update_preview_split_percent,
+                                inputs=[scene_id_702, split_percent_702],
                                 outputs=[preview_image702, scene_info_702], show_progress=False)
+
+        split_percent_alt_702.change(self.update_preview_split_percent_alt,
+                                inputs=[scene_id_702, split_percent_alt_702],
+                                outputs=[preview_image702, scene_info_702],
+                                show_progress=False)
 
         goto_0_702.click(self.goto_0_702, outputs=split_percent_702, show_progress=False)
 
@@ -1294,21 +1305,31 @@ class VideoRemixer(TabBase):
                                 inputs=[scene_id_702, split_percent_702, go_to_f_702],
                                 outputs=split_percent_702, show_progress=False)
 
-        split_button702.click(self.split_button702, inputs=[scene_id_702, split_percent_702],
-                              outputs=[tabs_video_remixer, message_box702, scene_index, scene_name,
+        split_button702.click(self.split_button702,
+                              inputs=[scene_id_702, split_percent_702, use_alt_split_702,
+                                      split_percent_alt_702],
+                              outputs=[tabs_video_remixer, message_box702, use_alt_split_702,
+                                       split_percent_alt_702, scene_index, scene_name,
                                        scene_image, scene_state, scene_info, set_scene_label])
 
         split_keep_before_702.click(self.split_keep_before_702,
-                                    inputs=[scene_id_702, split_percent_702],
-                                    outputs=[tabs_video_remixer, message_box702, scene_index,
-                                             scene_name, scene_image, scene_state, scene_info,
-                                             set_scene_label])
+                                inputs=[scene_id_702, split_percent_702, use_alt_split_702,
+                                    split_percent_alt_702],
+                                outputs=[tabs_video_remixer, message_box702, use_alt_split_702,
+                                            split_percent_alt_702, scene_index, scene_name,
+                                            scene_image, scene_state, scene_info, set_scene_label])
 
         split_keep_after_702.click(self.split_keep_after_702,
-                                    inputs=[scene_id_702, split_percent_702],
-                                    outputs=[tabs_video_remixer, message_box702, scene_index,
-                                             scene_name, scene_image, scene_state, scene_info,
-                                             set_scene_label])
+                                inputs=[scene_id_702, split_percent_702, use_alt_split_702,
+                                    split_percent_alt_702],
+                                outputs=[tabs_video_remixer, message_box702, use_alt_split_702,
+                                            split_percent_alt_702, scene_index, scene_name,
+                                            scene_image, scene_state, scene_info, set_scene_label])
+
+        use_alt_split_702.change(self.use_alt_split_change,
+                                inputs=[use_alt_split_702, split_percent_702, split_percent_alt_702],
+                                outputs=split_percent_alt_702,
+                                show_progress=False)
 
         back_button702.click(self.back_button702, outputs=tabs_video_remixer)
 
@@ -2593,14 +2614,20 @@ class VideoRemixer(TabBase):
             format_markdown(message), \
             *self.scene_chooser_details(self.state.current_scene)
 
-    def split_button702(self, scene_index, split_percent):
-        return self._split_scene(scene_index, split_percent, False, False)
+    def split_button702(self, scene_index, split_percent, use_alt_split, split_percent_alt):
+        return self._split_scene(scene_index, split_percent, False, False, use_alt_split, split_percent_alt)
 
-    def split_keep_before_702(self, scene_index, split_percent):
-        return self._split_scene(scene_index, split_percent, True, False)
+    def split_keep_before_702(self, scene_index, split_percent, use_alt_split, split_percent_alt):
+        return self._split_scene(scene_index, split_percent, True, False, use_alt_split, split_percent_alt)
 
-    def split_keep_after_702(self, scene_index, split_percent):
-        return self._split_scene(scene_index, split_percent, False, True)
+    def split_keep_after_702(self, scene_index, split_percent, use_alt_split, split_percent_alt):
+        return self._split_scene(scene_index, split_percent, False, True, use_alt_split, split_percent_alt)
+
+    def use_alt_split_change(self, use_alt_split, split_percent, split_percent_alt):
+        if use_alt_split:
+            return split_percent
+        else:
+            return split_percent_alt
 
     def back_button702(self):
         return gr.update(selected=self.TAB_CHOOSE_SCENES)
@@ -2610,6 +2637,10 @@ class VideoRemixer(TabBase):
 
     def update_preview_split_percent(self, scene_index, split_percent):
         return self.update_preview(scene_index, split_percent)
+
+    def update_preview_split_percent_alt(self, scene_index, split_percent):
+        display_frame, scene_info = self.update_preview(scene_index, split_percent)
+        return display_frame, scene_info
 
     def goto_0_702(self):
         return 0
@@ -2717,13 +2748,15 @@ class VideoRemixer(TabBase):
         _, _, _, _, scene_info, _ = self.state.scene_chooser_details(scene_index, self.GAP)
         return display_frame, scene_info
 
-    def _split_scene(self, scene_index, split_percent, keep_before, keep_after):
+    def _split_scene(self, scene_index, split_percent, keep_before, keep_after, use_alt_split, split_percent_alt):
         errors = self.state.ensure_project_dir_permissions()
+        empty_args = dummy_args(6)
         if errors:
             message = "\r\n".join(errors)
             return gr.update(selected=self.TAB_REMIX_EXTRA), \
                 format_markdown(message, "error"), \
-                *dummy_args(6)
+                False, 50.0, \
+                *empty_args
 
         backup_split_scenes = self.config.remixer_settings["backup_split_scenes"]
         try:
@@ -2733,12 +2766,14 @@ class VideoRemixer(TabBase):
 
             return gr.update(selected=self.TAB_CHOOSE_SCENES), \
                 format_markdown(message), \
+                False, 50.0, \
                 *self.scene_chooser_details(self.state.current_scene)
 
         except ValueError as error:
             return gr.update(selected=self.TAB_REMIX_EXTRA), \
                 format_markdown(f"Unable to split scene: {error}", "warning"), \
-                *dummy_args(6)
+                False, 50.0, \
+                *empty_args
 
     def export_project_703(self, new_project_path : str, new_project_name : str):
         empty_args = dummy_args(2, gr.update(visible=False))


### PR DESCRIPTION
On the Video Remixer **_Split Scene_** tab in the **Advanced Options** accordion there is a new feature to add a second split when splitting a scene. This is useful for when there is a scene that needs to be isolated within a larger scene, for example, when a commercial break needs to be dropped within a larger main scene.

## Checkbox _Use Secondary Split_

- On checking, copies the current split position to the secondary split slider
- This remembers the current split position and allows using the main split slider to identify the other needed split

**NOTE:** The earlier of the two split positions will be processed first. This allows an easy sequence of steps to isolate and remove a mid-scene ad break:
    1. Use the main slider to find the first frame of the ad break to remove
    2. Check the _Use Secondary Split_ checkbox. **This copies the main split position to the secondary slider.**
    3. Use the main slider again, this time to find the first frame of the main scene after the ad break
    4. Click the _Split - Keep Before_ button
    5. The earlier split, copied to the secondary slider is performed, and the part before the split is set to **Keep**
    6. The later split showing on the main slider is performed, and the part before the split is set to **Drop** while the part after the split is set to **Keep**
