### PR TITLE
Video Remixer: Find Break Frame in Scene Splitter

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -100,6 +100,7 @@ realesrgan_settings:
   model_name: "RealESRGAN_x4plus"
   tile_pad: 10
   tiling: 256
+remixer_settings:
   backup_split_scenes: True
   custom_ffmpeg_video: -c:v libx264 -crf 23
   custom_ffmpeg_audio: -c:a aac -shortest

--- a/config.yaml
+++ b/config.yaml
@@ -100,7 +100,6 @@ realesrgan_settings:
   model_name: "RealESRGAN_x4plus"
   tile_pad: 10
   tiling: 256
-remixer_settings:
   backup_split_scenes: True
   custom_ffmpeg_video: -c:v libx264 -crf 23
   custom_ffmpeg_audio: -c:a aac -shortest
@@ -119,6 +118,8 @@ remixer_settings:
   - "qt"
   - "webm"
   - "wmv"
+  find_break_stride: 128
+  find_break_threshold: 1
   gif_end_delay: 1.0
   gif_factor: 10
   labeled_ffmpeg_video: -vf "drawtext=<LABEL>" -c:v libx264 -crf <CRF>
@@ -144,6 +145,7 @@ remixer_settings:
   raise_on_error: False
   scale_type_up: "lanczos"
   scale_type_down: "area"
+  skip_break_threshold: 3
   source_audio_crf: 28
   thumb_scale: 0.5
   use_tiling_over: 921600

--- a/tabs/video_remixer_ui.py
+++ b/tabs/video_remixer_ui.py
@@ -610,6 +610,9 @@ class VideoRemixer(TabBase):
                                             label="Secondary Split Position", minimum=0.0,
                                             maximum=100.0, step=0.1, container=False, scale=2,
                                             info="Earliest split is performed first")
+                                    with gr.Row(variant="compact", equal_height=True):
+                                        prev_break_702 = gr.Button(value="< Find Break", size="sm", min_width=40)
+                                        next_break_702 = gr.Button(value="Find Break >", size="sm", min_width=40)
                                     with gr.Row(variant="compact", equal_height=False):
                                         set_view_hint_702 = gr.Textbox(placeholder="View Hint such as {V:200%}",
                                                                     max_lines=1, show_label=False,
@@ -1364,12 +1367,26 @@ class VideoRemixer(TabBase):
                                 inputs=[scene_id_702, split_percent_702, go_to_f_702],
                                 outputs=split_percent_702, show_progress=False)
 
-        split_button702.click(self.split_button702,
-                              inputs=[scene_id_702, split_percent_702, use_alt_split_702,
-                                      split_percent_alt_702],
-                              outputs=[tabs_video_remixer, message_box702, use_alt_split_702,
-                                       split_percent_alt_702, scene_index, scene_name,
-                                       scene_image, scene_state, scene_info, set_scene_label])
+
+        use_alt_split_702.change(self.use_alt_split_change,
+                                inputs=[use_alt_split_702, split_percent_702, split_percent_alt_702],
+                                outputs=[split_percent_702, split_percent_alt_702],
+                                show_progress=False)
+
+        prev_break_702.click(self.prev_break_702,
+                                inputs=[scene_id_702, split_percent_702],
+                                outputs=split_percent_702, show_progress=False)
+        next_break_702.click(self.next_break_702,
+                                inputs=[scene_id_702, split_percent_702],
+                                outputs=split_percent_702, show_progress=False)
+
+        set_view_hint_702.submit(self.set_view_hint_702,
+                                 inputs=[scene_id_702, split_percent_702, set_view_hint_702],
+                                 outputs=[preview_image702, scene_info_702], show_progress=False)
+
+        preview_view_hint_702.click(self.preview_view_hint_702,
+                                    inputs=[scene_id_702, split_percent_702, set_view_hint_702],
+                                    outputs=[preview_image702, scene_info_702], show_progress=False)
 
         split_keep_before_702.click(self.split_keep_before_702,
                                 inputs=[scene_id_702, split_percent_702, use_alt_split_702,
@@ -1385,20 +1402,14 @@ class VideoRemixer(TabBase):
                                             split_percent_alt_702, scene_index, scene_name,
                                             scene_image, scene_state, scene_info, set_scene_label])
 
-        use_alt_split_702.change(self.use_alt_split_change,
-                                inputs=[use_alt_split_702, split_percent_702, split_percent_alt_702],
-                                outputs=[split_percent_702, split_percent_alt_702],
-                                show_progress=False)
+        split_button702.click(self.split_button702,
+                              inputs=[scene_id_702, split_percent_702, use_alt_split_702,
+                                      split_percent_alt_702],
+                              outputs=[tabs_video_remixer, message_box702, use_alt_split_702,
+                                       split_percent_alt_702, scene_index, scene_name,
+                                       scene_image, scene_state, scene_info, set_scene_label])
 
         back_button702.click(self.back_button702, outputs=tabs_video_remixer)
