### PR TITLE
Video Remixer: Add volume adjustment for output video

### DIFF
--- a/tabs/video_remixer_ui.py
+++ b/tabs/video_remixer_ui.py
@@ -548,6 +548,11 @@ class VideoRemixer(TabBase):
                             output_filepath_labeled = gr.Textbox(label="Output Filepath",
                                 max_lines=1,
                                 info="Enter a path and filename for the remixed video")
+                        with gr.Accordion("Advanced Options", open=False):
+                            with gr.Row(variant="compact", equal_height=False):
+                                volume_63 = gr.Slider(value=0.0,
+                                    label="Volume Adjustment in dB", minimum=-30.0,
+                                    maximum=30.0, step=0.1, container=False)
                         with gr.Row():
                             message_box63 = gr.Markdown(value=format_markdown(self.TAB63_DEFAULT_MESSAGE))
                         gr.Markdown(format_markdown("Progress can be tracked in the console", color="none", italic=True, bold=False))
@@ -1318,7 +1323,7 @@ class VideoRemixer(TabBase):
                                 label_shadow_alpha, label_shadow_size, label_draw_box,
                                 label_box_color, label_box_alpha, label_border_size,
                                 label_position_v, label_position_h, output_filepath_labeled,
-                                quality_slider_labeled],
+                                quality_slider_labeled, volume_63],
                         outputs=message_box63)
 
         back_button63.click(self.back_button63, outputs=tabs_video_remixer)
@@ -1529,7 +1534,8 @@ class VideoRemixer(TabBase):
                             inputs=[projects_path7170, project_state7170, resynthesize, inflate,
                                     resize, upscale, upscale_option, inflate_by_option,
                                     inflate_slow_option, resynth_option, auto_save_remix,
-                                    auto_delete_remix, auto_coalesce_remix, keep_scene_videos],
+                                    auto_delete_remix, auto_coalesce_remix, keep_scene_videos,
+                                    quality_slider, volume_60],
                             outputs=message_box7170)
 
         process_button7171.click(self.process_button7171,
@@ -2607,7 +2613,8 @@ class VideoRemixer(TabBase):
                       label_position_v,
                       label_position_h,
                       output_filepath,
-                      quality):
+                      quality,
+                      volume):
         if not self.state.project_path:
             return format_markdown("The project has not yet been set up from the Set Up Project tab.", "error")
 
@@ -2663,7 +2670,8 @@ class VideoRemixer(TabBase):
             try:
                 self.processor.save_custom_remix(output_filepath, kept_scenes,
                                                  labeled_video_options, labeled_audio_options,
-                                                 draw_text_options, use_scene_sorting=True)
+                                                 draw_text_options, use_scene_sorting=True,
+                                                 volume=volume)
                 return format_markdown(
                     f"Remixed labeled video {output_filepath} is complete.", "highlight")
             except FFRuntimeError as error:
@@ -3677,7 +3685,7 @@ class VideoRemixer(TabBase):
     def save_mp4_video(self, output_filepath, quality=None, volume=None):
         self.state.output_filepath = output_filepath
         self.state.output_quality = quality or self.config.remixer_settings["default_crf"]
-        self.state.output_volume = volume or self.state.project.SAFETY_DEFAULTS["output_volume"]
+        self.state.output_volume = volume or 0.0
 
         self.state.save()
 
@@ -3790,7 +3798,9 @@ class VideoRemixer(TabBase):
                           auto_save_remix,
                           auto_delete_remix,
                           auto_coalesce_remix,
-                          keep_scene_videos):
+                          keep_scene_videos,
+                          quality,
+                          volume):
         messages = []
         if not projects_path:
             return format_markdown(
@@ -3845,7 +3855,9 @@ class VideoRemixer(TabBase):
                                                  auto_save_remix,
                                                  auto_delete_remix,
                                                  auto_coalesce_remix,
-                                                 keep_scene_videos)
+                                                 keep_scene_videos,
+                                                 quality,
+                                                 volume)
                     messages.append(message)
 
                 except ValueError as error:

--- a/video_remixer.py
+++ b/video_remixer.py
@@ -100,6 +100,7 @@ class VideoRemixerState():
         self.summary_info6 = None # re-set on re-opening project
         self.output_filepath = None
         self.output_quality = None
+        self.output_volume = None
 
         # set during final clip creation and remix merging
         self.video_clips_path = None

--- a/video_remixer_processor.py
+++ b/video_remixer_processor.py
@@ -2715,12 +2715,25 @@ f"Error in upscale_scenes() handling processing hint {upscale_hint} - skipping p
                     global_options=self.global_options).slice()
         self.state.audio_clips = sorted(get_files(self.state.audio_clips_path))
 
-    def compute_inflated_audio_options(self, custom_audio_options, force_inflation, force_audio,
-                                       force_inflate_by, force_silent):
+    def compute_audio_options(self,
+                              custom_audio_options,
+                              force_inflation,
+                              force_audio,
+                              force_inflate_by,
+                              force_silent,
+                              volume = 0.0):
 
