### PR TITLE
Video Remixer: Speed up ingest using Resequencer

### DIFF
--- a/resequence_files.py
+++ b/resequence_files.py
@@ -118,7 +118,6 @@ class ResequenceFiles:
         if self.zero_fill == ResequenceFiles.ZERO_FILL_AUTO_DETECT:
             max_index_num = all_files_count * self.index_step
             batch_zero_fill = len(str(max_index_num))
-            print(batch_zero_fill, self.index_step)
         else:
             batch_zero_fill = self.zero_fill
 

--- a/resequence_files.py
+++ b/resequence_files.py
@@ -92,7 +92,7 @@ class ResequenceFiles:
 
     ZERO_FILL_AUTO_DETECT = -1
 
-    def resequence_groups(self, group_names : list, contiguous=True, ignore_name_clash=True):
+    def resequence_groups(self, group_names : list, contiguous=True, ignore_name_clash=True, move_files=False):
         """Resequence files contained in the specified directory names at the input path. Returns a string with any errors."""
 
         # count the original files across groups
@@ -151,24 +151,26 @@ class ResequenceFiles:
                             self.log_fn,
                             group_output_path,
                             self.reverse).resequence(ignore_name_clash=ignore_name_clash,
-                                                     skip_if_not_required=not contiguous)
+                                                     skip_if_not_required=not contiguous,
+                                                     move_files=move_files)
                     except ValueError as error:
                         errors.append(f"Error handling directory {group_name}: " + str(error))
                     Mtqdm().update_bar(bar)
         if errors:
             return "\r\n".join(errors)
 
-    def resequence_batch(self, contiguous=True, ignore_name_clash=True):
+    def resequence_batch(self, contiguous=True, ignore_name_clash=True, move_files=False):
         """Resequence groups of files. Returns a string with any errors."""
         group_names = sorted(get_directories(self.input_path), reverse=self.reverse)
         return self.resequence_groups(group_names,
                                       contiguous=contiguous,
-                                      ignore_name_clash=ignore_name_clash)
+                                      ignore_name_clash=ignore_name_clash,
+                                      move_files=False)
 
-    def resequence(self, ignore_name_clash=True, skip_if_not_required=True) -> None:
+    def resequence(self, ignore_name_clash=True, skip_if_not_required=True, move_files=False, file_list=None) -> None:
         """Resesequence files in the directory per settings. Returns a count of the files resequenced. Raises ValueError on name clash."""
-        files = sorted(glob.glob(os.path.join(self.input_path, "*." + self.file_type)),
-                       reverse=self.reverse)
+        files = file_list or \
+            sorted(glob.glob(os.path.join(self.input_path, "*." + self.file_type)), reverse=self.reverse)
         num_files = len(files)
 
         # if renaming files in place, check to see that they are not already in proper sequence
@@ -191,7 +193,11 @@ class ResequenceFiles:
 
         running_index = self.start_index
         sample_set = create_sample_set(files, self.sample_offset, self.sample_stride)
-        pbar_title = "Resequence Rename" if self.rename else "Resequence Copy"
+
+        if self.rename:
+            pbar_title = "Resequence Rename"
+        else:
+            pbar_title = "Resequence Move" if move_files else "Resequence Copy"
         with Mtqdm().open_bar(total=len(sample_set), desc=pbar_title) as bar:
             for file in sample_set:
                 new_filename = \
@@ -204,7 +210,10 @@ class ResequenceFiles:
                         os.replace(old_filepath, new_filepath)
                 else:
                     new_filepath = os.path.join(self.output_path, new_filename)
-                    shutil.copy(old_filepath, new_filepath)
+                    if move_files:
+                        shutil.move(old_filepath, new_filepath)
+                    else:
+                        shutil.copy(old_filepath, new_filepath)
 
                 running_index += self.index_step
                 Mtqdm().update_bar(bar)

--- a/split_frames.py
+++ b/split_frames.py
@@ -184,40 +184,17 @@ class SplitFrames:
                 else:
                     create_directory(group_path)
 
-                desc = "Copying" if self.action == "copy" else "Moving"
-                with Mtqdm().open_bar(total=num_group_files, desc=desc) as file_bar:
-                    for file in group_files:
-                        from_filepath = file
-                        _, filename, ext = split_filepath(file)
-                        to_filepath = os.path.join(group_path, filename + ext)
-                        if self.dry_run:
-                            print(f"[Dry Run] Copying {from_filepath} to {to_filepath}")
-                        else:
-                            shutil.copy(from_filepath, to_filepath)
-                        Mtqdm().update_bar(file_bar)
+                base_filename = f"{group_name}-{self.type}-split-frame"
+                ResequenceFiles(self.input_path,
+                                self.file_ext,
+                                base_filename,
+                                0, 1, 1, 0,
+                                num_width,
+                                False,
+                                self.log,
+                                output_path=group_path).resequence(move_files=self.action == "move",
+                                                                   file_list=group_files)
                 Mtqdm().update_bar(group_bar)
