### PR TITLE
Video Remixer: optimize resequencing of files

### DIFF
--- a/tabs/resequence_files_ui.py
+++ b/tabs/resequence_files_ui.py
@@ -260,7 +260,8 @@ class ResequenceFiles(TabBase):
                              input_rename,
                              self.log,
                              output_path=output_path,
-                             reverse=input_reverse).resequence(ignore_name_clash=False)
+                             reverse=input_reverse).resequence(ignore_name_clash=False,
+                                                               skip_if_not_required=False)
         except ValueError as error:
             message = f"Error: {error}"
             if interactive:


### PR DESCRIPTION
Background: FFmpeg has specific requirements for using an image sequence as input, for example, the filenames must have a common root, they must have sequential zero-filled integer indexes, and the first one must be 0 or 1.

Video Remixer often resequences frame files to ensure FFmpeg can read them, for instance, to create thumbnails. Often this is not needed due to the files already being in the proper sequence. 

This adds a check to _ResequenceFiles_  to test if the files already met FFmpeg requirements. If so, the resequencing is skipped.