-        motion_factor, audio_slow_motion, silent_slow_motion, _project_inflation_rate, \
-            _forced_inflation_rate = self.compute_effective_slow_motion(force_inflation, force_audio,
-                                                                    force_inflate_by, force_silent)
+        if volume:
+            custom_audio_options += f" -filter:a \"volume={volume}dB\""
+
+        motion_factor, \
+        audio_slow_motion, \
+        silent_slow_motion, \
+        _project_inflation_rate, \
+        _forced_inflation_rate = self.compute_effective_slow_motion(force_inflation,
+                                                                    force_audio,
+                                                                    force_inflate_by,
+                                                                    force_silent)
 
         audio_motion_factor = motion_factor
 
@@ -3004,11 +3017,12 @@ f"Error in upscale_scenes() handling processing hint {upscale_hint} - skipping p
                     force_inflation, force_audio, force_inflate_by, force_silent =\
                         self.compute_forced_inflation(scene_name)
 
-                    output_options = self.compute_inflated_audio_options("-c:a aac -shortest ",
-                                                                         force_inflation,
-                                                                         force_audio,
-                                                                         force_inflate_by,
-                                                                         force_silent)
+                    output_options = self.compute_audio_options("-c:a aac -shortest ",
+                                                                force_inflation,
+                                                                force_audio,
+                                                                force_inflate_by,
+                                                                force_silent,
+                                                                volume=self.state.output_volume)
                     combine_video_audio(scene_video_path,
                                         scene_audio_path,
                                         scene_output_filepath,
@@ -3034,7 +3048,7 @@ f"Error in upscale_scenes() handling processing hint {upscale_hint} - skipping p
                     force_inflation, force_audio, force_inflate_by, force_silent =\
                         self.compute_forced_inflation(scene_name)
 
-                    output_options = self.compute_inflated_audio_options(custom_audio_options,
+                    output_options = self.compute_audio_options(custom_audio_options,
                                                                 force_inflation,
                                                                 force_audio=force_audio,
                                                                 force_inflate_by=force_inflate_by,

--- a/video_remixer_processor.py
+++ b/video_remixer_processor.py
@@ -203,7 +203,8 @@ class VideoRemixerProcessor():
                           custom_video_options,
                           custom_audio_options,
                           draw_text_options=None,
-                          use_scene_sorting=True):
+                          use_scene_sorting=True,
+                          volume=0.0):
         _, _, output_ext = split_filepath(output_filepath)
         output_ext = output_ext[1:]
 
@@ -214,8 +215,10 @@ class VideoRemixerProcessor():
                                                 draw_text_options=draw_text_options)
             self.state.save()
 
-        self.create_custom_scene_clips(kept_scenes, custom_audio_options=custom_audio_options,
-                                             custom_ext=output_ext)
+        self.create_custom_scene_clips(kept_scenes,
+                                       custom_audio_options=custom_audio_options,
+                                       custom_ext=output_ext,
+                                       volume=volume)
         self.state.save()
 
         if not self.state.clips:
@@ -3036,7 +3039,8 @@ f"Error in upscale_scenes() handling processing hint {upscale_hint} - skipping p
     def create_custom_scene_clips(self,
                                   kept_scenes,
                                   custom_audio_options,
-                                  custom_ext):
+                                  custom_ext,
+                                  volume):
         if self.state.video_details["has_audio"]:
             with Mtqdm().open_bar(total=len(kept_scenes), desc="Remix Clips") as bar:
                 for index, scene_name in enumerate(kept_scenes):
@@ -3052,7 +3056,8 @@ f"Error in upscale_scenes() handling processing hint {upscale_hint} - skipping p
                                                                 force_inflation,
                                                                 force_audio=force_audio,
                                                                 force_inflate_by=force_inflate_by,
-                                                                force_silent=force_silent)
+                                                                force_silent=force_silent,
+                                                                volume=volume)
 
                     combine_video_audio(scene_video_path, scene_audio_path,
                                         scene_output_filepath, global_options=self.global_options,

--- a/video_remixer_project.py
+++ b/video_remixer_project.py
@@ -487,7 +487,7 @@ class VideoRemixerProject():
         self.state.resynth_option = defaults["resynth_option"]
         self.state.frame_format = defaults["frame_format"]
         self.state.sound_format = defaults["sound_format"]
-        self.state.volume = defaults["volume"]
+        self.state.volume = defaults["output_volume"]
 
     def project_filepath(self, filename : str=DEF_FILENAME):
         return os.path.join(self.state.project_path, filename)

--- a/video_remixer_project.py
+++ b/video_remixer_project.py
@@ -50,7 +50,9 @@ class VideoRemixerProject():
         "crop_w" : 1920,
         "crop_h" : 1080,
         "frame_format" : "png",
-        "sound_format" : "wav"
+        "sound_format" : "wav",
+        "output_quality" : 23,
+        "output_volume" : 0.0
     }
 
     DEF_FILENAME = "project.yaml"
@@ -485,6 +487,7 @@ class VideoRemixerProject():
         self.state.resynth_option = defaults["resynth_option"]
         self.state.frame_format = defaults["frame_format"]
         self.state.sound_format = defaults["sound_format"]
+        self.state.volume = defaults["volume"]
 
     def project_filepath(self, filename : str=DEF_FILENAME):
         return os.path.join(self.state.project_path, filename)


### PR DESCRIPTION
Adds a volume adjust slider in dB to the _Create MP4 Remix_ and _Create Labeled Remix_ tabs
- The default is `0.0` (no adjustment)
- The range is from `-30.0` (very quiet) to `30.0` (very loud)

This is useful when the source control has audio that is too soft or loud.