-
-                if add_resynthesis_frames or add_inflation_frame:
-                    if self.dry_run:
-                        print(f"[Dry Run] Resequencing files in {group_path}")
-                    else:
-                        base_filename = f"{group_name}-{self.type}-split-frame"
-                        ResequenceFiles(group_path,
-                                        self.file_ext,
-                                        base_filename,
-                                        0, 1, 1, 0, num_width,
-                                        True,
-                                        self.log).resequence()
-
-        if self.action != "copy":
-            with Mtqdm().open_bar(total=num_files, desc="Deleting") as bar:
-                for file in files:
-                    if os.path.exists(file):
-                        if self.dry_run:
-                            print(f"[Dry Run] Deleting {file}")
-                        else:
-                            os.remove(file)
-                    Mtqdm().update_bar(bar)
 
         return group_paths
 

--- a/split_scenes.py
+++ b/split_scenes.py
@@ -69,7 +69,7 @@ class SplitScenes:
         if not self.type in valid_types:
             raise ValueError(f"'type' must be one of {', '.join([t for t in valid_types])}")
 
-    def split_scenes(self, format : str="png"):
+    def split_scenes(self, format : str="png", move : bool=False):
         files = sorted(glob.glob(os.path.join(self.input_path, f"*.{self.file_ext}")))
         num_files = len(files)
         num_width = len(str(num_files))
@@ -162,22 +162,18 @@ class SplitScenes:
 
         return group_paths
 
-    def split(self, type : str="png") -> list:
+    def split(self, type : str="png", move : bool=False) -> list:
         """Invoke the Split Scenes feature"""
-        # files = sorted(glob.glob(os.path.join(self.input_path, f"*.{self.file_ext}")))
-        # num_files = len(files)
-        # num_width = len(str(num_files))
-
         if self.type == "scene":
             if self.scene_threshold < 0.0 or self.scene_threshold > 1.0:
                 raise ValueError("'scene_threshold' must be between 0.0 and 1.0")
-            self.split_scenes(type)
+            self.split_scenes(type, move)
         else:
             if self.break_duration < 0.0:
                 raise ValueError("'break_duration' >= 0.0")
             if self.break_ratio < 0.0 or self.break_ratio > 1.0:
                 raise ValueError("'break_ratio' must be between 0.0 and 1.0")
-            self.split_breaks(type)
+            self.split_breaks(type, move)
 
         if self.dry_run:
             print(f"[Dry Run] Creating base output path {self.output_path}")

--- a/split_scenes.py
+++ b/split_scenes.py
@@ -8,6 +8,7 @@ from webui_utils.simple_log import SimpleLog
 from webui_utils.file_utils import create_directory, is_safe_path, split_filepath
 from webui_utils.video_utils import get_detected_scenes, get_detected_breaks, scene_list_to_ranges
 from webui_utils.mtqdm import Mtqdm
+from resequence_files import ResequenceFiles
 
 def main():
     """Use the Split Scenes feature from the command line"""
@@ -69,7 +70,7 @@ class SplitScenes:
         if not self.type in valid_types:
             raise ValueError(f"'type' must be one of {', '.join([t for t in valid_types])}")
 
-    def split_scenes(self, format : str="png", move : bool=False):
+    def split_scenes(self, format : str="png", move_files : bool=False):
         files = sorted(glob.glob(os.path.join(self.input_path, f"*.{self.file_ext}")))
         num_files = len(files)
         num_width = len(str(num_files))
@@ -98,24 +99,23 @@ class SplitScenes:
                 else:
                     create_directory(group_path)
 
-                desc = "Copying"
-                with Mtqdm().open_bar(total=group_size, desc=desc) as file_bar:
-                    for index in range(first_index, last_index+1):
-                        frame_file = files[index]
-                        from_filepath = frame_file
-                        _, filename, ext = split_filepath(frame_file)
-                        to_filepath = os.path.join(group_path, filename + ext)
+                group_files = [files[index] for index in range(first_index, last_index+1)]
+                base_filename = f"{group_name}-{self.type}-split-frame"
+                ResequenceFiles(self.input_path,
+                                self.file_ext,
+                                base_filename,
+                                0, 1, 1, 0,
+                                num_width,
+                                False,
+                                self.log,
+                                output_path=group_path).resequence(move_files=move_files,
+                                                                   file_list=group_files)
 
-                        if self.dry_run:
-                            print(f"[Dry Run] Copying {from_filepath} to {to_filepath}")
-                        else:
-                            shutil.copy(from_filepath, to_filepath)
-                        Mtqdm().update_bar(file_bar)
                 Mtqdm().update_bar(scene_bar)
 
         return group_paths
 
