### PR TITLE
Video Remixer: Add Special Bulk Processing + fixes

### DIFF
--- a/guide/video_blender_frame_fixer.md
+++ b/guide/video_blender_frame_fixer.md
@@ -7,7 +7,7 @@
 1. Set _Last clean frame BEFORE damaged ones_ to the frame number of a clean frame befor the bad ones
     - This is pre-filled with the current frame number if the _Fix Frames_ button is used
 1. Set _First clean frame AFTER damaged ones_ to the frame number of a clean frame after the bad ones
-1. Click _Preview Fixed Frames_
+1. Click _Create and Preview Fixed Frames_
 1. A set of high-precision replacement frames are made using _Frame Search_
     - The search precision is set via the config setting `blender_settings.frame_fixer_depth`
 1. An animated GIF is shown with the replacement frames

--- a/resequence_files.py
+++ b/resequence_files.py
@@ -178,7 +178,8 @@ class ResequenceFiles:
 
                 if self.rename:
                     new_filepath = os.path.join(self.input_path, new_filename)
-                    os.replace(old_filepath, new_filepath)
+                    if old_filepath != new_filepath:
+                        os.replace(old_filepath, new_filepath)
                 else:
                     new_filepath = os.path.join(self.output_path, new_filename)
                     shutil.copy(old_filepath, new_filepath)

--- a/tabs/video_blender_ui.py
+++ b/tabs/video_blender_ui.py
@@ -173,7 +173,7 @@ class VideoBlender(TabBase):
                                 label="First clean frame AFTER damaged ones", value=0,
                                 precision=0)
                         with gr.Row():
-                            preview_button_ff = gr.Button(value="Preview Fixed Frames",
+                            preview_button_ff = gr.Button(value="Create and Preview Fixed Frames",
                                 variant="primary", elem_id="highlightbutton")
                     with gr.Column():
                         preview_image_ff = gr.Image(type="filepath",

--- a/tabs/video_remixer_ui.py
+++ b/tabs/video_remixer_ui.py
@@ -948,7 +948,8 @@ class VideoRemixer(TabBase):
                                 with gr.Row():
                                     gr.Markdown(
                                         format_markdown(
-                        "Use the Remix Settings and Set Up Project tabs to choose project options"))
+                        "Use the Remix Settings and Set Up Project tabs to choose project options",
+                                            color="more"))
                                 with gr.Row():
                                     videos_path = gr.Textbox(label="Videos Path", max_lines=1,
                                 placeholder="Path on this server to the videos to be remixed",
@@ -991,91 +992,79 @@ class VideoRemixer(TabBase):
                                                                 variant="primary", scale=0)
 
                             with gr.Tab(SimpleIcons.TORNADO + " Process Multiple Projects"):
+
                                 gr.Markdown(
                     "**_Perform Processing for each Video Remixer project in a directory_**")
-                                with gr.Tabs():
-                                    with gr.Tab("Process Remix Videos"):
-                                        gr.Markdown(
-                                            format_markdown(
-                                        "Use the Process Remix tab to choose processing options"))
 
