### PR TITLE
Video Remixer: Bulk Open - Skip directories without project files

### DIFF
--- a/tabs/video_remixer_ui.py
+++ b/tabs/video_remixer_ui.py
@@ -3527,6 +3527,13 @@ class VideoRemixer(TabBase):
             for dir in dir_list:
                 try:
                     project_path = os.path.join(projects_path, dir)
+
+                    try:
+                        VideoRemixerProject.determine_project_filepath(project_path)
+                    except ValueError:
+                        self.log(f"skipping non project directory {project_path}")
+                        continue
+
                     messages = self._next_button01(project_path)
                     self.log(messages)
                     Mtqdm().update_bar(bar)


### PR DESCRIPTION
When using the _Open Multiple Projects by State_ bulk processing feature, if any found directories are not Video Remixer projects directories (missing a `project.yaml` file) it will be skipped when checking for projects to open.