-
-        set_view_hint_702.submit(self.set_view_hint_702,
-                                 inputs=[scene_id_702, split_percent_702, set_view_hint_702],
-                                 outputs=[preview_image702, scene_info_702], show_progress=False)
-
-        preview_view_hint_702.click(self.preview_view_hint_702,
-                                    inputs=[scene_id_702, split_percent_702, set_view_hint_702],
-                                    outputs=[preview_image702, scene_info_702], show_progress=False)
 
         export_project_703.click(self.export_project_703,
                                  inputs=[export_path_703, project_name_703],
@@ -2719,6 +2730,38 @@ class VideoRemixer(TabBase):
             return split_percent, split_percent
         else:
             return split_percent_alt, split_percent_alt
+
+    def is_break_frame(self, frame_file):
+        print(frame_file)
+        return True
+
+    def next_break_702(self, scene_index, split_percent):
+        scene_index = int(scene_index)
+        num_scenes = len(self.state.scene_names)
+        last_scene = num_scenes - 1
+        if scene_index < 0 or scene_index > last_scene:
+            return split_percent
+
+        scene_name = self.state.scene_names[scene_index]
+        _, num_frames, _, _, split_frame = self.state.compute_scene_split(scene_name, split_percent)
+
+        last_frame = num_frames - 1
+        last_staring_search_frame = last_frame - 1
+        if split_frame > last_staring_search_frame:
+            return split_percent
+        starting_search_frame = split_frame + 1
+
+        skipping_dupes = False
+        frame_files = self.state.get_split_scene_cache(scene_index)
+        for frame_index in range(starting_search_frame, num_frames):
+            frame_file = frame_files[frame_index]
+            if self.is_break_frame(frame_file):
+                new_split_percent = 100.0 * (frame_index * 1.0 / num_frames)
+                return new_split_percent
+        return split_percent
+
+    def prev_break_702(self, scene_id, split_percent):
+        ...
 
     def back_button702(self):
         return gr.update(selected=self.TAB_CHOOSE_SCENES)

--- a/video_remixer.py
+++ b/video_remixer.py
@@ -609,14 +609,16 @@ class VideoRemixerState():
 
         scene_name = self.scene_names[scene_index]
         _, num_frames, _, _, split_frame = self.compute_scene_split(scene_name, split_percent)
-        original_scene_path = os.path.join(self.scenes_path, scene_name)
-        frame_files = self.valid_split_scene_cache(scene_index)
-        if not frame_files:
-            # optimize to uncompile only the first time it's needed
-            self.uncompile_scenes()
 
-            frame_files = sorted(get_files(original_scene_path))
-            self.fill_split_scene_cache(scene_index, frame_files)
+        # original_scene_path = os.path.join(self.scenes_path, scene_name)
+        # frame_files = self.valid_split_scene_cache(scene_index)
+        # if not frame_files:
+        #     # optimize to uncompile only the first time it's needed
+        #     self.uncompile_scenes()
+
+        #     frame_files = sorted(get_files(original_scene_path))
+        #     self.fill_split_scene_cache(scene_index, frame_files)
+        frame_files = self.get_split_scene_cache(scene_index)
 
         num_frame_files = len(frame_files)
         if num_frame_files != num_frames:
@@ -878,3 +880,15 @@ class VideoRemixerState():
     def invalidate_split_scene_cache(self):
         self.split_scene_cache = []
         self.split_scene_cached_index = -1
+
+    def get_split_scene_cache(self, scene_index):
+        entries = self.valid_split_scene_cache(scene_index)
+        if not entries:
+            # optimize to uncompile only the first time it's needed
+            self.uncompile_scenes()
+
+            scene_name = self.scene_names[scene_index]
+            original_scene_path = os.path.join(self.scenes_path, scene_name)
+            entries = sorted(get_files(original_scene_path))
+            self.fill_split_scene_cache(scene_index, entries)
+        return entries

--- a/webui_utils/image_utils.py
+++ b/webui_utils/image_utils.py
@@ -43,3 +43,19 @@ def gif_frame_count(filepath : str):
     gif = Image.open(filepath)
     if gif:
         return gif.n_frames
+
+def get_average_lightness(image_path : str, stride : int = 1) -> int:
+    with Image.open(image_path) as img:
+        img = img.convert('L')
+        pixels = img.getdata()
+        total = 0
+        pixel_count = 0
+        pixels = list(pixels)
+        for pixel in pixels[::stride]:
+            # assume the sampled pixel is an average representative of the stride range
+            total += pixel * stride
+            pixel_count += 1
+
+        average = int(total / (pixel_count * stride))
+        return average
+


### PR DESCRIPTION
Adds _Find Next Break_ buttons to the Video Remixer **Scene Splitter**
- scans through the frames to find a mostly all-black frame
- works in forward and reverse directions
- samples a configurable subset of pixels to speed up the search

This is useful when trimming content around opening and ending credits, or when manually splitting a scene on natural breaks.

### New `config.yaml` settings
```yaml
remixer_settings:
  find_break_stride: 128  # only check every this many pixels in the image to speed up the check
  find_break_threshold: 1 # the average lightness of the sampled pixels must be this value or lower to be a break frame (0-255)
  skip_break_threshold: 3 # near-break frames are skipped on repeated use if at or below this value
```