-                                        with gr.Row():
-                                            projects_path7170 = gr.Textbox(
-                    label="Projects Path", max_lines=1,
-                    placeholder="Path on this server to the Video Remixer projects to be processed",
-                    value=lambda : Session().get("last-bulk-process-path"))
-
-                                        with gr.Row():
-                                            project_state7170 = gr.Radio(
+                                gr.Markdown(
+                                    format_markdown(
+                                        "Use the Process Remix tab to choose processing options",
+                                        color="more"))
+                                with gr.Row():
+                                    projects_path7170 = gr.Textbox(
+                label="Projects Path", max_lines=1,
+                placeholder="Path on this server to the Video Remixer projects to be processed",
+                value=lambda : Session().get("last-bulk-process-path"))
+                                with gr.Row():
+                                    project_state7170 = gr.Radio(
                                     choices=["All found projects", "Projects in state: Process"],
                                     value="All found projects", label="Project State")
-
-                                        with gr.Row():
-                                            message_box7170 = gr.Markdown(format_markdown(
+                                with gr.Row():
+                                    message_box7170 = gr.Markdown(format_markdown(
                                 "Click Process Projects to: Process Remix Video for each project"))
-                                        with gr.Row():
-                                            gr.Markdown(
+                                with gr.Row():
+                                    gr.Markdown(
                     format_markdown(
                         SimpleIcons.WARNING + " This action may take a very long time to complete",
                         "warning"))
-                                        with gr.Row():
-                                            gr.Markdown(
-                    format_markdown("Progress can be tracked in the console",
-                        color="none", italic=True, bold=False))
-                                        with gr.Row():
-                                            process_button7170 = gr.Button(value="Process Projects",
-                                                                           variant="primary",
+                                with gr.Row():
+                                    gr.Markdown(
+                                        format_markdown("Progress can be tracked in the console",
+                                            color="none", italic=True, bold=False))
+                                with gr.Row():
+                                    process_button7170 = gr.Button(value="Process Projects",
+                                                                    variant="primary",
                                                                            scale=0)
 
-                                    with gr.Tab("Perform Bulk Actions"):
-                                        with gr.Row():
-                                            process_thumbnails_7171 = gr.Checkbox(value=False,
-                                                label="Recreate Thumbnails")
-                                            with gr.Column(variant="compact"):
-                                                gr.Markdown(
-                                    "Recreate Thumbnails for projects per the Set Up Project tab.")
-
-                                        with gr.Row():
-                                            process_delete_7171 = gr.Checkbox(value=False,
-                                                label="Delete Processed Content")
-                                            with gr.Column(variant="compact"):
-                                                gr.Markdown(
-                                    "Delete all processed project content (except videos)")
-
-                                    #     with gr.Row():
-                                    #         process_settings_7171 = gr.Checkbox(value=False,
-                                    #             label="Update Remix Settings")
-                                    #         with gr.Column(variant="compact"):
-                                    #             gr.Markdown(
-                                    # "Update Settings for projects per the Remix Settings tab.")
-
-                                        with gr.Row():
-                                            projects_path7171 = gr.Textbox(
+                            with gr.Tab(SimpleIcons.ROBOT + " Perform Bulk Actions"):
+                                with gr.Row():
+                                    process_thumbnails_7171 = gr.Checkbox(value=False,
+                                        label="Recreate Thumbnails")
+                                    with gr.Column(variant="compact"):
+                                        gr.Markdown(format_markdown(
+                                    "Recreate Thumbnails for projects per the Set Up Project tab.",
+                                            color="more"))
+                                with gr.Row():
+                                    process_delete_7171 = gr.Checkbox(value=False, label=
+                                                                      "Delete Processed Content")
+                                    with gr.Column(variant="compact"):
+                                        gr.Markdown(format_markdown(
+                                            "Delete all processed project content (except videos)",
+                                            color="more"))
+                                with gr.Row():
+                                    projects_path7171 = gr.Textbox(
                     label="Projects Path", max_lines=1,
                     placeholder="Path on this server to the Video Remixer projects to be processed",
                     value=lambda : Session().get("last-bulk-process-path"))
-
-                                        with gr.Row():
-                                            project_state7171 = gr.Dropdown(
+                                    project_state7171 = gr.Dropdown(
                     choices=["Any", "Settings", "Setup", "Choose", "Compile", "Process", "Save"],
                     value="Any", label="Project State")
-
-                                        with gr.Row():
-                                            message_box7171 = gr.Markdown(format_markdown(
-                                "Click Process Projects to: Perform the selection actions for each project"))
-                                        with gr.Row():
-                                            gr.Markdown(
+                                with gr.Row():
+                                    message_box7171 = gr.Markdown(format_markdown(
+                    "Click Process Projects to: Perform the selection actions for each project"))
+                                with gr.Row():
+                                    gr.Markdown(
                     format_markdown(
                         SimpleIcons.WARNING + " This action may take a very long time to complete",
                         "warning"))
-                                        with gr.Row():
-                                            gr.Markdown(
+                                with gr.Row():
+                                    gr.Markdown(
                     format_markdown("Progress can be tracked in the console",
                         color="none", italic=True, bold=False))
-                                        with gr.Row():
-                                            process_button7171 = gr.Button(value="Process Projects",
-                                                                           variant="primary",
-                                                                           scale=0)
+                                with gr.Row():
+                                    process_button7171 = gr.Button(value="Process Projects",
+                                                                    variant="primary",
+                                                                    scale=0)
 
                 with gr.Accordion(SimpleIcons.TIPS_SYMBOL + " Guide", open=False):
                     WebuiTips.video_remixer_extra.render()
@@ -2034,10 +2023,11 @@ class VideoRemixer(TabBase):
         return gr.update(selected=self.TAB_REMIX_SETTINGS)
 
     def thumb_change(self, thumbnail_type):
-        self.state.thumbnail_type = thumbnail_type
-        if self.state.project_path:
-            self.log(f"Saving project after hot-setting thumbnail type to {thumbnail_type}")
-            self.state.save()
+        if self.state:
+            self.state.thumbnail_type = thumbnail_type
+            if self.state.project_path:
+                self.log(f"Saving project after hot-setting thumbnail type to {thumbnail_type}")
+                self.state.save()
 
     ### SCENE CHOOSER EVENT HANDLERS
 

--- a/tabs/video_remixer_ui.py
+++ b/tabs/video_remixer_ui.py
@@ -956,7 +956,7 @@ class VideoRemixer(TabBase):
                                     with gr.Column(variant="compact"):
                                         gr.Markdown(
                                         format_markdown(
-                        "Use the Remix Settings and Set Up Project tabs to choose project options",
+                        "Use the **_Remix Settings_** and **_Set Up Project_** tabs to choose project options",
                                             color="more"))
                                 with gr.Row():
                                    message_box716 = gr.Markdown(
@@ -1006,7 +1006,7 @@ class VideoRemixer(TabBase):
                                     with gr.Column(variant="compact"):
                                         gr.Markdown(
                                     format_markdown(
-                                        "Use the Process Remix tab to choose processing options",
+                                        "Use the **_Process Remix_** tab to choose processing options",
                                         color="more"))
                                 with gr.Row():
                                     project_state7170 = gr.Radio(

--- a/tabs/video_remixer_ui.py
+++ b/tabs/video_remixer_ui.py
@@ -1312,8 +1312,8 @@ class VideoRemixer(TabBase):
                                         scene_name, scene_image, scene_state, scene_info,
                                         set_scene_label])
 
-        scene_id_702.change(self.update_preview_scene_id, inputs=[scene_id_702, split_percent_702],
-                                outputs=[preview_image702, scene_info_702], show_progress=False)
+        scene_id_702.input(self.update_preview_scene_id, inputs=[scene_id_702, split_percent_702],
+                                outputs=[preview_image702, scene_info_702], show_progress=True)
 
         split_percent_702.change(self.update_preview_split_percent,
                                 inputs=[scene_id_702, split_percent_702],

--- a/tabs/video_remixer_ui.py
+++ b/tabs/video_remixer_ui.py
@@ -417,16 +417,19 @@ class VideoRemixer(TabBase):
                         bold=False))
 
                 with gr.Row():
-                    back_button5 = gr.Button(value="< Back", variant="secondary", scale=0)
-                    next_button5 = gr.Button(value="Process Remix " +
-                                SimpleIcons.SLOW_SYMBOL, variant="primary",
-                                elem_id="actionbutton")
-                    with gr.Accordion(label="Advanced Options", open=False):
-                        with gr.Row(variant="compact"):
-                            auto_save_remix = gr.Checkbox(label="Automatically save default MP4 video", container=False)
-                            auto_delete_remix = gr.Checkbox(label="Delete processed content after saving", container=False)
-                        with gr.Row(variant="compact"):
-                            auto_coalesce_remix = gr.Checkbox(label="Automatically coalesce kept scenes", container=False)
+                    with gr.Column():
+                        with gr.Row():
+                            back_button5 = gr.Button(value="< Back", variant="secondary", scale=0)
+                            next_button5 = gr.Button(value="Process Remix " +
+                                        SimpleIcons.SLOW_SYMBOL, variant="primary",
+                                        elem_id="actionbutton")
+                    with gr.Column():
+                        with gr.Accordion(label="Advanced Options", open=False):
+                            with gr.Row(variant="compact"):
+                                auto_save_remix = gr.Checkbox(label="Automatically save default MP4 video", container=False)
+                                auto_delete_remix = gr.Checkbox(label="Delete processed content after saving", container=False)
+                            with gr.Row(variant="compact"):
+                                auto_coalesce_remix = gr.Checkbox(label="Automatically coalesce kept scenes", container=False)
                 with gr.Accordion(SimpleIcons.TIPS_SYMBOL + " Guide", open=False):
                     WebuiTips.video_remixer_processing.render()
 
@@ -946,14 +949,14 @@ class VideoRemixer(TabBase):
                                 gr.Markdown(
                     "**_Create Video Remixer projects for each video in a directory_**")
                                 with gr.Row():
-                                    gr.Markdown(
-                                        format_markdown(
-                        "Use the Remix Settings and Set Up Project tabs to choose project options",
-                                            color="more"))
-                                with gr.Row():
                                     videos_path = gr.Textbox(label="Videos Path", max_lines=1,
                                 placeholder="Path on this server to the videos to be remixed",
                                 value=lambda : Session().get("last-bulk-create-path"))
+                                    with gr.Column(variant="compact"):
+                                        gr.Markdown(
+                                        format_markdown(
+                        "Use the Remix Settings and Set Up Project tabs to choose project options",
+                                            color="more"))
                                 with gr.Row():
                                    message_box716 = gr.Markdown(
                                         format_markdown(
@@ -992,23 +995,24 @@ class VideoRemixer(TabBase):
                                                                 variant="primary", scale=0)
 
                             with gr.Tab(SimpleIcons.TORNADO + " Process Multiple Projects"):
-
                                 gr.Markdown(
                     "**_Perform Processing for each Video Remixer project in a directory_**")
-
-                                gr.Markdown(
-                                    format_markdown(
-                                        "Use the Process Remix tab to choose processing options",
-                                        color="more"))
                                 with gr.Row():
                                     projects_path7170 = gr.Textbox(
                 label="Projects Path", max_lines=1,
                 placeholder="Path on this server to the Video Remixer projects to be processed",
                 value=lambda : Session().get("last-bulk-process-path"))
+                                    with gr.Column(variant="compact"):
+                                        gr.Markdown(
+                                    format_markdown(
+                                        "Use the Process Remix tab to choose processing options",
+                                        color="more"))
                                 with gr.Row():
                                     project_state7170 = gr.Radio(
                                     choices=["All found projects", "Projects in state: Process"],
                                     value="All found projects", label="Project State")
+                                    gr.Column(variant="compact")
+
                                 with gr.Row():
                                     message_box7170 = gr.Markdown(format_markdown(
                                 "Click Process Projects to: Process Remix Video for each project"))

--- a/tabs/video_remixer_ui.py
+++ b/tabs/video_remixer_ui.py
@@ -635,7 +635,7 @@ class VideoRemixer(TabBase):
                     # MERGE SCENES
                     with gr.Tab(SimpleIcons.PACKAGE + " Merge Scenes",
                                 id=self.TAB_EXTRA_MERGE_SCENES):
-                        gr.Markdown("Removed unneeded splits between adjacent scenes")
+                        gr.Markdown("Removes unneeded splits between adjacent scenes")
                         with gr.Tabs() as tabs_merge_scenes:
                             with gr.Tab(SimpleIcons.PACKAGE + " Merge Scene Range",
                                         id=self.TAB_EXTRA_MERGE_RANGE):

--- a/tabs/video_remixer_ui.py
+++ b/tabs/video_remixer_ui.py
@@ -611,7 +611,7 @@ class VideoRemixer(TabBase):
                                             maximum=100.0, step=0.1, container=False, scale=2,
                                             info="Earliest split is performed first")
                                     with gr.Row(variant="compact", equal_height=False):
-                                        set_view_hint_702 = gr.Textbox(placeholder="View Hint",
+                                        set_view_hint_702 = gr.Textbox(placeholder="View Hint such as {V:200%}",
                                                                     max_lines=1, show_label=False,
                                                                     min_width=100, container=False)
                                         preview_view_hint_702 = gr.Button(value="Visualize View Hint",
@@ -744,7 +744,7 @@ class VideoRemixer(TabBase):
                                                         variant="stop", scale=0)
                                 with gr.Row():
                                     result_box703 = gr.Textbox(label="New Project Path", max_lines=1, visible=False)
-                                    open_result703 = gr.Button("Open New Project", visible=False, scale=0)
+                                    open_result703 = gr.Button("Open New Project", visible=False, scale=0, variant="primary")
                             with gr.Tab(SimpleIcons.HEART_EXCLAMATION + " Import Scenes"):
                                 gr.Markdown("**_Import Scenes Exported from the Same Source Video_**")
                                 with gr.Row():

--- a/tabs/video_remixer_ui.py
+++ b/tabs/video_remixer_ui.py
@@ -993,31 +993,42 @@ class VideoRemixer(TabBase):
                             with gr.Tab(SimpleIcons.TORNADO + " Process Multiple Projects"):
                                 gr.Markdown(
                     "**_Perform Processing for each Video Remixer project in a directory_**")
-                                with gr.Row():
-                                    gr.Markdown(
-                                        format_markdown(
-                        "Use the Process Remix tab to choose processing options"))
-                                with gr.Row():
-                                    projects_path717 = gr.Textbox(label="Projects Path", max_lines=1,
+                                with gr.Tabs():
+                                    with gr.Tab("Process Remix Video For All Projects"):
+                                        gr.Markdown(
+                                            format_markdown(
+                                        "Use the Process Remix tab to choose processing options"))
+
+                                        with gr.Row():
+                                            projects_path7170 = gr.Textbox(
+                    label="Projects Path", max_lines=1,
                     placeholder="Path on this server to the Video Remixer projects to be processed",
-                                value=lambda : Session().get("last-bulk-process-path"))
-                                with gr.Row():
-                                    project_state717 = gr.Radio(choices=["All found projects", "Projects in state: Process"], value="All found projects", label="Project State")
-                                with gr.Row():
-                                   message_box717 = gr.Markdown(
-                                        format_markdown(
-                                "Click Process Projects to: Process each Video Remixer project"))
-                                gr.Markdown(
-                                    format_markdown(
-                                        SimpleIcons.WARNING + \
-                                            " This action may take a very long time to complete",
-                                            "warning"))
-                                gr.Markdown(
-                                    format_markdown(
-                "Progress can be tracked in the console", color="none", italic=True, bold=False))
-                                with gr.Row():
-                                    process_button717 = gr.Button(value="Process Projects",
-                                                                variant="primary", scale=0)
+                    value=lambda : Session().get("last-bulk-process-path"))
+
+                                        with gr.Row():
+                                            message_box7170 = gr.Markdown(format_markdown(
+                                "Click Process Projects to: Process Remix Video for each project"))
+                                        with gr.Row():
+                                            gr.Markdown(
+                    format_markdown(
+                        SimpleIcons.WARNING + " This action may take a very long time to complete",
+                        "warning"))
+                                        with gr.Row():
+                                            gr.Markdown(
+                    format_markdown("Progress can be tracked in the console",
+                        color="none", italic=True, bold=False))
+                                        with gr.Row():
+                                            process_button7170 = gr.Button(value="Process Projects",
+                                                                           variant="primary",
+                                                                           scale=0)
+
+                                    with gr.Tab("Process All Projects According To State"):
+                                        ...
+
+
+                                # with gr.Row():
+                                #     project_state717 = gr.Radio(choices=["All found projects", "Projects in state: Process"], value="All found projects", label="Project State")
+
 
                 with gr.Accordion(SimpleIcons.TIPS_SYMBOL + " Guide", open=False):
                     WebuiTips.video_remixer_extra.render()
@@ -1434,12 +1445,12 @@ class VideoRemixer(TabBase):
                                     thumbnail_type, min_frames_per_scene, remove_source],
                             outputs=message_box716)
 
-        process_button717.click(self.process_button717,
-                            inputs=[projects_path717, project_state717, resynthesize, inflate,
+        process_button7170.click(self.process_button7170,
+                            inputs=[projects_path7170, resynthesize, inflate,
                                     resize, upscale, upscale_option, inflate_by_option,
                                     inflate_slow_option, resynth_option, auto_save_remix,
                                     auto_delete_remix, auto_coalesce_remix],
-                            outputs=message_box717)
+                            outputs=message_box7170)
 
         open_button718.click(self.open_button718,
                              inputs=[projects_path718, project_state718, search_order718],
@@ -3489,9 +3500,8 @@ class VideoRemixer(TabBase):
         else:
             return format_markdown(f"{len(file_list)} files processed")
 
-    def process_button717(self,
+    def process_button7170(self,
                           projects_path,
-                          project_state : str,
                           resynthesize,
                           inflate,
                           resize,
@@ -3520,7 +3530,7 @@ class VideoRemixer(TabBase):
                 f"Directory '{projects_path}' was not found to contain Video Remixer projects",
                 "error")
 
-        all_projects = project_state.startswith("A")
+        # all_projects = project_state.startswith("A")
         Session().set("last-bulk-process-path", projects_path)
 
         with Mtqdm().open_bar(total=num_dirs, desc="Process Projects") as bar:
@@ -3538,10 +3548,10 @@ class VideoRemixer(TabBase):
                     message = self._next_button01(project_path)
                     messages.append(message)
 
-                    if not all_projects:
-                        if not self.state.progress.startswith("process"):
-                            Mtqdm().update_bar(bar)
-                            continue
+                    # if not all_projects:
+                    #     if not self.state.progress.startswith("process"):
+                    #         Mtqdm().update_bar(bar)
+                    #         continue
 
                     if len(self.state.kept_scenes()) < 1:
                         self.state.keep_all_scenes()

--- a/tabs/video_remixer_ui.py
+++ b/tabs/video_remixer_ui.py
@@ -2718,7 +2718,7 @@ class VideoRemixer(TabBase):
         if use_alt_split:
             return split_percent, split_percent
         else:
-            return split_percent_alt, split_percent
+            return split_percent_alt, split_percent_alt
 
     def back_button702(self):
         return gr.update(selected=self.TAB_CHOOSE_SCENES)

--- a/video_remixer.py
+++ b/video_remixer.py
@@ -157,6 +157,7 @@ class VideoRemixerState():
     CLIPS_PATH = "CLIPS"
     AUDIO_CLIPS_PATH = "AUDIO"
     VIDEO_CLIPS_PATH = "VIDEO"
+    STICKY_PROGRESS = "!"
 
     def log(self, message):
         self.log_fn(message)
@@ -186,7 +187,7 @@ class VideoRemixerState():
 
     def save_progress(self, progress : str, save_project : bool=True):
         # if the saved progress ends with "!" it means to always return to this tab, so don't change
-        if self.progress[-1] != "!":
+        if self.progress[-1] != self.STICKY_PROGRESS:
             self.progress = progress
         if save_project:
             self.save()

--- a/webui_utils/video_utils.py
+++ b/webui_utils/video_utils.py
@@ -779,12 +779,12 @@ f"{default_filename}[{str(first_frame).zfill(num_width)}-{str(last_frame).zfill(
             if gif_high_quality:
                 ffcmd = FFmpeg(inputs= {input_path : None},
                                         outputs={output_filepath :
-                        f"-ss {start_time} -vf 'scale=iw*{scale_factor}:-2,split[s0][s1];[s0]palettegen[p];[s1][p]paletteuse' -vframes 1"},
+                        f"-framerate {fps} -ss {start_time} -vf 'scale=iw*{scale_factor}:-2,split[s0][s1];[s0]palettegen[p];[s1][p]paletteuse' -vframes 1"},
                     global_options="-y " + global_options)
             else:
                 ffcmd = FFmpeg(inputs= {input_path : None},
                                         outputs={output_filepath :
-                        f"-ss {start_time} -vf 'scale=iw*{scale_factor}:-2' -vframes 1"},
+                        f"-framerate {fps} -ss {start_time} -vf 'scale=iw*{scale_factor}:-2' -vframes 1"},
                     global_options="-y " + global_options)
 
     elif type == "jpg":
@@ -793,7 +793,7 @@ f"{default_filename}[{str(first_frame).zfill(num_width)}-{str(last_frame).zfill(
         mid_frame = int((last_frame + first_frame) / 2)
         start_second = mid_frame / (fps * 1.0)
         start_time = seconds_to_hms(start_second)
-        ffcmd = FFmpeg(inputs= {input_path : f"-ss {start_time}"},
+        ffcmd = FFmpeg(inputs= {input_path : f"-framerate {fps} -ss {start_time}"},
                                 outputs={output_filepath :
                 f"-vf scale=iw*{scale_factor}:-2 -qscale:v 2 -vframes 1"},
             global_options="-y " + global_options)


### PR DESCRIPTION
- add new Perform Bulk Actions tab
  - add feature to recreate thumbnails across projects using current thumbnail settings
  - add feature to delete all generated project content (except created videos) across projects 
- add advanced processing option to save remix scene videos
  - they are moved from the CLIPS directory to the project home directory
- fix static thumbnails being generated at the wrong timing position