-    def split_breaks(self, format : str="jpg"):
+    def split_breaks(self, format : str="jpg", move_files : bool=False):
         files = sorted(glob.glob(os.path.join(self.input_path, f"*.{self.file_ext}")))
         num_files = len(files)
         num_width = len(str(num_files))
@@ -145,35 +145,34 @@ class SplitScenes:
                 else:
                     create_directory(group_path)
 
-                desc = "Copying"
-                with Mtqdm().open_bar(total=group_size, desc=desc) as file_bar:
-                    for index in range(first_index, last_index+1):
-                        frame_file = files[index]
-                        from_filepath = frame_file
-                        _, filename, ext = split_filepath(frame_file)
-                        to_filepath = os.path.join(group_path, filename + ext)
+                group_files = [files[index] for index in range(first_index, last_index+1)]
+                base_filename = f"{group_name}-{self.type}-split-frame"
+                ResequenceFiles(self.input_path,
+                                self.file_ext,
+                                base_filename,
+                                0, 1, 1, 0,
+                                num_width,
+                                False,
+                                self.log,
+                                output_path=group_path).resequence(move_files=move_files,
+                                                                   file_list=group_files)
 
-                        if self.dry_run:
-                            print(f"[Dry Run] Copying {from_filepath} to {to_filepath}")
-                        else:
-                            shutil.copy(from_filepath, to_filepath)
-                        Mtqdm().update_bar(file_bar)
                 Mtqdm().update_bar(scene_bar)
 
         return group_paths
 
-    def split(self, type : str="png", move : bool=False) -> list:
+    def split(self, type : str="png", move_files : bool=False) -> list:
         """Invoke the Split Scenes feature"""
         if self.type == "scene":
             if self.scene_threshold < 0.0 or self.scene_threshold > 1.0:
                 raise ValueError("'scene_threshold' must be between 0.0 and 1.0")
-            self.split_scenes(type, move)
+            self.split_scenes(type, move_files)
         else:
             if self.break_duration < 0.0:
                 raise ValueError("'break_duration' >= 0.0")
             if self.break_ratio < 0.0 or self.break_ratio > 1.0:
                 raise ValueError("'break_ratio' must be between 0.0 and 1.0")
-            self.split_breaks(type, move)
+            self.split_breaks(type, move_files)
 
         if self.dry_run:
             print(f"[Dry Run] Creating base output path {self.output_path}")

--- a/tabs/video_remixer_ui.py
+++ b/tabs/video_remixer_ui.py
@@ -2010,7 +2010,7 @@ class VideoRemixer(TabBase):
             self.state.save()
 
             # split frames into scenes
-            error = self.state.ingest.split_scenes(prevent_overwrite=False)
+            error = self.state.ingest.split_scenes(prevent_overwrite=False, move_files=remove_source)
             if error:
                 raise ValueError(f"There was an error splitting the source video: {error}")
 

--- a/video_remixer_ingest.py
+++ b/video_remixer_ingest.py
@@ -279,7 +279,7 @@ class VideoRemixerIngest():
                         global_options=self.state.global_options)
             Mtqdm().update_bar(bar)
 
-    def split_scenes(self, prevent_overwrite=False):
+    def split_scenes(self, prevent_overwrite=False, move_files=False):
         if prevent_overwrite and self.scenes_present():
                 return None
         try:
@@ -293,7 +293,8 @@ class VideoRemixerIngest():
                                 self.state.scene_threshold,
                                 0.0,
                                 0.0,
-                                self.state.log_fn).split(type=self.state.frame_format)
+                                self.state.log_fn).split(type=self.state.frame_format,
+                                                         move_files=move_files)
                     Mtqdm().update_bar(bar)
 
             elif self.state.split_type == "Break":
@@ -306,7 +307,8 @@ class VideoRemixerIngest():
                                 0.0,
                                 float(self.state.break_duration),
                                 float(self.state.break_ratio),
-                                self.state.log_fn).split(type=self.state.frame_format)
+                                self.state.log_fn).split(type=self.state.frame_format,
+                                                         move_files=move_files)
                     Mtqdm().update_bar(bar)
             elif self.state.split_type == "Time":
                 # split by seconds
@@ -317,7 +319,7 @@ class VideoRemixerIngest():
                     "precise",
                     0,
                     self.state.split_frames,
-                    "copy",
+                    "move" if move_files else "copy",
                     False,
                     self.state.log_fn).split()
             else:
@@ -329,7 +331,7 @@ class VideoRemixerIngest():
                     "precise",
                     1,
                     0,
-                    "copy",
+                    "move" if move_files else "copy",
                     False,
                     self.state.log_fn).split()
             return None


### PR DESCRIPTION
Use the _Resequencer_ to move and rename/renumber frame files at the same time. This significantly speeds up creating new projects. The speediest project creation is by choosing _Remove Source Frames_ under _More Options_ on the _Set Up Project_ tab.